### PR TITLE
docs: encourage people to dog-food local packages

### DIFF
--- a/projects/eslint-config/CONTRIBUTING.md
+++ b/projects/eslint-config/CONTRIBUTING.md
@@ -14,11 +14,11 @@
 
     Run [`@liferay/changelog-generator`](https://www.npmjs.com/package/@liferay/changelog-generator):
 
-        npx @liferay/changelog-generator --version=v4.1.0
+        yarn run liferay-changelog-generator --version=v4.1.0
 
-    If you're not sure what version number to supply (ie. because you don't know exactly what changes will be included), you can pass the `--dry-run` switch along with an arbitrary version number to get a preview printed to standard output:
+    If you're not sure what version number to supply (ie. because you don't know exactly what changes will be included), you can pass the `--dry-run` switch to get a preview printed to standard output:
 
-        npx @liferay/changelog-generator --version=v0.0.0 --dry-run
+        yarn run liferay-changelog-generator --dry-run
 
 4.  Review the changes.
 

--- a/projects/eslint-config/package.json
+++ b/projects/eslint-config/package.json
@@ -53,7 +53,7 @@
 		"lint": "cd ../.. && yarn lint",
 		"lint:fix": "cd ../.. && yarn lint:fix",
 		"postinstall": "node scripts/postinstall.js",
-		"postversion": "npx @liferay/js-publish",
+		"postversion": "node ../npm-tools/packages/js-publish/bin/liferay-js-publish.js",
 		"preversion": "yarn ci",
 		"test": "cd ../.. && yarn test"
 	},

--- a/projects/npm-tools/CONTRIBUTING.md
+++ b/projects/npm-tools/CONTRIBUTING.md
@@ -25,8 +25,11 @@ yarn ci
 # Change to the directory of the package you wish to publish:
 cd packages/npm-scripts
 
+# Preview the changelog changes, to decide on an appropriate version numbers:
+yarn run liferay-changelog-generator --dry-run
+
 # Update the changelog:
-npx @liferay/changelog-generator --version=29.0.1
+yarn run liferay-changelog-generator --version=29.0.1
 
 # Review and stage the generated changes:
 git add -p
@@ -95,7 +98,7 @@ yarn ci
 cd packages/npm-scripts
 
 # Update the changelog.
-npx @liferay/changelog-generator --version=$PACKAGE_NAME/v9.5.0-beta.1
+yarn run liferay-changelog-generator --version=$PACKAGE_NAME/v9.5.0-beta.1
 
 # Bump to the prerelease version number
 yarn version --new-version 9.5.0-beta.1


### PR DESCRIPTION
A few places where we're telling people to use the last-published version of the changelog-generator (via `npx`) tell them to use `yarn run` instead; this means they'll get the current version in the workspace instead.

About the only time this won't work is if you haven't run `yarn` yet, which I'm not particularly worried about, or you have broken the local copy of the generator (and that's one of the main reasons why we like dog-fooding anyway; to find out when we've broken things).

We also get rid of one `npx` usage in eslint-config's `package.json file. That runs the last-published version of js-publish, but we should instead  directly run the one that we have in the repo (we're already doing this
in the npm-tools packages).