### PR TITLE
chore(js-toolkit): update info and links in package.json files

### DIFF
--- a/maintenance/projects/js-toolkit/package.json
+++ b/maintenance/projects/js-toolkit/package.json
@@ -1,13 +1,4 @@
 {
-	"homepage": "https://github.com/liferay/liferay-js-toolkit#readme",
-	"license": "LGPL-3.0",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/liferay/liferay-js-toolkit.git"
-	},
-	"bugs": {
-		"url": "https://github.com/liferay/liferay-js-toolkit/issues"
-	},
 	"private": true,
 	"workspaces": [
 		"packages/*"

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-add-module-metadata/package.json
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-add-module-metadata/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "babel-plugin-add-module-metadata",
 	"version": "2.19.3",
 	"description": "A Babel plugin to add AMD modules' metadata to the manifest.json file.",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/babel-plugin-add-module-metadata",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-alias-modules/package.json
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-alias-modules/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "babel-plugin-alias-modules",
 	"version": "2.19.3",
 	"description": "A Babel plugin to rewrite aliased require() calls.",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/babel-plugin-alias-modules",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-name-amd-modules/package.json
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-name-amd-modules/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "babel-plugin-name-amd-modules",
 	"version": "2.19.3",
 	"description": "A Babel plugin to give name to AMD modules based on their path and package.",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/babel-plugin-name-amd-modules",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-namespace-amd-define/package.json
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-namespace-amd-define/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "babel-plugin-namespace-amd-define",
 	"version": "2.19.3",
 	"description": "A Babel plugin to namespace (prefix) AMD define() calls.",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/babel-plugin-namespace-amd-define",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-namespace-modules/package.json
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-namespace-modules/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "babel-plugin-namespace-modules",
 	"version": "2.19.3",
 	"description": "A Babel plugin to namespace AMD module names based on root's project name.",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/babel-plugin-namespace-modules",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-normalize-requires/package.json
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-normalize-requires/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "babel-plugin-normalize-requires",
 	"version": "2.19.3",
 	"description": "A Babel plugin that rewrites require() calls to normalize them (removing extensions and trailing slashes, for example).",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/babel-plugin-normalize-requires",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-wrap-modules-amd/package.json
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-wrap-modules-amd/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "babel-plugin-wrap-modules-amd",
 	"version": "2.19.3",
 	"description": "A Babel plugin to wrap package modules inside AMD define() calls.",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/babel-plugin-wrap-modules-amd",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/babel-preset-liferay-standard/package.json
+++ b/maintenance/projects/js-toolkit/packages/babel-preset-liferay-standard/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "babel-preset-liferay-standard",
 	"version": "2.19.3",
 	"description": "Babel preset for bundling standard Liferay projects.",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/babel-preset-liferay-standard",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/generator-liferay-js/package.json
+++ b/maintenance/projects/js-toolkit/packages/generator-liferay-js/package.json
@@ -1,4 +1,5 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "generator-liferay-js",
 	"version": "2.19.3",
 	"description": "Yeoman generators for Liferay DXP and Portal CE JavaScript projects.",
@@ -11,6 +12,11 @@
 		"liferay",
 		"liferay-js"
 	],
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/generator-liferay-js",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bridge-generator/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bridge-generator/package.json
@@ -1,9 +1,15 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bridge-generator",
 	"version": "2.19.3",
 	"description": "A CLI utility to generate module bridges (modules that re-export other modules).",
 	"bin": {
 		"liferay-npm-bridge-generator": "bin/liferay-npm-bridge-generator.js"
+	},
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bridge-generator",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-support/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-support/package.json
@@ -1,4 +1,5 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-build-support",
 	"version": "2.19.3",
 	"description": "A library of scripts and helpers used by generated projects in their build processes.",
@@ -9,6 +10,11 @@
 		"lnbs-deploy": "bin/lnbs-deploy.js",
 		"lnbs-start": "bin/lnbs-start.js",
 		"lnbs-translate": "bin/lnbs-translate.js"
