### PR TITLE
fix(scripts): apply Liferay-specific Prettier overrides to TS also

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/prettier/index.js
+++ b/projects/npm-tools/packages/npm-scripts/src/prettier/index.js
@@ -27,7 +27,7 @@ const {SCRIPTLET_CONTENT} = require('../jsp/substituteTags');
 const {BLOCK_CLOSE, BLOCK_OPEN} = require('../jsp/tagReplacements');
 const {FILLER_CHAR, SPACE_CHAR, TAB_CHAR} = require('../jsp/toFiller');
 
-const EXTENSIONS = new Set(['.js', '.jsp', '.jspf']);
+const EXTENSIONS = new Set(['.js', '.jsp', '.jspf', '.ts', '.tsx']);
 
 const linter = new Linter();
 


### PR DESCRIPTION
Noticed while testing a PR for [#92](https://github.com/liferay/liferay-frontend-projects/issues/92) that we aren't applying our Liferay-specific Prettier overrides to TS files. ie. we're not enforcing this:

    }
    else {

**Test plan:**

Add a ".ts" file, "x.ts" with these contents:

    if (true) {
    alert('t');
    } else {
        alert('f');
    }

Add an "npmscripts.config.js" file (you don't need the ".md" and ".yml" in there, but this is the file I had to create to test the other PR anyway, so I'm just using the same one):

    module.exports = {
            check: ['**/*.{md,ts,yml}'],
            fix: ['**/*.{md,ts,yml}'],
    }

Run `projects/npm-tools/packages/npm-scripts/bin/liferay-npm-scripts.js check` and see the error reported.

Run `projects/npm-tools/packages/npm-scripts/bin/liferay-npm-scripts.js fix` and see the code fixed to:

    if (true) {
            alert('t');
    }
    else {
            alert('f');
    }