### PR TITLE
docs: add a table with links to per-project and per-package issue listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,27 @@ This is an experimental exploration of the ideas proposed in [liferay-frontend-g
 
 ## Projects
 
--   [@liferay/eslint-config](./projects/eslint-config)
--   [Liferay NPM Tools](./projects/npm-tools):
-    -   [@liferay/changelog-generator](./projects/npm-tools/packages/changelog-generator)
-    -   [@liferay/jest-junit-reporter](./projects/npm-tools/packages/jest-junit-reporter)
-    -   [@liferay/js-insights](./projects/npm-tools/packages/js-insights)
-    -   [@liferay/js-publish](./projects/npm-tools/packages/js-publish)
-    -   [@liferay/npm-bundler-preset-liferay-dev](./projects/npm-tools/packages/npm-bundler-preset-liferay-dev)
-    -   [@liferay/npm-scripts](./projects/npm-tools/packages/npm-scripts)
+### `eslint-config`
+
+| Package                                              | Issues                                                                                                                             |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| [`@liferay/eslint-config`](./projects/eslint-config) | [label: `eslint-config`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Aeslint-config) |
+
+### `npm-tools`
+
+#### Project
+
+| Project                             | Issues                                                                                                                     |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| [`npm-tools`](./projects/npm-tools) | [label: `npm-tools`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Anpm-tools) |
+
+#### Packages
+
+| Packages                                                                                                  | Issues                                                                                                                                                               |
+| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`@liferay/changelog-generator`](./projects/npm-tools/packages/changelog-generator)                       | [label: `changelog-generator`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Achangelog-generator)                       |
+| [`@liferay/jest-junit-reporter`](./projects/npm-tools/packages/jest-junit-reporter)                       | [label: `jest-junit-reporter`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Ajest-junit-reporter)                       |
+| [`@liferay/js-insights`](./projects/npm-tools/packages/js-insights)                                       | [label: `js-insights`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Ajs-insights)                                       |
+| [`@liferay/js-publish`](./projects/npm-tools/packages/js-publish)                                         | [label: `js-publish`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Ajs-publish)                                         |
+| [`@liferay/npm-bundler-preset-liferay-dev`](./projects/npm-tools/packages/npm-bundler-preset-liferay-dev) | [label: `npm-bundler-preset-liferay-dev`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Anpm-bundler-preset-liferay-dev) |
+| [`@liferay/npm-scripts`](./projects/npm-tools/packages/npm-scripts)                                       | [label: `npm-scripts`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Anpm-scripts)                                       |


### PR DESCRIPTION
With more projects in the monorepo we need good tools for dealing with the increased load on the issue tracker, so that people can focus on what they need to on any given moment.