### PR TITLE
fix: don't use a mailto URL in the issue template configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,5 +2,5 @@
 blank_issues_enabled: true
 contact_links:
     - name: 👮 Report a security issue
-      url: 'mailto:pt-frontend-infrastructure@liferay.com'
+      url: https://github.com/node-fetch/node-fetch/issues/new/choose
       about: Report security problems privately here


### PR DESCRIPTION
As described [here (see screenshots)](https://github.com/liferay/liferay-frontend-projects/pull/76#issuecomment-698896555), it doesn't seem to be allowed.

Example project using a non-mailto URL:

- https://github.com/node-fetch/node-fetch/issues/new/choose
- https://github.com/node-fetch/node-fetch/blob/master/.github/ISSUE_TEMPLATE/config.yml

Note it is also using `blank_issues_enabled`, but it doesn't seem to make any difference. Clay for example, has the same behavior even without the property. Perhaps it defaults to `true`.

- https://github.com/liferay/clay/issues/new/choose
- https://github.com/liferay/clay/tree/master/.github/ISSUE_TEMPLATE