### PR TITLE
fix(npm-tools): make Prettier overrides work with TS

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/prettier/rules/newline-before-block-statements.js
+++ b/projects/npm-tools/packages/npm-scripts/src/prettier/rules/newline-before-block-statements.js
@@ -31,7 +31,7 @@ module.exports = {
 						}
 
 						return fixer.replaceTextRange(
-							[last.end, keyword.start],
+							[last.range[1], keyword.range[0]],
 							`\n${indent}`
 						);
 					},

--- a/projects/npm-tools/packages/npm-scripts/test/prettier/index.js
+++ b/projects/npm-tools/packages/npm-scripts/test/prettier/index.js
@@ -70,15 +70,15 @@ describe('code``', () => {
 
 describe('prettier/index.js', () => {
 	describe('prettier.format()', () => {
-		function format(source, options = {}) {
-			return prettier.format(source, {
-				...config,
-				filepath: 'some/directory/__sample__.js',
-				...options,
-			});
-		}
-
 		it('does not choke on SCSS files', () => {
+			function format(source, options = {}) {
+				return prettier.format(source, {
+					...config,
+					filepath: 'some/directory/__sample__.scss',
+					...options,
+				});
+			}
+
 			expect(
 				format(
 					code`
@@ -103,10 +103,7 @@ describe('prettier/index.js', () => {
 							pointer-events: none;
 						}
 					}
-			`,
-					{
-						filepath: 'some/directory/__sample__.scss',
-					}
+			`
 				)
 			).toBe(code`
 					@mixin button-base() {
@@ -133,375 +130,390 @@ describe('prettier/index.js', () => {
 			`);
 		});
 
-		it('does standard prettier formatting', () => {
-			expect(
-				format(code`
-					if (test) { exit(); }
-			`)
-			).toBe(code`
-					if (test) {
-						exit();
-					}
-			`);
-		});
+		describe.each(['.js', '.ts', '.tsx'])(
+			'prettier.format("sample%s")',
+			(extension) => {
+				function format(source, options = {}) {
+					return prettier.format(source, {
+						...config,
+						filepath: `some/directory/__sample__${extension}`,
+						...options,
+					});
+				}
 
-		describe('new-line-before-block-statements', () => {
-			it('breaks before "else"', () => {
-				expect(
-					format(code`
-						// Random ES6 to prove that custom lint rule can handle
-						// it without choking.
-
-						const arrow = () => {};
-
-						function thing() {
-							if (test) {
-								return 1;
-							} else {
-								return 2;
-							}
-						}
+				it('does standard prettier formatting', () => {
+					expect(
+						format(code`
+						if (test) { exit(); }
 				`)
-				).toBe(code`
-						// Random ES6 to prove that custom lint rule can handle
-						// it without choking.
-
-						const arrow = () => {};
-
-						function thing() {
-							if (test) {
-								return 1;
-							}
-							else {
-								return 2;
-							}
-						}
-				`);
-			});
-
-			it('breaks before "else if"', () => {
-				expect(
-					format(code`
-						function thing() {
-							if (test) {
-								return 1;
-							} else if (other) {
-								return 2;
-							} else {
-								return 3;
-							}
-						}
-				`)
-				).toBe(code`
-						function thing() {
-							if (test) {
-								return 1;
-							}
-							else if (other) {
-								return 2;
-							}
-							else {
-								return 3;
-							}
-						}
-				`);
-			});
-
-			it('preserves inline comments before alternates', () => {
-				// Prettier does some "crazy" things with comments (moving them
-				// in and out of blocks) but this is one case where it leaves
-				// them alone.
-
-				expect(
-					format(code`
+					).toBe(code`
 						if (test) {
-							a();
-						} /* comment */ else {
-							b();
-						}
-				`)
-				).toBe(code`
-						if (test) {
-							a();
-						} /* comment */
-						else {
-							b();
+							exit();
 						}
 				`);
-			});
+				});
 
-			it('preserves alone-on-a-line comments before alternates', () => {
-				// This is a regression test.
-				//
-				// Given JSP source like this:
-				//
-				//      if (test) {
-				//          a();
-				//      }
-				//      <c:if test="<%= value %>">
-				//          else {
-				//              b();
-				//          }
-				//      </c:if>
-				//
-				// We will transform that to source (roughly) like this before
-				// formatting it:
-				//
-				//      if (test) {
-				//          a();
-				//      }
-				//      // opening JSP tag comment
-				//      else {
-				//          b();
-				//      }
-				//      // closing JSP tag comment
-				//
-				// We were incorrectly stripping the comment before the
-				// alternate (ie. the first one).
+				describe('new-line-before-block-statements', () => {
+					it('breaks before "else"', () => {
+						expect(
+							format(code`
+							// Random ES6 to prove that custom lint rule can handle
+							// it without choking.
 
-				expect(
-					format(code`
-						if (test) {
-							a();
-						}
+							const arrow = () => {};
 
-						// opening JSP tag comment
-
-						else if (x) {
-							b();
-						}
-
-						// closing JSP tag comment
-				`)
-				).toBe(code`
-						if (test) {
-							a();
-						}
-
-						// opening JSP tag comment
-
-						else if (x) {
-							b();
-						}
-
-						// closing JSP tag comment
-				`);
-			});
-
-			it('does not re-fix alternates that are already correct', () => {
-				// Prettier will first move the "else" here back onto
-				// the preceding line, then our wrapper moves it back down
-				// again.
-
-				expect(
-					format(code`
-						if (test) {
-							a();
-						}
-						else {
-							b();
-						}
-				`)
-				).toBe(code`
-						if (test) {
-							a();
-						}
-						else {
-							b();
-						}
-				`);
-			});
-
-			it('breaks before "catch" (with catch binding)', () => {
-				expect(
-					format(code`
-						try {
-							a();
-						} catch (error) {
-							log(error);
-						}
-				`)
-				).toBe(code`
-						try {
-							a();
-						}
-						catch (error) {
-							log(error);
-						}
-				`);
-			});
-
-			// Disabled until we switch our ESLint ecmaVersion to '2019'.
-
-			it.skip('breaks before "catch" (without optional catch binding)', () => {
-				expect(
-					format(code`
-						try {
-							b();
-						} catch {
-							c();
-						}
-				`)
-				).toBe(code`
-						try {
-							b();
-						}
-						catch {
-							c();
-						}
-				`);
-			});
-
-			it('breaks before "finally" (after a "catch" handler)', () => {
-				expect(
-					format(code`
-						try {
-							a();
-						} catch (error) {
-							log(error);
-						} finally {
-							dispose();
-						}
-				`)
-				).toBe(code`
-						try {
-							a();
-						}
-						catch (error) {
-							log(error);
-						}
-						finally {
-							dispose();
-						}
-				`);
-			});
-
-			it('breaks before "finally" (when no "catch" handler)', () => {
-				expect(
-					format(code`
-						try {
-							a();
-						} finally {
-							dispose();
-						}
-				`)
-				).toBe(code`
-						try {
-							a();
-						}
-						finally {
-							dispose();
-						}
-				`);
-			});
-
-			it('copes with comments near "try"/"catch" constructs', () => {
-				// Note: the movement of "comment 2" below is Prettier
-				// craziness and not the fault of our post-processor.
-
-				expect(
-					format(code`
-						try {
-							a();
-						} /* comment 1 */ catch /* comment 2 */ (error) {
-							log(error);
-						} /* comment 3 */ finally /* comment 4 */ {
-							dispose();
-						}
-				`)
-				).toBe(code`
-						try {
-							a();
-						} /* comment 1 */
-						catch (/* comment 2 */ error) {
-							log(error);
-						} /* comment 3 */
-						finally /* comment 4 */ {
-							dispose();
-						}
-				`);
-			});
-
-			it('copes with import statements', () => {
-				expect(
-					format(code`
-						import {a, b} from './a';
-
-						if (test) {
-							a();
-						} else {
-							b();
-						}
-				`)
-				).toBe(code`
-						import {a, b} from './a';
-
-						if (test) {
-							a();
-						}
-						else {
-							b();
-						}
-				`);
-			});
-
-			it('copes with static class properties', () => {
-				expect(
-					format(code`
-						class Thing extends React.Component {
-							static propTypes = {};
-
-							render() {
-								if (x()) {
-									return 'text';
+							function thing() {
+								if (test) {
+									return 1;
 								} else {
-									return null;
+									return 2;
 								}
 							}
-						}
-				`)
-				).toBe(code`
-						class Thing extends React.Component {
-							static propTypes = {};
+					`)
+						).toBe(code`
+							// Random ES6 to prove that custom lint rule can handle
+							// it without choking.
 
-							render() {
-								if (x()) {
-									return 'text';
+							const arrow = () => {};
+
+							function thing() {
+								if (test) {
+									return 1;
 								}
 								else {
-									return null;
+									return 2;
 								}
 							}
-						}
-				`);
-			});
+					`);
+					});
 
-			it('copes with JSX', () => {
-				expect(
-					format(code`
-						class Thing extends React.Component {
-							render() {
-								if (x()) {
-									return <One />;
+					it('breaks before "else if"', () => {
+						expect(
+							format(code`
+							function thing() {
+								if (test) {
+									return 1;
+								} else if (other) {
+									return 2;
 								} else {
-									return <Other />;
+									return 3;
 								}
 							}
-						}
-				`)
-				).toBe(code`
-						class Thing extends React.Component {
-							render() {
-								if (x()) {
-									return <One />;
+					`)
+						).toBe(code`
+							function thing() {
+								if (test) {
+									return 1;
+								}
+								else if (other) {
+									return 2;
 								}
 								else {
-									return <Other />;
+									return 3;
 								}
 							}
+					`);
+					});
+
+					it('preserves inline comments before alternates', () => {
+						// Prettier does some "crazy" things with comments (moving them
+						// in and out of blocks) but this is one case where it leaves
+						// them alone.
+
+						expect(
+							format(code`
+							if (test) {
+								a();
+							} /* comment */ else {
+								b();
+							}
+					`)
+						).toBe(code`
+							if (test) {
+								a();
+							} /* comment */
+							else {
+								b();
+							}
+					`);
+					});
+
+					it('preserves alone-on-a-line comments before alternates', () => {
+						// This is a regression test.
+						//
+						// Given JSP source like this:
+						//
+						//      if (test) {
+						//          a();
+						//      }
+						//      <c:if test="<%= value %>">
+						//          else {
+						//              b();
+						//          }
+						//      </c:if>
+						//
+						// We will transform that to source (roughly) like this before
+						// formatting it:
+						//
+						//      if (test) {
+						//          a();
+						//      }
+						//      // opening JSP tag comment
+						//      else {
+						//          b();
+						//      }
+						//      // closing JSP tag comment
+						//
+						// We were incorrectly stripping the comment before the
+						// alternate (ie. the first one).
+
+						expect(
+							format(code`
+							if (test) {
+								a();
+							}
+
+							// opening JSP tag comment
+
+							else if (x) {
+								b();
+							}
+
+							// closing JSP tag comment
+					`)
+						).toBe(code`
+							if (test) {
+								a();
+							}
+
+							// opening JSP tag comment
+
+							else if (x) {
+								b();
+							}
+
+							// closing JSP tag comment
+					`);
+					});
+
+					it('does not re-fix alternates that are already correct', () => {
+						// Prettier will first move the "else" here back onto
+						// the preceding line, then our wrapper moves it back down
+						// again.
+
+						expect(
+							format(code`
+							if (test) {
+								a();
+							}
+							else {
+								b();
+							}
+					`)
+						).toBe(code`
+							if (test) {
+								a();
+							}
+							else {
+								b();
+							}
+					`);
+					});
+
+					it('breaks before "catch" (with catch binding)', () => {
+						expect(
+							format(code`
+							try {
+								a();
+							} catch (error) {
+								log(error);
+							}
+					`)
+						).toBe(code`
+							try {
+								a();
+							}
+							catch (error) {
+								log(error);
+							}
+					`);
+					});
+
+					// Disabled until we switch our ESLint ecmaVersion to '2019'.
+
+					it.skip('breaks before "catch" (without optional catch binding)', () => {
+						expect(
+							format(code`
+							try {
+								b();
+							} catch {
+								c();
+							}
+					`)
+						).toBe(code`
+							try {
+								b();
+							}
+							catch {
+								c();
+							}
+					`);
+					});
+
+					it('breaks before "finally" (after a "catch" handler)', () => {
+						expect(
+							format(code`
+							try {
+								a();
+							} catch (error) {
+								log(error);
+							} finally {
+								dispose();
+							}
+					`)
+						).toBe(code`
+							try {
+								a();
+							}
+							catch (error) {
+								log(error);
+							}
+							finally {
+								dispose();
+							}
+					`);
+					});
+
+					it('breaks before "finally" (when no "catch" handler)', () => {
+						expect(
+							format(code`
+							try {
+								a();
+							} finally {
+								dispose();
+							}
+					`)
+						).toBe(code`
+							try {
+								a();
+							}
+							finally {
+								dispose();
+							}
+					`);
+					});
+
+					it('copes with comments near "try"/"catch" constructs', () => {
+						// Note: the movement of "comment 2" below is Prettier
+						// craziness and not the fault of our post-processor.
+
+						expect(
+							format(code`
+							try {
+								a();
+							} /* comment 1 */ catch /* comment 2 */ (error) {
+								log(error);
+							} /* comment 3 */ finally /* comment 4 */ {
+								dispose();
+							}
+					`)
+						).toBe(code`
+							try {
+								a();
+							} /* comment 1 */
+							catch (/* comment 2 */ error) {
+								log(error);
+							} /* comment 3 */
+							finally /* comment 4 */ {
+								dispose();
+							}
+					`);
+					});
+
+					it('copes with import statements', () => {
+						expect(
+							format(code`
+							import {a, b} from './a';
+
+							if (test) {
+								a();
+							} else {
+								b();
+							}
+					`)
+						).toBe(code`
+							import {a, b} from './a';
+
+							if (test) {
+								a();
+							}
+							else {
+								b();
+							}
+					`);
+					});
+
+					it('copes with static class properties', () => {
+						expect(
+							format(code`
+							class Thing extends React.Component {
+								static propTypes = {};
+
+								render() {
+									if (x()) {
+										return 'text';
+									} else {
+										return null;
+									}
+								}
+							}
+					`)
+						).toBe(code`
+							class Thing extends React.Component {
+								static propTypes = {};
+
+								render() {
+									if (x()) {
+										return 'text';
+									}
+									else {
+										return null;
+									}
+								}
+							}
+					`);
+					});
+
+					it('copes with JSX', () => {
+						if (extension === '.js' || extension === '.tsx') {
+							expect(
+								format(code`
+							class Thing extends React.Component {
+								render() {
+									if (x()) {
+										return <One />;
+									} else {
+										return <Other />;
+									}
+								}
+							}
+					`)
+							).toBe(code`
+							class Thing extends React.Component {
+								render() {
+									if (x()) {
+										return <One />;
+									}
+									else {
+										return <Other />;
+									}
+								}
+							}
+					`);
 						}
-				`);
-			});
-		});
+					});
+				});
+			}
+		);
 	});
 });


### PR DESCRIPTION
So, I thought I had this working in [#101](https://github.com/liferay/liferay-frontend-projects/pull/101) (see the test plan), but when I got this into liferay-portal in [liferay-frontend/liferay-portal#415](https://github.com/liferay-frontend/liferay-portal/pull/415), I found it wasn't working (the `else` formatting wasn't applying). So I made the edits in this PR directly in the node_modules folder to realllllly see it working.

First step: switch in the TS parser when dealing with a TS file.

Second step: observe the same problem we saw (and fixed) in d8b03088be5c76fed — namely, that the TS parser doesn't put `start` and `end` properties on its tokens. We can switch to `range[0]` and `range[1]` respectively, making the rule work with both parsers.

Test plan: manually tested in-place, plus added automated tests.