### PR TITLE
feat: set up issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/changelog-generator.md
+++ b/.github/ISSUE_TEMPLATE/changelog-generator.md
@@ -1,15 +1,22 @@
 ---
-
 name: @liferay/changelog-generator
 about: Issues related to the @liferay/changelog-generator package
 labels: npm-tools, changelog-generator
---
+---
 
-**Issue type (mark with `x`):**
+### Issue type (mark with `x`)
 
 -   [ ] :thinking: Question
 -   [ ] :bug: Bug report
 -   [ ] :gift: Feature request
 -   [ ] :woman_shrugging: Other
 
-**Description:**
+### Description
+
+**Desired behavior:**
+
+**Current behavior:**
+
+**Repro instructions (if applicable):**
+
+**Other information (environment, versions etc):**

--- a/.github/ISSUE_TEMPLATE/changelog-generator.md
+++ b/.github/ISSUE_TEMPLATE/changelog-generator.md
@@ -1,0 +1,15 @@
+---
+
+name: @liferay/changelog-generator
+about: Issues related to the @liferay/changelog-generator package
+labels: npm-tools, changelog-generator
+--
+
+**Issue type (mark with `x`):**
+
+-   [ ] :thinking: Question
+-   [ ] :bug: Bug report
+-   [ ] :gift: Feature request
+-   [ ] :woman_shrugging: Other
+
+**Description:**

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+---
+blank_issues_enabled: true
+contact_links:
+    - name: 👮 Report a security issue
+      url: 'mailto:pt-frontend-infrastructure@liferay.com'
+      about: Report security problems privately here

--- a/.github/ISSUE_TEMPLATE/eslint-config.md
+++ b/.github/ISSUE_TEMPLATE/eslint-config.md
@@ -1,15 +1,22 @@
 ---
-
 name: @liferay/eslint-config
 about: Issues related to the @liferay/eslint-config project
 labels: eslint-config
---
+---
 
-**Issue type (mark with `x`):**
+### Issue type (mark with `x`)
 
 -   [ ] :thinking: Question
 -   [ ] :bug: Bug report
 -   [ ] :gift: Feature request
 -   [ ] :woman_shrugging: Other
 
-**Description:**
+### Description
+
+**Desired behavior:**
+
+**Current behavior:**
+
+**Repro instructions (if applicable):**
+
+**Other information (environment, versions etc):**

--- a/.github/ISSUE_TEMPLATE/eslint-config.md
+++ b/.github/ISSUE_TEMPLATE/eslint-config.md
@@ -1,0 +1,15 @@
+---
+
+name: @liferay/eslint-config
+about: Issues related to the @liferay/eslint-config project
+labels: eslint-config
+--
+
+**Issue type (mark with `x`):**
+
+-   [ ] :thinking: Question
+-   [ ] :bug: Bug report
+-   [ ] :gift: Feature request
+-   [ ] :woman_shrugging: Other
+
+**Description:**

--- a/.github/ISSUE_TEMPLATE/jest-junit-reporter.md
+++ b/.github/ISSUE_TEMPLATE/jest-junit-reporter.md
@@ -1,0 +1,15 @@
+---
+
+name: @liferay/jest-junit-reporter
+about: Issues related to the @liferay/jest-junit-reporter package
+labels: npm-tools, jest-junit-reporter
+--
+
+**Issue type (mark with `x`):**
+
+-   [ ] :thinking: Question
+-   [ ] :bug: Bug report
+-   [ ] :gift: Feature request
+-   [ ] :woman_shrugging: Other
+
+**Description:**

--- a/.github/ISSUE_TEMPLATE/jest-junit-reporter.md
+++ b/.github/ISSUE_TEMPLATE/jest-junit-reporter.md
@@ -1,15 +1,22 @@
 ---
-
 name: @liferay/jest-junit-reporter
 about: Issues related to the @liferay/jest-junit-reporter package
 labels: npm-tools, jest-junit-reporter
---
+---
 
-**Issue type (mark with `x`):**
+### Issue type (mark with `x`)
 
 -   [ ] :thinking: Question
 -   [ ] :bug: Bug report
 -   [ ] :gift: Feature request
 -   [ ] :woman_shrugging: Other
 
-**Description:**
+### Description
+
+**Desired behavior:**
+
+**Current behavior:**
+
+**Repro instructions (if applicable):**
+
+**Other information (environment, versions etc):**

--- a/.github/ISSUE_TEMPLATE/js-insights.md
+++ b/.github/ISSUE_TEMPLATE/js-insights.md
@@ -1,15 +1,22 @@
 ---
-
 name: @liferay/js-insights
 about: Issues related to the @liferay/js-insights package
 labels: npm-tools, js-insights
---
+---
 
-**Issue type (mark with `x`):**
+### Issue type (mark with `x`)
 
 -   [ ] :thinking: Question
 -   [ ] :bug: Bug report
 -   [ ] :gift: Feature request
 -   [ ] :woman_shrugging: Other
 
-**Description:**
+### Description
+
+**Desired behavior:**
+
+**Current behavior:**
+
+**Repro instructions (if applicable):**
+
+**Other information (environment, versions etc):**

