### PR TITLE
feat: add script to install packages locally in a DXP checkout

### DIFF
--- a/support/install-packages.sh
+++ b/support/install-packages.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+# SPDX-License-Identifier: MIT
+
+##
+#
+# A hacky script to overwrite liferay-frontend-projects packages in a
+# liferay-repo checkout with the ones from this repo, for testing purposes.
+#
+# Usage:
+#
+#     bash install-packages.sh $PATH_TO_PORTAL_REPO
+
+die() {
+  echo "error: $*"
+  exit 1
+}
+
+remove() {
+  while (( "$#" )); do
+    local DEP=$1
+
+    if grep "\"$DEP\"" package.json &> /dev/null; then
+      echo "Removing $DEP dependency"
+      yarn remove -W --silent "$DEP"
+    fi
+
+    shift
+  done
+}
+
+#
+# Main.
+#
+
+ROOT=$(realpath "${BASH_SOURCE%/*}/..")
+
+if [ $# != 1 ]; then
+  echo "Usage: $0 PORTAL_REPO"
+  exit 1
+fi
+
+PORTAL_REPO=$1
+MODULES="${PORTAL_REPO}/modules"
+
+if [ ! -d "$MODULES" -o ! -e "$MODULES/yarn.lock" ]; then
+  die "\`$PORTAL_REPO\` does not appear to be a liferay-portal checkout"
+fi
+
+echo "Purging nested node_modules folders"
+
+find "$ROOT/projects" -depth -name node_modules -print -exec rm -r {} \;
+
+cd "$MODULES"
+
+remove \
+    @liferay/npm-scripts \
+    @liferay/eslint-config \
+    liferay-npm-scripts \
+    eslint-config-liferay
+
+echo "Adding local dependencies"
+
+yarn add -W --dev --silent \
+  "$ROOT/projects/eslint-config" \
+  "$ROOT/projects/npm-tools/packages/npm-scripts"


### PR DESCRIPTION
This is a crude script that will almost certainly have to be evolved as the shape and structure of the monorepo evolves, but it works for now with the set of packages that we currently have.

It addresses a bunch of "gotchas" that come with trying to test out packages with local changes in a liferay-portal checkout. Depending on which packages you want to test and the dependency graph between them, you may find that `yarn link` (or even `yarn add`) doesn't do what you want. Even if you manually copy files (`cp`), things still might not work because Gradle may decide to re-run a task that ends up blowing away any changes you make locally under `node_modules`.

At least for the simple case, this script was good enough to allow me to test [#97](https://github.com/liferay/liferay-frontend-projects/pull/97), even though it involved changes to both `eslint-config` and `npm-scripts`.

As you can see, it does three things:

- Blows away nested `node_modules` folders inside the monorepo, because `yarn add` can end up copying these over in ways that cause confusion (broken `bin` links and so on).
- Cleans out the existing versions of the dependencies (in my testing, removing and then re-adding seemed to produce a cleaner result than just overwriting).
- Adds the modules to be tested.

Like I said at the start, this is a hack (and not even trying to make it work on Windows), but it's a useful hack.