### PR TITLE
chore(npm-scripts): update npm-bundler-preset-liferay-dev to v4.6.3

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/package.json
+++ b/projects/npm-tools/packages/npm-scripts/package.json
@@ -15,7 +15,7 @@
 		"@babel/preset-react": "7.8.3",
 		"@liferay/eslint-config": "21.1.0",
 		"@liferay/jest-junit-reporter": "1.2.0",
-		"@liferay/npm-bundler-preset-liferay-dev": "4.6.2",
+		"@liferay/npm-bundler-preset-liferay-dev": "4.6.3",
 		"@storybook/addon-a11y": "^5.1.9",
 		"@storybook/addon-actions": "^5.1.9",
 		"@storybook/addon-knobs": "^5.1.9",


### PR DESCRIPTION
[npm-bundler-preset-liferay-dev release notes](https://github.com/liferay/liferay-frontend-projects/releases/tag/npm-bundler-preset-liferay-dev%2Fv4.6.3).

Motivating change is to get [liferay-js-toolkit#654](https://github.com/liferay/liferay-js-toolkit/pull/654) ("fix(common): allow presets that have a named-scope").

Updated with:

    cd projects/npm-tools/packages/npm-scripts
    yarn add @liferay/npm-bundler-preset-liferay-dev@4.6.3