### PR TITLE
chore(eslint-config): mark typescript as a peer dependency

### DIFF
--- a/projects/eslint-config/package.json
+++ b/projects/eslint-config/package.json
@@ -33,7 +33,13 @@
 	"main": "index.js",
 	"name": "@liferay/eslint-config",
 	"peerDependencies": {
-		"eslint": ">=4.1.1"
+		"eslint": ">=4.1.1",
+		"typescript": "*"
+	},
+	"peerDependenciesMeta": {
+		"typescript": {
+			"optional": true
+		}
 	},
 	"repository": {
 		"directory": "projects/eslint-config",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16039,7 +16039,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.0.3:
+typescript@*, typescript@4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
   integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==


### PR DESCRIPTION
This isn't _strictly_ necessary, but it is an accurate description of the requirements of the project. We go with the somewhat unsatisfying range of "*" to to minimize the risk of introducing duplicates in a consuming project. At the moment, we're using v4+ in this monorepo, 3.9.7 in liferay-portal, and the lowest range that we're currently using in any other project is "^3.6.3" (in liferay-js-toolkit). In the future, we should be able to converge on v4+.

If you have a ".ts" file in your project, you are going to have `typescript` in your `devDependencies`, and our `overrides` configuration is going to use `@typescript-eslint/parser`, which in turn is going to require `typescript`, transitively, in `@typescript-eslint/typescript-estree` [here](https://github.com/typescript-eslint/typescript-eslint/blob/c5ffe8833da7875e82953de117b0abe6fa8a60b0/packages/typescript-estree/src/parser.ts#L2).

And all will work, even though `@typescript-eslint/typescript-estree` doesn't explicitly declare its hard dependency on `typescript` in [its `package.json`](https://github.com/typescript-eslint/typescript-eslint/blob/c5ffe8833da7875e82953de117b0abe6fa8a60b0/packages/typescript-estree/package.json#L41-L49).

But if you don't have any ".ts", then you shouldn't need to have `typescript` in your dependency graph, and we won't use `@typescript/eslint-parser`. So, it makes sense for us to call this an `peerDependency` and mark it as `optional` as per these posts:

- https://medium.com/@noamgjacobsonknzi/what-is-peerdependenciesmeta-acea887c32dd
- https://github.com/npm/cli/issues/1247

(Note that the `peerDependenciesMeta` field isn't documented yet.)

You could also argue that this should be under [`optionalDependencies`](https://docs.npmjs.com/files/package.json#optionaldependencies), but I think "optional peer" comes closer to the reality here. `optionalDependencies` is for things that you can add, but the package should work if they're not there. That's not the case here. The package won't work if you have ".ts" files but no `typescript`.

Related: https://github.com/liferay/liferay-frontend-projects/issues/91#issuecomment-702881845