### PR TITLE
chore(npm-scripts): update @liferay/eslint-config to v21.2.1

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/package.json
+++ b/projects/npm-tools/packages/npm-scripts/package.json
@@ -14,7 +14,7 @@
 		"@babel/preset-env": "^7.4.2",
 		"@babel/preset-react": "^7.8.3",
 		"@babel/preset-typescript": "^7.10.4",
-		"@liferay/eslint-config": "21.2.0",
+		"@liferay/eslint-config": "21.2.1",
 		"@liferay/jest-junit-reporter": "1.2.0",
 		"@liferay/npm-bundler-preset-liferay-dev": "4.6.3",
 		"@storybook/addon-a11y": "^5.1.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6236,7 +6236,7 @@ ejs@^2.7.4:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
-electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.570, electron-to-chromium@^1.3.571:
+electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.571:
   version "1.3.576"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.576.tgz#2e70234484e03d7c7e90310d7d79fd3775379c34"
   integrity sha512-uSEI0XZ//5ic+0NdOqlxp0liCD44ck20OAGyLMSymIWTEAtHKVJi6JM18acOnRgUgX7Q65QqnI+sNncNvIy8ew==


### PR DESCRIPTION
Just a routine update; nothing in here will really makes a visible difference, but seeing as I am about to cut an npm-scripts release, I may as well update to the latest.

[Full release notes for `@liferay/eslint-config` v21.2.1 are here](https://github.com/liferay/liferay-frontend-projects/releases/tag/eslint-config%2Fv21.2.1). Copy-pasting the relevant bits:

-   chore(eslint-config): update eslint-plugin-react to v7.21.3 ([\#115](https://github.com/liferay/liferay-frontend-projects/pull/115))
-   chore(eslint-config): mark typescript as a peer dependency ([\#113](https://github.com/liferay/liferay-frontend-projects/pull/113))