### PR TITLE
docs: update changelogs for imported packages

### DIFF
--- a/CONTRIBUTING/migrating-an-npm-package-to-the-liferay-named-scope.md
+++ b/CONTRIBUTING/migrating-an-npm-package-to-the-liferay-named-scope.md
@@ -65,7 +65,17 @@ In the example of [eslint-config-liferay](https://github.com/liferay/eslint-conf
 
 6.  Check the release page on GitHub to confirm that the release is showing up there too; it should be at a URL like: [github.com/liferay/liferay-frontend-projects/releases/tag/eslint-config/v21.1.0](https://github.com/liferay/liferay-frontend-projects/releases/tag/eslint-config/v21.1.0)
 
-    > :construction: At the moment, we haven't taught liferay-changelog-generator how to emit release notes for this kind of release. We'll remedy that shortly.
+    > :construction: `@liferay/changelog-generator` can produce release notes for this kind of release but it is rather edge-casey so they may need some manual tweaking. For example, it assumes that the tag prefix doesn't change from release to release like it does here (and we probably won't bother changing it because importing a package is such a once-off thing), so you'll have to manually edit the "compare" URL to show the right starting tag. Other than that, it should work fine.
+    >
+    > An example invocation, used to document the move from `eslint-config-liferay/v21.1.10` (the tag pointing at the final release of the old package) to `eslint-config/v21.1.0` (the first release of the new named-scope version of the package) is:
+    >
+    > ```
+    > cd projects/eslint-config
+    > node ../npm-tools/packages/changelog-generator/bin/liferay-changelog-generator.js --from=eslint-config-liferay/v21.1.0 --version=21.1.0
+    >
+    > # Edit the starting tag from "eslint-config/v21.1.0" to "liferay-eslint-config/v21.1.0":
+    > vim CHANGELOG.md
+    > ```
 
 ### Configuring package access control
 

--- a/projects/eslint-config/CHANGELOG.md
+++ b/projects/eslint-config/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [eslint-config/v21.1.0](https://github.com/liferay/liferay-frontend-projects/tree/eslint-config/v21.1.0) (2020-09-22)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-eslint-config/v21.1.0...eslint-config/v21.1.0)
+
+### :woman_juggling: Refactoring
+
+-   refactor: migrate eslint-config-liferay to @liferay/eslint-config ([b0174d9d5fd](https://github.com/liferay/liferay-frontend-projects/commit/b0174d9d5fd556737054d96e6de7b0af8a7a9525))
+
 ## [v21.1.0](https://github.com/liferay/eslint-config-liferay/tree/v21.1.0) (2020-05-07)
 
 [Full changelog](https://github.com/liferay/eslint-config-liferay/compare/v21.0.0...v21.1.0)

--- a/projects/npm-tools/packages/changelog-generator/CHANGELOG.md
+++ b/projects/npm-tools/packages/changelog-generator/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [changelog-generator/v1.4.1](https://github.com/liferay/liferay-frontend-projects/tree/changelog-generator/v1.4.1) (2020-09-24)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-changelog-generator/v1.4.1...changelog-generator/v1.4.1)
+
+### :woman_juggling: Refactoring
+
+-   refactor: migrate liferay-changelog-generator to @liferay/changelog-generator ([47bc87477f1](https://github.com/liferay/liferay-frontend-projects/commit/47bc87477f19222e61321db0c204012c0dc7dc8c))
+
 ## [liferay-changelog-generator/v1.4.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-changelog-generator/v1.4.1) (2020-07-09)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-changelog-generator/v1.4.0...liferay-changelog-generator/v1.4.1)

--- a/projects/npm-tools/packages/jest-junit-reporter/CHANGELOG.md
+++ b/projects/npm-tools/packages/jest-junit-reporter/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [jest-junit-reporter/v1.2.0](https://github.com/liferay/liferay-frontend-projects/tree/jest-junit-reporter/v1.2.0) (2020-09-24)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-jest-junit-reporter/v1.2.0...jest-junit-reporter/v1.2.0)
+
+### :woman_juggling: Refactoring
+
+-   refactor: migrate liferay-jest-junit-reporter to @liferay/jest-junit-reporter ([ffb850968c4](https://github.com/liferay/liferay-frontend-projects/commit/ffb850968c417c760c294f1962d3c38939e37b06))
+
 ## [liferay-jest-junit-reporter/v1.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-jest-junit-reporter/v1.2.0) (2020-02-17)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-jest-junit-reporter/v1.1.0-beta.1...liferay-jest-junit-reporter/v1.2.0)

--- a/projects/npm-tools/packages/js-insights/CHANGELOG.md
+++ b/projects/npm-tools/packages/js-insights/CHANGELOG.md
@@ -1,0 +1,5 @@
+## [js-insights/v0.0.1](https://github.com/liferay/liferay-frontend-projects/tree/js-insights/v0.0.1) (2020-09-24)
+
+### :woman_juggling: Refactoring
+
+-   refactor: migrate liferay-js-insights to @liferay/js-insights ([9a981ac2e2e](https://github.com/liferay/liferay-frontend-projects/commit/9a981ac2e2ea0967eb163e6350868cf381d05900))

--- a/projects/npm-tools/packages/js-publish/CHANGELOG.md
+++ b/projects/npm-tools/packages/js-publish/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [js-publish/v1.1.0](https://github.com/liferay/liferay-frontend-projects/tree/js-publish/v1.1.0) (2020-09-24)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-js-publish/v1.1.0...js-publish/v1.1.0)
+
+### :woman_juggling: Refactoring
+
+-   refactor: migrate liferay-js-publish to @liferay/js-publish ([63222b948b1](https://github.com/liferay/liferay-frontend-projects/commit/63222b948b14f891f7a3bb507181964da1ed5c0f))
+
 ## [liferay-js-publish/v1.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-js-publish/v1.1.0) (2020-03-25)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-js-publish/v1.1.0-alpha.1...liferay-js-publish/v1.1.0)

--- a/projects/npm-tools/packages/npm-bundler-preset-liferay-dev/CHANGELOG.md
+++ b/projects/npm-tools/packages/npm-bundler-preset-liferay-dev/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [npm-bundler-preset-liferay-dev/v4.6.2](https://github.com/liferay/liferay-frontend-projects/tree/npm-bundler-preset-liferay-dev/v4.6.2) (2020-09-24)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-npm-bundler-preset-liferay-dev/v4.6.2...npm-bundler-preset-liferay-dev/v4.6.2)
+
+### :woman_juggling: Refactoring
+
+-   refactor: migrate liferay-npm-bundler-preset-liferay-dev to @liferay/npm-bundler-preset-liferay-dev ([54fb5e92fb2](https://github.com/liferay/liferay-frontend-projects/commit/54fb5e92fb21b7eebdfc402ca382bba70cd2b839))
+
 ## [liferay-npm-bundler-preset-liferay-dev/v4.6.2](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v4.6.2) (2020-09-17)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v4.6.1...liferay-npm-bundler-preset-liferay-dev/v4.6.2)

--- a/projects/npm-tools/packages/npm-scripts/CHANGELOG.md
+++ b/projects/npm-tools/packages/npm-scripts/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [npm-scripts/v32.7.0](https://github.com/liferay/liferay-frontend-projects/tree/npm-scripts/v32.7.0) (2020-09-24)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-npm-scripts/v32.7.0...npm-scripts/v32.7.0)
+
+### :woman_juggling: Refactoring
+
+-   refactor: migrate liferay-npm-scripts to @liferay/npm-scripts ([c6a0257953f](https://github.com/liferay/liferay-frontend-projects/commit/c6a0257953ffbdc0edb60aa17406aade3cda57b1))
+
 ## [liferay-npm-scripts/v32.7.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v32.7.0) (2020-09-18)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v32.6.2...liferay-npm-scripts/v32.7.0)


### PR DESCRIPTION
I couldn't do this when I did the original import, then migrated the packages into named scopes, then did equivalent releases, because we needed [this PR](https://github.com/liferay/liferay-frontend-projects/pull/83) in to teach the changelog-generator to work with the new monorepo structure.

Now we have that, though, I was able to generator the changelogs with these commands:

    cd projects/npm-tools/packages/changelog-generator
    node bin/liferay-changelog-generator.js --from=liferay-changelog-generator/v1.4.1 --version=1.4.1

    cd ../jest-junit-reporter
    node ../changelog-generator/bin/liferay-changelog-generator.js --from=liferay-jest-junit-reporter/v1.2.0 --version=1.2.0

    # Note that this one never had a changelog before, or even a release, so starting from scratch...
    cd ../js-insights
    node ../changelog-generator/bin/liferay-changelog-generator.js --version=0.0.1

    cd ../js-publish
    node ../changelog-generator/bin/liferay-changelog-generator.js --from=liferay-js-publish/v1.1.0 --version=1.1.0

    cd ../npm-bundler-preset-liferay-dev
    node ../changelog-generator/bin/liferay-changelog-generator.js --from=liferay-npm-bundler-preset/v4.6.2 --version=4.6.2

    cd ../npm-scripts
    node ../changelog-generator/bin/liferay-changelog-generator.js --from=liferay-npm-scripts/v32.7.0 --version=32.7.0

    cd ../../../eslint-config
    node ../npm-tools/packages/changelog-generator/bin/liferay-changelog-generator.js --from=eslint-config-liferay/v21.1.0 --version=21.1.0

So, because I am doing this a day or two after the actual releases, I had to hand-edit the documents to tweak the release date.

I also had to tweak the starting tag name in the "compare" URLs because this is a super-edge-casey thing (a name and therefore tag changing between releases), and I don't think it is worth teaching the tool to handle this (because once we have done these migrations to this monorepo and the named-scope, we'll never have to do this again).

So, a package that like liferay-npm-scripts used to use tags like "liferay-npm-scripts/v32.7.0" in its old repo. On moving here and going into our named-scope (ie. becoming `@liferay/npm-scripts`) we start using tags of the form "npm-scripts/v32.7.0". The changelog generator assumes the start tag and the end tag are going to be of the same format, so it makes a URL like this:

https://github.com/liferay/liferay-frontend-projects/compare/npm-scripts/v32.7.0...npm-scripts/v32.7.0

I just hand-edited it back to:

https://github.com/liferay/liferay-frontend-projects/compare/liferay-npm-scripts/v32.7.0...npm-scripts/v32.7.0

Which gives us a working link, albeit not a very useful/readable one, because there is a huge subtree merge commit between one tag and the other, but at least the info is in there for those who care to dig into it (probably better with `git diff -M liferay-npm-scripts/v32.7.0...npm-scripts/v32.7.0` than trying to make sense of it in the GitHub UI).

Finally, seeing as I did the initial set-up of this repo on the `master` branch directly with no PRs, the were no merge commits to populate the changelog. I just constructed a changelog entry with a link to the relevant commit instead. Again, I don't think we'll have to do this in the future because now we have our repo actually provisioned and we can do the normal PR-based workflow instead.