### PR TITLE
docs(scripts): add top-level sinopsis

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/README.md
+++ b/projects/npm-tools/packages/npm-scripts/README.md
@@ -3,7 +3,7 @@
 `@liferay/npm-scripts` is our principal abstraction for building, formatting, linting, and testing frontend code in [liferay-portal](https://github.com/liferay/liferay-portal). It provides:
 
 -   **A simplified interface:** The `liferay-npm-scripts` command-line implements a small number of subcommands such as `build`, `checkFormat` and `test`, most of which don't require any arguments and do the right thing "out-of-the-box", automatically.
--   **Industry-standard dependencies:** `@liferay/npm-scripts` brings a set of well-tested and robust dependencies including Babel, ESLint, Jest, Prettier, and others, ensuring that people working anywhere in liferay-portal have access to a single, consistent set of tools.
+-   **Industry-standard dependencies:** `@liferay/npm-scripts` brings a set of well-tested and robust dependencies including Babel, ESLint, Jest, Prettier, and others, ensuring that people working anywhere in a Liferay project have access to a single, consistent set of tools.
 -   **Reasonable default configuration:** All of the bundled tools come with configurations that have been tuned to work in a Liferay environment, and can be overridden via standard configuration files (eg. `.eslintrc.js` etc) on the rare occasions that it is necessary to do so.
 
 While `@liferay/npm-scripts` was designed with liferay-portal in mind, it is also used in other projects such as [liferay-learn](https://github.com/liferay/liferay-learn); see [this issue](https://github.com/liferay/liferay-frontend-projects/issues/91) for context.

--- a/projects/npm-tools/packages/npm-scripts/README.md
+++ b/projects/npm-tools/packages/npm-scripts/README.md
@@ -1,5 +1,13 @@
 # @liferay/npm-scripts
 
+`@liferay/npm-scripts` is our principal abstraction for building, formatting, linting, and testing frontend code in [liferay-portal](https://github.com/liferay/liferay-portal). It provides:
+
+-   **A simplified interface:** The `liferay-npm-scripts` command-line implements a small number of subcommands such as `build`, `checkFormat` and `test`, most of which don't require any arguments and do the right thing "out-of-the-box", automatically.
+-   **Industry-standard dependencies:** `@liferay/npm-scripts` brings a set of well-tested and robust dependencies including Babel, ESLint, Jest, Prettier, and others, ensuring that people working anywhere in liferay-portal have access to a single, consistent set of tools.
+-   **Reasonable default configuration:** All of the bundled tools come with configurations that have been tuned to work in a Liferay environment, and can be overridden via standard configuration files (eg. `.eslintrc.js` etc) on the rare occasions that it is necessary to do so.
+
+While `@liferay/npm-scripts` was designed with liferay-portal in mind, it is also used in other projects such as [liferay-learn](https://github.com/liferay/liferay-learn); see [this issue](https://github.com/liferay/liferay-frontend-projects/issues/91) for context.
+
 ## Usage
 
 ```sh
@@ -20,7 +28,7 @@ npm install --save-dev @liferay/npm-scripts
 
 ### build
 
-Build script that compiles all necessary javascript, soy, and bundles it together using `liferay-npm-bundler`.
+Build script that compiles all necessary JavaScript, soy, and bundles it together using `liferay-npm-bundler`.
 
 ```sh
 liferay-npm-scripts build


### PR DESCRIPTION
Seeing as we have our first external "client", I think we should give a high-level intro about what the scripts are for, as well as linking to an example of an integration.

Via the "Boy Scout Rule", fixing a capitalization error on the way.