### PR TITLE
chore: configure labeler for js-toolkit

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,6 +3,14 @@
 #
 # See: https://github.com/actions/labeler
 
+2.x:
+    - maintenance/projects/js-toolkit/*
+    - maintenance/projects/js-toolkit/**/*
+
+3.x:
+    - projects/js-toolkit/*
+    - projects/js-toolkit/**/*
+
 changelog-generator:
     - projects/npm-tools/packages/changelog-generator/*
     - projects/npm-tools/packages/changelog-generator/**/*
@@ -22,6 +30,12 @@ js-insights:
 js-publish:
     - projects/npm-tools/packages/js-publish/*
     - projects/npm-tools/packages/js-publish/**/*
+
+js-toolkit:
+    - maintenance/projects/js-toolkit/*
+    - maintenance/projects/js-toolkit/**/*
+    - projects/js-toolkit/*
+    - projects/js-toolkit/**/*
 
 npm-bundler-preset-liferay-dev:
     - projects/npm-tools/packages/npm-bundler-preset-liferay-dev/*


### PR DESCRIPTION
Anything touching either 2.x or 3.x gets a "js-toolkit" label.

Additionally, we add "2.x" and "3.x" to distinguish the two projects.

(Note that there is no problem with having a "2.x" label eventually being shared by another project, like, say, AlloyEditor, because these projects can always be distinguished by looking at the combination of the version number label and the project name label.)