### PR TITLE
chore: ignore yarn-error.log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-# Third-party code.
 node_modules
+yarn-error.log


### PR DESCRIPTION
Keep the clutter out of the `git status` output for these files that are all too easy to produce.