+	},
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-build-support",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/package.json
@@ -1,7 +1,13 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-build-tools-common",
 	"version": "2.19.3",
 	"description": "Utility library for Liferay NPM Build Tools.",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-babel-loader/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-babel-loader/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bundler-loader-babel-loader",
 	"version": "2.19.3",
 	"description": "A liferay-npm-bundler loader that runs Babel on source files.",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-babel-loader",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-copy-loader/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-copy-loader/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bundler-loader-copy-loader",
 	"version": "2.19.3",
 	"description": "A liferay-npm-bundler loader that copies files.",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-copy-loader",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-css-loader/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-css-loader/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bundler-loader-css-loader",
 	"version": "2.19.3",
 	"description": "A liferay-npm-bundler loader that turns CSS files into JavaScript modules that inject a <link> into the HTML when they are required.",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-css-loader",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-json-loader/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-json-loader/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bundler-loader-json-loader",
 	"version": "2.19.3",
 	"description": "A liferay-npm-bundler loader that turns JSON files into JavaScript modules that export the parsed JSON object.",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-json-loader",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-sass-loader/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-sass-loader/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bundler-loader-sass-loader",
 	"version": "2.19.3",
 	"description": "A liferay-npm-bundler loader that runs `sass` or `node-sass` on source files.",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-sass-loader",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-style-loader/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-style-loader/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bundler-loader-style-loader",
 	"version": "2.19.3",
 	"description": "A liferay-npm-bundler loader that turns CSS files into JavaScript modules that inject the CSS into the HTML when they are required.",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-style-loader",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-exclude-imports/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-exclude-imports/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bundler-plugin-exclude-imports",
 	"version": "2.19.3",
 	"description": "A liferay-npm-bundler plugin to exclude imported dependencies.",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-exclude-imports",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-inject-imports-dependencies/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-inject-imports-dependencies/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bundler-plugin-inject-imports-dependencies",
 	"version": "2.19.3",
 	"description": "A liferay-npm-bundler plugin to force injection of declared imports as dependencies.",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-inject-imports-dependencies",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-inject-peer-dependencies/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-inject-peer-dependencies/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bundler-plugin-inject-peer-dependencies",
 	"version": "2.19.3",
 	"description": "A liferay-npm-bundler plugin to force injection of dependencies in packages declaring peer dependencies.",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-inject-peer-dependencies",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-namespace-packages/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-namespace-packages/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bundler-plugin-namespace-packages",
 	"version": "2.19.3",
 	"description": "A liferay-npm-bundler plugin to namespace package names based on root project's name.",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-namespace-packages",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-replace-browser-modules/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-replace-browser-modules/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bundler-plugin-replace-browser-modules",
 	"version": "2.19.3",
 	"description": "A liferay-npm-bundler plugin to replace files listed under the browser/module entry of package.json files.",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-replace-browser-modules",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-resolve-linked-dependencies/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-resolve-linked-dependencies/package.json
@@ -1,8 +1,14 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bundler-plugin-resolve-linked-dependencies",
 	"version": "2.19.3",
 	"description": "A liferay-npm-bundler plugin to replace linked dependencies versions by their real values..",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-resolve-linked-dependencies",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-angular-cli/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-angular-cli/package.json
@@ -1,4 +1,5 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bundler-preset-angular-cli",
 	"version": "2.19.3",
 	"description": "Configuration for liferay-npm-bundler to integrate with Angular CLI projects",
@@ -8,5 +9,10 @@
 		"liferay-npm-build-support": "2.19.3",
 		"liferay-npm-bundler-loader-babel-loader": "2.19.3",
 		"liferay-npm-bundler-loader-copy-loader": "2.19.3"
+	},
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-angular-cli",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	}
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-create-react-app/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-create-react-app/package.json
@@ -1,4 +1,5 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bundler-preset-create-react-app",
 	"version": "2.19.3",
 	"description": "Configuration for liferay-npm-bundler to integrate with create-react-app projects",
@@ -8,5 +9,10 @@
 		"liferay-npm-bundler-loader-babel-loader": "2.19.3",
 		"liferay-npm-bundler-loader-copy-loader": "2.19.3",
 		"liferay-npm-bundler-plugin-resolve-linked-dependencies": "2.19.3"
+	},
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-create-react-app",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	}
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-standard/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-standard/package.json
@@ -1,4 +1,5 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bundler-preset-standard",
 	"version": "2.19.3",
 	"description": "Standard configuration for liferay-npm-bundler.",
@@ -11,5 +12,10 @@
 		"liferay-npm-bundler-plugin-namespace-packages": "2.19.3",
 		"liferay-npm-bundler-plugin-replace-browser-modules": "2.19.3",
 		"liferay-npm-bundler-plugin-resolve-linked-dependencies": "2.19.3"
+	},
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-standard",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	}
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-vue-cli/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-vue-cli/package.json
@@ -1,4 +1,5 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bundler-preset-vue-cli",
 	"version": "2.19.3",
 	"description": "Configuration for liferay-npm-bundler to integrate with Vue CLI projects",
@@ -8,5 +9,10 @@
 		"liferay-npm-build-support": "2.19.3",
 		"liferay-npm-bundler-loader-babel-loader": "2.19.3",
 		"liferay-npm-bundler-loader-copy-loader": "2.19.3"
+	},
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-vue-cli",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	}
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/package.json
@@ -1,10 +1,16 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bundler",
 	"version": "2.19.3",
 	"description": "A CLI utility to bundle NPM dependencies of a Liferay OSGi bundle.",
 	"main": "lib/index.js",
 	"bin": {
 		"liferay-npm-bundler": "bin/liferay-npm-bundler.js"
+	},
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-imports-checker/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-imports-checker/package.json
@@ -1,9 +1,15 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-imports-checker",
 	"version": "2.19.3",
 	"description": "A CLI utility to check `imports` sections of `.npmbundlerrc` files in a multiproject source tree.",
 	"bin": {
 		"liferay-npm-imports-checker": "bin/liferay-npm-imports-checker.js"
+	},
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-imports-checker",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
 		"copyfiles": "node ../../scripts/copyfiles.js",

