### PR TITLE
docs: move CI badge up to top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # liferay-frontend-projects monorepo
 
+![](https://github.com/liferay/liferay-frontend-projects/workflows/ci/badge.svg)
+
 Welcome to the monorepo of the Liferay Frontend Infrastructure team.
 
 This is an experimental exploration of the ideas proposed in [liferay-frontend-guidelines#88](https://github.com/liferay/liferay-frontend-guidelines/issues/88), "Explore consolidation of projects to reduce overhead".

--- a/projects/eslint-config/README.md
+++ b/projects/eslint-config/README.md
@@ -1,7 +1,5 @@
 # @liferay/eslint-config
 
-![](https://github.com/liferay/eslint-config-liferay/workflows/ci/badge.svg)
-
 > An ESLint [shareable config](http://eslint.org/docs/developer-guide/shareable-configs.html) that helps enforce the [Liferay Frontend Guidelines](https://github.com/liferay/liferay-frontend-guidelines).
 
 ## Overview


### PR DESCRIPTION
As I've noted in other commits, for now we are just going to run CI over everything in the monorepo. Once that gets too big/slow we will look at making the runs "smarter" (eg. only run on projects which have changes in them).

But for now, given that the run is global, the badge belongs somewhere global too.