--- a/.github/ISSUE_TEMPLATE/js-insights.md
+++ b/.github/ISSUE_TEMPLATE/js-insights.md
@@ -1,0 +1,15 @@
+---
+
+name: @liferay/js-insights
+about: Issues related to the @liferay/js-insights package
+labels: npm-tools, js-insights
+--
+
+**Issue type (mark with `x`):**
+
+-   [ ] :thinking: Question
+-   [ ] :bug: Bug report
+-   [ ] :gift: Feature request
+-   [ ] :woman_shrugging: Other
+
+**Description:**

--- a/.github/ISSUE_TEMPLATE/js-publish.md
+++ b/.github/ISSUE_TEMPLATE/js-publish.md
@@ -1,0 +1,15 @@
+---
+
+name: @liferay/js-publish
+about: Issues related to the @liferay/js-publish package
+labels: npm-tools, js-publish
+--
+
+**Issue type (mark with `x`):**
+
+-   [ ] :thinking: Question
+-   [ ] :bug: Bug report
+-   [ ] :gift: Feature request
+-   [ ] :woman_shrugging: Other
+
+**Description:**

--- a/.github/ISSUE_TEMPLATE/js-publish.md
+++ b/.github/ISSUE_TEMPLATE/js-publish.md
@@ -1,15 +1,22 @@
 ---
-
 name: @liferay/js-publish
 about: Issues related to the @liferay/js-publish package
 labels: npm-tools, js-publish
---
+---
 
-**Issue type (mark with `x`):**
+### Issue type (mark with `x`)
 
 -   [ ] :thinking: Question
 -   [ ] :bug: Bug report
 -   [ ] :gift: Feature request
 -   [ ] :woman_shrugging: Other
 
-**Description:**
+### Description
+
+**Desired behavior:**
+
+**Current behavior:**
+
+**Repro instructions (if applicable):**
+
+**Other information (environment, versions etc):**

--- a/.github/ISSUE_TEMPLATE/npm-bundler-preset-liferay-dev.md
+++ b/.github/ISSUE_TEMPLATE/npm-bundler-preset-liferay-dev.md
@@ -1,0 +1,15 @@
+---
+
+name: @liferay/npm-bundler-preset-liferay-dev
+about: Issues related to the @liferay/npm-bundler-preset-liferay-dev package
+labels: npm-tools, npm-bundler-preset-liferay-dev
+--
+
+**Issue type (mark with `x`):**
+
+-   [ ] :thinking: Question
+-   [ ] :bug: Bug report
+-   [ ] :gift: Feature request
+-   [ ] :woman_shrugging: Other
+
+**Description:**

--- a/.github/ISSUE_TEMPLATE/npm-bundler-preset-liferay-dev.md
+++ b/.github/ISSUE_TEMPLATE/npm-bundler-preset-liferay-dev.md
@@ -1,15 +1,22 @@
 ---
-
 name: @liferay/npm-bundler-preset-liferay-dev
 about: Issues related to the @liferay/npm-bundler-preset-liferay-dev package
 labels: npm-tools, npm-bundler-preset-liferay-dev
---
+---
 
-**Issue type (mark with `x`):**
+### Issue type (mark with `x`)
 
 -   [ ] :thinking: Question
 -   [ ] :bug: Bug report
 -   [ ] :gift: Feature request
 -   [ ] :woman_shrugging: Other
 
-**Description:**
+### Description
+
+**Desired behavior:**
+
+**Current behavior:**
+
+**Repro instructions (if applicable):**
+
+**Other information (environment, versions etc):**

--- a/.github/ISSUE_TEMPLATE/npm-scripts.md
+++ b/.github/ISSUE_TEMPLATE/npm-scripts.md
@@ -1,0 +1,15 @@
+---
+
+name: @liferay/npm-scripts
+about: Issues related to the @liferay/npm-scripts package
+labels: npm-tools, npm-scripts
+--
+
+**Issue type (mark with `x`):**
+
+-   [ ] :thinking: Question
+-   [ ] :bug: Bug report
+-   [ ] :gift: Feature request
+-   [ ] :woman_shrugging: Other
+
+**Description:**

--- a/.github/ISSUE_TEMPLATE/npm-scripts.md
+++ b/.github/ISSUE_TEMPLATE/npm-scripts.md
@@ -1,15 +1,22 @@
 ---
-
 name: @liferay/npm-scripts
 about: Issues related to the @liferay/npm-scripts package
 labels: npm-tools, npm-scripts
---
+---
 
-**Issue type (mark with `x`):**
+### Issue type (mark with `x`)
 
 -   [ ] :thinking: Question
 -   [ ] :bug: Bug report
 -   [ ] :gift: Feature request
 -   [ ] :woman_shrugging: Other
 
-**Description:**
+### Description
+
+**Desired behavior:**
+
+**Current behavior:**
+
+**Repro instructions (if applicable):**
+
+**Other information (environment, versions etc):**


### PR DESCRIPTION
As discussed [here](https://github.com/liferay/liferay-frontend-projects/pull/73#issuecomment-698824867).

Note: this won't scale super well once this project has many more packages in it (which will happen as soon as we pull in the js-toolkit), so we may have to revisit this in the future.

We can't have a hierarchical issue template (ie. projects, with issue types as sub-templates), so I have just stuck the type in here as a generic checklist. We can flesh these out more later. Maybe something super generic like:

---

**Desired behavior:**

**Current behavior:**

**Other information (environment, versions etc):**

---

That might cover feature requests, bug reports and questions well enough, even though it is a bit imprecise.

But note that even without hierarchical templates, doing what I've done here (one template per package) is going to get out of hand soon. At that point we might have to distill this down a bit more.