### PR TITLE
chore(monorepo): add ".ts" to our editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@
 
 root = true
 
-[**.{js,json}]
+[**.{js,json,ts}]
 indent_size = 4
 indent_style = tab
 


### PR DESCRIPTION
In preparing https://github.com/liferay/liferay-frontend-projects/pull/126 I had to edit some ".ts" files by hand, so noticed that we didn't have ".ts" in our editorconfig yet.