### PR TITLE
feat(changelog-generator): make --version optional when --dry-run is on

### DIFF
--- a/projects/npm-tools/packages/changelog-generator/src/index.js
+++ b/projects/npm-tools/packages/changelog-generator/src/index.js
@@ -702,13 +702,6 @@ async function getVersionTagPrefix() {
 }
 
 async function main(_node, _script, ...args) {
-	const options = await parseArgs(args);
-
-	if (!options) {
-		process.exit(1);
-	}
-	const {outfile, to, updateTags} = options;
-
 	printBanner(`
 		changelog.js
 		============
@@ -716,6 +709,14 @@ async function main(_node, _script, ...args) {
 		Reporting
 		for duty!
 	`);
+
+	const options = await parseArgs(args);
+
+	if (!options) {
+		process.exit(1);
+	}
+
+	const {outfile, to, updateTags} = options;
 
 	if (updateTags) {
 		try {

--- a/projects/npm-tools/packages/changelog-generator/src/index.js
+++ b/projects/npm-tools/packages/changelog-generator/src/index.js
@@ -510,7 +510,7 @@ async function normalizeVersion(version, {force}, versionTagPrefix) {
 	return version;
 }
 
-function parseArgs(args) {
+async function parseArgs(args) {
 	const options = {
 		dryRun: false,
 		outfile: './CHANGELOG.md',
@@ -595,9 +595,19 @@ function parseArgs(args) {
 	});
 
 	if (!options.version) {
-		error('Missing required option: --version; see --help for usage');
+		if (options.dryRun) {
+			const prefix = await getVersionTagPrefix();
 
-		return null;
+			const version = `${prefix}0.0.0-placeholder`;
+
+			info(`Using phony version ${version} during --dry-run`);
+
+			options.version = version;
+		} else {
+			error('Missing required option: --version; see --help for usage');
+
+			return null;
+		}
 	}
 
 	return options;
@@ -692,7 +702,8 @@ async function getVersionTagPrefix() {
 }
 
 async function main(_node, _script, ...args) {
-	const options = parseArgs(args);
+	const options = await parseArgs(args);
+
 	if (!options) {
 		process.exit(1);
 	}


### PR DESCRIPTION
This makes the workflow described in [this comment](https://github.com/liferay/liferay-frontend-projects/issues/87#issuecomment-702644789) a bit easier.

Namely, when you are about to cut a release, and you want to preview what will go into the changelog and use that to guide your decision about whether to make this a `--patch`, `--minor` or `--major` (etc) release, you can just run the generator with the `--dry-run` switch, ignoring the usual requirement to pass a `--version`.

Test plan:

1.  Try running the generator without a `--version` and see it complain:

    ```
    changelog-generator ❯ bin/liferay-changelog-generator.js
     ____________________
    (_)                  `
      |                  |
      |   changelog.js   |
      |   ============   |
      |                  |
      |   Reporting      |
      |   for duty!      |
      |                  |
      |__________________|
      (_)_________________)

    error: Missing required option: --version; see --help for usage
    zsh: exit 1     bin/liferay-changelog-generator.js
    ```

2.  Repeat the test, this time with `--dry-run`, and see this:

    ```
    changelog-generator ❯ bin/liferay-changelog-generator.js --dry-run
     ____________________
    (_)                  `
      |                  |
      |   changelog.js   |
      |   ============   |
      |                  |
      |   Reporting      |
      |   for duty!      |
      |                  |
      |__________________|
      (_)_________________)

    Using phony version changelog-generator/v0.0.0-placeholder during --dry-run
    Fetching remote tags: run with --no-update-tags to skip
    ## [changelog-generator/v0.0.0-placeholder](https://github.com/liferay/liferay-frontend-projects/tree/changelog-generator/v0.0.0-placeholder) (2020-10-05)

    [Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/changelog-generator/v1.5.0...changelog-generator/v0.0.0-placeholder)

    ### :book: Documentation

    -   docs(changelog-generator): update project links ([\#94](https://github.com/liferay/liferay-frontend-projects/pull/94))

    [--dry-run] Would write ./CHANGELOG.md 6943 bytes ✨
    ```