### PR TITLE
feat!(js-publish): don't bother updating stable branch any more

### DIFF
--- a/projects/npm-tools/CONTRIBUTING.md
+++ b/projects/npm-tools/CONTRIBUTING.md
@@ -69,17 +69,7 @@ git rev-parse --abbrev-ref HEAD
 git diff --quiet
 
 # Update upstream "master"
-git push upstream master
-
-# Merge "master" into "stable"
-git checkout stable
-git merge --ff-only master
-
-# Update upstream "stable"
-git push upstream stable --follow-tags
-
-# Return to the "master" branch
-git checkout master
+git push upstream master --follow-tags
 
 # Actually publish
 yarn publish

--- a/projects/npm-tools/packages/js-publish/README.md
+++ b/projects/npm-tools/packages/js-publish/README.md
@@ -5,7 +5,7 @@
 Simplifying assumptions:
 
 -   You are working in a repository that uses Yarn
--   You develop on the "master" branch and update "stable" whenever you do a release
+-   You develop on the "master" branch
 -   You publish using `yarn version`
 -   You are millennial (or pretend to be) and expect your tools to use emoji 😎
 

--- a/projects/npm-tools/packages/js-publish/src/index.js
+++ b/projects/npm-tools/packages/js-publish/src/index.js
@@ -14,9 +14,6 @@ const run = require('./run');
  * whenever we update a package version by (effectively) running:
  *
  *     git push $REMOTE master &&
- *     git checkout stable &&
- *     git merge --ff-only master &&
- *     git push $REMOTE stable --follow-tags &&
  *     yarn publish
  *
  * This is "safe" (enough) because:
@@ -49,22 +46,6 @@ async function main() {
 	await confirm(`Push to ${remote}/master?`);
 
 	git('push', remote, 'master', '--follow-tags');
-
-	if (isPrereleaseVersion(pkg)) {
-		print('👉 Detected prerelease version: skipping merge/push to stable');
-	} else {
-		await confirm('Merge "master" into "stable"?');
-
-		git('checkout', 'stable');
-
-		git('merge', '--ff-only', 'master');
-
-		await confirm(`Push to ${remote}/stable?`);
-
-		git('push', remote, 'stable');
-	}
-
-	git('checkout', 'master');
 
 	await runYarnPublish(pkg);
 
@@ -218,10 +199,7 @@ main()
 			'For reference, these are the publishing steps:',
 			'git rev-parse --abbrev-ref HEAD # expect "master"\n' +
 				'git diff --quiet # expect no output\n' +
-				'git push $REMOTE master # you will need to supply $REMOTE\n' +
-				'git checkout stable\n' +
-				'git merge --ff-only master\n' +
-				'git push $REMOTE stable --follow-tags\n' +
+				'git push $REMOTE master --follow-tags # you will need to supply $REMOTE\n' +
 				'yarn publish'
 		);
 


### PR DESCRIPTION
After using this "auto-update-`stable`" behavior for a year now, we've never once needed to go back to `stable` and cut a release from it.

So, let's just jettison it. Now that we've moved to the monorepo it seems like a good opportunity to avoid adding the clutter.