### PR TITLE
feat: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# See: https://editorconfig.org/
+
+root = true
+
+[**.{js,json}]
+indent_size = 4
+indent_style = tab
+
+[**.{md}]
+indent_size = 4
+indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,6 @@ root = true
 indent_size = 4
 indent_style = tab
 
-[**.{md}]
+[**.{md,yml}]
 indent_size = 4
 indent_style = space


### PR DESCRIPTION
Targeting the same filetypes as we run Prettier against in our format jobs. As we pull more stuff into the monorepo we'll need to expand both of the lists (eg. other projects will bring in ".ts", ".tsx", ".scss" etc).

Side note: I have changed my mind a bit on the value of `.editorconfig`; I used to consider it useless clutter because with Prettier you're supposed to not even be thinking about this stuff (a `yarn format` will put everything the right way for you). But I now think it has some small marginal value at a low cost, given that it can allow your editor to get things "right" first time, and it reduces the likelihood of you committing something that is going to fail CI because you forgot to manually run `yarn format`, or you never configured your editor to do it for you automatically.

More on `.editorconfig` here: https://editorconfig.org/