### PR TITLE
fix(scripts): remove stale reference to old bundler preset

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/config/npm-bundler.json
+++ b/projects/npm-tools/packages/npm-scripts/src/config/npm-bundler.json
@@ -1,3 +1,3 @@
 {
-	"preset": "liferay-npm-bundler-preset-liferay-dev"
+	"preset": "@liferay/npm-bundler-preset-liferay-dev"
 }


### PR DESCRIPTION
But note that, [as described here](https://github.com/liferay/liferay-js-toolkit/pull/654), we are going to need a fix to the bundler because it doesn't currently work with named-scope presets:

