### PR TITLE
fix(scripts): update references to @liferay/jest-junit-reporter

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/config/jest.config.js
+++ b/projects/npm-tools/packages/npm-scripts/src/config/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
 	testEnvironment: 'jest-environment-jsdom-thirteen',
 	testMatch: ['**/test/**/*.js'],
 	testPathIgnorePatterns: ['/node_modules/', '<rootDir>/test/stories/'],
-	testResultsProcessor: 'liferay-jest-junit-reporter',
+	testResultsProcessor: '@liferay/jest-junit-reporter',
 	testURL: 'http://localhost',
 	transform: {
 		/* eslint-disable sort-keys */


### PR DESCRIPTION
Noticed while running test for https://github.com/liferay-frontend/liferay-portal/pull/409 that we had this straggling reference to the old reporter.