### PR TITLE
docs: add top-level CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+## Project-specific contribution guidelines
+
+-   [eslint-config](projects/eslint-config/CONTRIBUTING.md)
+-   [npm-tools](projects/npm-tools/CONTRIBUTING.md)
+
+## General contributing tips for the monorepo as a whole
+
+-   [Creating a project](CONTRIBUTING/creating-a-project.md)
+-   [Importing a project](CONTRIBUTING/importing-a-project.md)
+-   [Migrating an npm package to the `@liferay` named scope](CONTRIBUTING/migrating-an-npm-package-to-the-liferay-named-scope.md)


### PR DESCRIPTION
At this time, this is just a table-of-contents for the other contributing docs in the repo.

As we standardize the procedures across projects, some or all of the project-specific contributing guides will probably go away, but for now, we link to them.