--- a/projects/js-toolkit/package.json
+++ b/projects/js-toolkit/package.json
@@ -1,17 +1,5 @@
 {
-	"homepage": "https://github.com/liferay/liferay-js-toolkit#readme",
-	"license": "LGPL-3.0",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/liferay/liferay-js-toolkit.git"
-	},
-	"bugs": {
-		"url": "https://github.com/liferay/liferay-js-toolkit/issues"
-	},
 	"private": true,
-	"workspaces": [
-		"packages/*"
-	],
 	"scripts": {
 		"build": "tsc --build packages/*/tsconfig.json && yarn workspaces run copyfiles",
 		"check-deps": "node scripts/check-deps.js",

--- a/projects/js-toolkit/packages/generator-liferay-js/package.json
+++ b/projects/js-toolkit/packages/generator-liferay-js/package.json
@@ -1,4 +1,5 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "generator-liferay-js",
 	"version": "3.0.0",
 	"description": "Yeoman generators for Liferay DXP and Portal CE JavaScript projects.",
@@ -12,6 +13,11 @@
 		"liferay",
 		"liferay-js"
 	],
+	"repository": {
+		"directory": "projects/js-toolkit/packages/generator-liferay-js",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"build": "tsc && yarn copyfiles",
 		"clean": "node ../../scripts/clean.js",

--- a/projects/js-toolkit/packages/liferay-js-toolkit-core/package.json
+++ b/projects/js-toolkit/packages/liferay-js-toolkit-core/package.json
@@ -1,9 +1,15 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-js-toolkit-core",
 	"version": "3.0.0-alpha.2",
 	"description": "Utility library for Liferay NPM Build Tools.",
 	"license": "LGPL-3.0",
 	"main": "lib/index.js",
+	"repository": {
+		"directory": "projects/js-toolkit/packages/liferay-js-toolkit-core",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
 	"scripts": {
 		"build": "tsc && yarn copyfiles",
 		"ci": "cd ../.. && yarn ci",

--- a/projects/js-toolkit/packages/liferay-js-toolkit-scripts/package.json
+++ b/projects/js-toolkit/packages/liferay-js-toolkit-scripts/package.json
@@ -1,10 +1,16 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-js-toolkit-scripts",
 	"version": "3.0.0",
 	"description": "A library of helper scripts used by Liferay JavaScript projects.",
 	"license": "LGPL-3.0",
 	"bin": {
 		"js-toolkit": "bin/js-toolkit.js"
+	},
+	"repository": {
+		"directory": "projects/js-toolkit/packages/liferay-js-toolkit-scripts",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
 		"build": "tsc && yarn copyfiles",

--- a/projects/js-toolkit/packages/liferay-npm-bridge-generator/package.json
+++ b/projects/js-toolkit/packages/liferay-npm-bridge-generator/package.json
@@ -1,10 +1,16 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bridge-generator",
 	"version": "3.0.0",
 	"description": "A CLI utility to generate module bridges (modules that re-export other modules).",
 	"license": "LGPL-3.0",
 	"bin": {
 		"liferay-npm-bridge-generator": "bin/liferay-npm-bridge-generator.js"
+	},
+	"repository": {
+		"directory": "projects/js-toolkit/packages/liferay-npm-bridge-generator",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
 		"build": "tsc && yarn copyfiles",

--- a/projects/js-toolkit/packages/liferay-npm-bundler/package.json
+++ b/projects/js-toolkit/packages/liferay-npm-bundler/package.json
@@ -1,4 +1,5 @@
 {
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"name": "liferay-npm-bundler",
 	"version": "3.0.0-alpha.5",
 	"description": "A CLI utility to bundle NPM dependencies of a Liferay OSGi bundle.",
@@ -6,6 +7,11 @@
 	"main": "lib/index.js",
 	"bin": {
 		"liferay-npm-bundler": "bin/liferay-npm-bundler.js"
+	},
+	"repository": {
+		"directory": "projects/js-toolkit/packages/liferay-npm-bundler",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
 		"build": "tsc && yarn copyfiles",


### PR DESCRIPTION
- Remove stuff that doesn't make sense in private packages because they never get published to the registry (ie. anything with links). Likewise, we remove the "workspaces" from "projects/js-toolkit/package.json" because it is now participating in the monorepo's top-level workspaces configuration. I didn't touch the 2.x equivalent under "maintenance/projects/js-toolkit" because that one _is_ using its own workspace set-up.
- Add "author" to all public packages.
- Add "repository" info to all public packages.

Not sorting the keys yet, but will do that in a separate PR, for consistency with all the other package.json in the monorepo.