### PR TITLE
feat(scripts): allow Prettier to format more files (YAML, Markdown)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
     CI: true
-    yarn-cache-name: yarn-cache
+    yarn-cache-name: yarn-cache-2
     yarn-cache-path: .yarn
 
 jobs:

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/format.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/format.js
@@ -18,9 +18,21 @@ const DEFAULT_OPTIONS = {
 };
 
 /**
- * File extensions that we want Prettier to process.
+ * File extensions that we allow Prettier to process.
  */
-const EXTENSIONS = ['.js', '.json', '.jsp', '.jspf', '.scss', '.ts', '.tsx'];
+const EXTENSIONS = [
+	'.js',
+	'.json',
+	'.jsp',
+	'.jspf',
+	'.md',
+	'.markdown',
+	'.scss',
+	'.ts',
+	'.tsx',
+	'.yml',
+	'.yaml',
+];
 
 const IGNORE_FILE = '.prettierignore';
 


### PR DESCRIPTION
We're not going to change the default globs in liferay-portal yet (or possibly ever?) because the Java Source Formatter currently handles these types.

However, we can make it easier for non-liferay-portal projects like [liferay-learn](https://github.com/liferay/liferay-learn) that use liferay-npm-scripts to run Prettier over a broader range of files. It's a simple matter of expanding the list of allowed globs.

**Test plan:**

In order to actually test this I had these two PRs applied:

- https://github.com/liferay/liferay-frontend-projects/pull/101
- https://github.com/liferay/liferay-frontend-projects/pull/102

Then, with this npmscripts.config.js at the top level of the monorepo:

    module.exports = {
        check: ['**/*.{md,ts,yml}'],
        fix: ['**/*.{md,ts,yml}'],
    }

I created some bad files and ran
`projects/npm-tools/packages/npm-scripts/bin/liferay-npm-scripts.js
check` and saw these errors:

    x.md: BAD
    x.ts: BAD
    x.yml: BAD

and then ran `check` and saw them get fixed.

Then, for good measure, in a liferay-learn clone, I added "yml" and "md" to the globs in the npmscripts.config.js and repeated the test after a:

    npm install
    cp -R path/to/npm-scripts node_modules/@liferay/

ie.

    npm run format:check

see:

    site/homepage/x.md: BAD
    site/homepage/x.yml: BAD
    Prettier checked 21 files, 2 files have problems

Then:

    npm run format

and see the errors fixed:

    Prettier checked 21 files, fixed 2 files

Closes: https://github.com/liferay/liferay-frontend-projects/issues/92