### PR TITLE
chore(js-toolkit): sort package.json files

### DIFF
--- a/maintenance/projects/js-toolkit/package.json
+++ b/maintenance/projects/js-toolkit/package.json
@@ -1,8 +1,20 @@
 {
+	"dependencies": {
+		"xml-js": "^1.6.8"
+	},
+	"devDependencies": {
+		"@types/jest": "^24.0.18",
+		"copyfiles": "^2.1.1",
+		"fs-extra": "^8.1.0",
+		"globby": "^10.0.1",
+		"jest": "^24.9.0",
+		"lerna": "^3.16.4",
+		"prettier": "1.18.2",
+		"ts-jest": "^24.1.0",
+		"typescript": "^3.6.3",
+		"yo": "^3.1.0"
+	},
 	"private": true,
-	"workspaces": [
-		"packages/*"
-	],
 	"scripts": {
 		"build": "lerna run build",
 		"check-deps": "node scripts/check-deps.js",
@@ -19,19 +31,7 @@
 		"test": "jest --runInBand",
 		"watch": "node scripts/watch"
 	},
-	"devDependencies": {
-		"@types/jest": "^24.0.18",
-		"copyfiles": "^2.1.1",
-		"fs-extra": "^8.1.0",
-		"globby": "^10.0.1",
-		"jest": "^24.9.0",
-		"lerna": "^3.16.4",
-		"prettier": "1.18.2",
-		"ts-jest": "^24.1.0",
-		"typescript": "^3.6.3",
-		"yo": "^3.1.0"
-	},
-	"dependencies": {
-		"xml-js": "^1.6.8"
-	}
+	"workspaces": [
+		"packages/*"
+	]
 }

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-add-module-metadata/package.json
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-add-module-metadata/package.json
@@ -1,21 +1,21 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "babel-plugin-add-module-metadata",
-	"version": "2.19.3",
+	"dependencies": {
+		"liferay-npm-build-tools-common": "2.19.3",
+		"read-json-sync": "^2.0.1"
+	},
 	"description": "A Babel plugin to add AMD modules' metadata to the manifest.json file.",
 	"main": "lib/index.js",
+	"name": "babel-plugin-add-module-metadata",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/babel-plugin-add-module-metadata",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"dependencies": {
-		"liferay-npm-build-tools-common": "2.19.3",
-		"read-json-sync": "^2.0.1"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-alias-modules/package.json
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-alias-modules/package.json
@@ -1,20 +1,20 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "babel-plugin-alias-modules",
-	"version": "2.19.3",
+	"dependencies": {
+		"liferay-npm-build-tools-common": "2.19.3"
+	},
 	"description": "A Babel plugin to rewrite aliased require() calls.",
 	"main": "lib/index.js",
+	"name": "babel-plugin-alias-modules",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/babel-plugin-alias-modules",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"dependencies": {
-		"liferay-npm-build-tools-common": "2.19.3"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-name-amd-modules/package.json
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-name-amd-modules/package.json
@@ -1,20 +1,20 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "babel-plugin-name-amd-modules",
-	"version": "2.19.3",
+	"dependencies": {
+		"liferay-npm-build-tools-common": "2.19.3"
+	},
 	"description": "A Babel plugin to give name to AMD modules based on their path and package.",
 	"main": "lib/index.js",
+	"name": "babel-plugin-name-amd-modules",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/babel-plugin-name-amd-modules",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"dependencies": {
-		"liferay-npm-build-tools-common": "2.19.3"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-namespace-amd-define/package.json
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-namespace-amd-define/package.json
@@ -1,20 +1,20 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "babel-plugin-namespace-amd-define",
-	"version": "2.19.3",
+	"dependencies": {
+		"liferay-npm-build-tools-common": "2.19.3"
+	},
 	"description": "A Babel plugin to namespace (prefix) AMD define() calls.",
 	"main": "lib/index.js",
+	"name": "babel-plugin-namespace-amd-define",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/babel-plugin-namespace-amd-define",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"dependencies": {
-		"liferay-npm-build-tools-common": "2.19.3"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-namespace-modules/package.json
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-namespace-modules/package.json
@@ -1,20 +1,20 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "babel-plugin-namespace-modules",
-	"version": "2.19.3",
+	"dependencies": {
+		"liferay-npm-build-tools-common": "2.19.3"
+	},
 	"description": "A Babel plugin to namespace AMD module names based on root's project name.",
 	"main": "lib/index.js",
+	"name": "babel-plugin-namespace-modules",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/babel-plugin-namespace-modules",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"dependencies": {
-		"liferay-npm-build-tools-common": "2.19.3"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-normalize-requires/package.json
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-normalize-requires/package.json
@@ -1,20 +1,20 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "babel-plugin-normalize-requires",
-	"version": "2.19.3",
+	"dependencies": {
+		"liferay-npm-build-tools-common": "2.19.3"
+	},
 	"description": "A Babel plugin that rewrites require() calls to normalize them (removing extensions and trailing slashes, for example).",
 	"main": "lib/index.js",
+	"name": "babel-plugin-normalize-requires",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/babel-plugin-normalize-requires",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"dependencies": {
-		"liferay-npm-build-tools-common": "2.19.3"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-wrap-modules-amd/package.json
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-wrap-modules-amd/package.json
@@ -1,22 +1,22 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "babel-plugin-wrap-modules-amd",
-	"version": "2.19.3",
+	"dependencies": {
+		"babel-template": "^6.26.0",
+		"liferay-npm-build-tools-common": "2.19.3",
+		"read-json-sync": "^2.0.1"
+	},
 	"description": "A Babel plugin to wrap package modules inside AMD define() calls.",
 	"main": "lib/index.js",
+	"name": "babel-plugin-wrap-modules-amd",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/babel-plugin-wrap-modules-amd",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"dependencies": {
-		"babel-template": "^6.26.0",
-		"liferay-npm-build-tools-common": "2.19.3",
-		"read-json-sync": "^2.0.1"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/babel-preset-liferay-standard/package.json
+++ b/maintenance/projects/js-toolkit/packages/babel-preset-liferay-standard/package.json
@@ -1,19 +1,5 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "babel-preset-liferay-standard",
-	"version": "2.19.3",
-	"description": "Babel preset for bundling standard Liferay projects.",
-	"main": "lib/index.js",
-	"repository": {
-		"directory": "maintenance/projects/js-toolkit/packages/babel-preset-liferay-standard",
-		"type": "git",
-		"url": "https://github.com/liferay/liferay-frontend-projects.git"
-	},
-	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
-		"build": "tsc && yarn copyfiles",
-		"prepublish": "yarn build"
-	},
 	"dependencies": {
 		"babel-plugin-add-module-metadata": "2.19.3",
 		"babel-plugin-alias-modules": "2.19.3",
@@ -24,5 +10,19 @@
 		"babel-plugin-normalize-requires": "2.19.3",
 		"babel-plugin-transform-node-env-inline": "0.4.3",
 		"babel-plugin-wrap-modules-amd": "2.19.3"
-	}
+	},
+	"description": "Babel preset for bundling standard Liferay projects.",
+	"main": "lib/index.js",
+	"name": "babel-preset-liferay-standard",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/babel-preset-liferay-standard",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
+	"scripts": {
+		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
+		"prepublish": "yarn build"
+	},
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/generator-liferay-js/package.json
+++ b/maintenance/projects/js-toolkit/packages/generator-liferay-js/package.json
@@ -1,9 +1,18 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "generator-liferay-js",
-	"version": "2.19.3",
+	"dependencies": {
+		"dot-prop": "^5.0.1",
+		"liferay-npm-build-tools-common": "2.19.3",
+		"read-json-sync": "^2.0.1",
+		"yargs": "^14.0.0",
+		"yeoman-generator": "^3.2.0"
+	},
 	"description": "Yeoman generators for Liferay DXP and Portal CE JavaScript projects.",
-	"main": "generators/app/index.js",
+	"devDependencies": {
+		"mem-fs": "^1.1.3",
+		"mem-fs-editor": "^6.0.0",
+		"rimraf": "^3.0.0"
+	},
 	"files": [
 		"generators"
 	],
@@ -12,26 +21,17 @@
 		"liferay",
 		"liferay-js"
 	],
+	"main": "generators/app/index.js",
+	"name": "generator-liferay-js",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/generator-liferay-js",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"devDependencies": {
-		"mem-fs": "^1.1.3",
-		"mem-fs-editor": "^6.0.0",
-		"rimraf": "^3.0.0"
-	},
-	"dependencies": {
-		"dot-prop": "^5.0.1",
-		"liferay-npm-build-tools-common": "2.19.3",
-		"read-json-sync": "^2.0.1",
-		"yargs": "^14.0.0",
-		"yeoman-generator": "^3.2.0"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bridge-generator/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bridge-generator/package.json
@@ -1,25 +1,25 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bridge-generator",
-	"version": "2.19.3",
-	"description": "A CLI utility to generate module bridges (modules that re-export other modules).",
 	"bin": {
 		"liferay-npm-bridge-generator": "bin/liferay-npm-bridge-generator.js"
-	},
-	"repository": {
-		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bridge-generator",
-		"type": "git",
-		"url": "https://github.com/liferay/liferay-frontend-projects.git"
-	},
-	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
-		"build": "tsc && yarn copyfiles",
-		"prepublish": "yarn build"
 	},
 	"dependencies": {
 		"fs-extra": "^8.1.0",
 		"globby": "^10.0.1",
 		"read-json-sync": "^2.0.1",
 		"yargs": "^14.0.0"
-	}
+	},
+	"description": "A CLI utility to generate module bridges (modules that re-export other modules).",
+	"name": "liferay-npm-bridge-generator",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bridge-generator",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
+	"scripts": {
+		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
+		"prepublish": "yarn build"
+	},
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-support/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-support/package.json
@@ -1,8 +1,5 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-build-support",
-	"version": "2.19.3",
-	"description": "A library of scripts and helpers used by generated projects in their build processes.",
 	"bin": {
 		"lnbs-build": "bin/lnbs-build.js",
 		"lnbs-copy-assets": "bin/lnbs-copy-assets.js",
@@ -10,16 +7,6 @@
 		"lnbs-deploy": "bin/lnbs-deploy.js",
 		"lnbs-start": "bin/lnbs-start.js",
 		"lnbs-translate": "bin/lnbs-translate.js"
-	},
-	"repository": {
-		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-build-support",
-		"type": "git",
-		"url": "https://github.com/liferay/liferay-frontend-projects.git"
-	},
-	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
-		"build": "tsc && yarn copyfiles",
-		"prepublish": "yarn build"
 	},
 	"dependencies": {
 		"@babel/core": "^7.0.0",
@@ -36,5 +23,18 @@
 		"request": "^2.88.0",
 		"resolve": "^1.8.1",
 		"uuid": "^3.3.2"
-	}
+	},
+	"description": "A library of scripts and helpers used by generated projects in their build processes.",
+	"name": "liferay-npm-build-support",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-build-support",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
+	"scripts": {
+		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
+		"prepublish": "yarn build"
+	},
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/package.json
@@ -1,18 +1,5 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-build-tools-common",
-	"version": "2.19.3",
-	"description": "Utility library for Liferay NPM Build Tools.",
-	"repository": {
-		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common",
-		"type": "git",
-		"url": "https://github.com/liferay/liferay-frontend-projects.git"
-	},
-	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
-		"build": "tsc && yarn copyfiles",
-		"prepublish": "yarn build"
-	},
 	"dependencies": {
 		"chalk": "^2.4.2",
 		"dot-prop": "^5.0.1",
@@ -22,5 +9,18 @@
 		"properties": "^1.2.1",
 		"read-json-sync": "^2.0.1",
 		"resolve": "^1.8.1"
-	}
+	},
+	"description": "Utility library for Liferay NPM Build Tools.",
+	"name": "liferay-npm-build-tools-common",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
+	"scripts": {
+		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
+		"prepublish": "yarn build"
+	},
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-babel-loader/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-babel-loader/package.json
@@ -1,26 +1,26 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bundler-loader-babel-loader",
-	"version": "2.19.3",
-	"description": "A liferay-npm-bundler loader that runs Babel on source files.",
-	"main": "lib/index.js",
-	"repository": {
-		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-babel-loader",
-		"type": "git",
-		"url": "https://github.com/liferay/liferay-frontend-projects.git"
-	},
-	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
-		"build": "tsc && yarn copyfiles",
-		"prepublish": "yarn build"
-	},
 	"dependencies": {
 		"babel-core": "^6.26.3",
 		"data-urls": "^1.1.0",
 		"liferay-npm-build-tools-common": "2.19.3",
 		"read-json-sync": "^2.0.1"
 	},
+	"description": "A liferay-npm-bundler loader that runs Babel on source files.",
 	"devDependencies": {
 		"babel-preset-es2015": "^6.24.1"
-	}
+	},
+	"main": "lib/index.js",
+	"name": "liferay-npm-bundler-loader-babel-loader",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-babel-loader",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
+	"scripts": {
+		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
+		"prepublish": "yarn build"
+	},
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-copy-loader/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-copy-loader/package.json
@@ -1,20 +1,20 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bundler-loader-copy-loader",
-	"version": "2.19.3",
+	"dependencies": {
+		"liferay-npm-build-tools-common": "2.19.3"
+	},
 	"description": "A liferay-npm-bundler loader that copies files.",
 	"main": "lib/index.js",
+	"name": "liferay-npm-bundler-loader-copy-loader",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-copy-loader",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"dependencies": {
-		"liferay-npm-build-tools-common": "2.19.3"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-css-loader/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-css-loader/package.json
@@ -1,21 +1,21 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bundler-loader-css-loader",
-	"version": "2.19.3",
+	"dependencies": {
+		"liferay-npm-build-tools-common": "2.19.3",
+		"read-json-sync": "^2.0.1"
+	},
 	"description": "A liferay-npm-bundler loader that turns CSS files into JavaScript modules that inject a <link> into the HTML when they are required.",
 	"main": "lib/index.js",
+	"name": "liferay-npm-bundler-loader-css-loader",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-css-loader",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"dependencies": {
-		"liferay-npm-build-tools-common": "2.19.3",
-		"read-json-sync": "^2.0.1"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-json-loader/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-json-loader/package.json
@@ -1,20 +1,20 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bundler-loader-json-loader",
-	"version": "2.19.3",
+	"dependencies": {
+		"liferay-npm-build-tools-common": "2.19.3"
+	},
 	"description": "A liferay-npm-bundler loader that turns JSON files into JavaScript modules that export the parsed JSON object.",
 	"main": "lib/index.js",
+	"name": "liferay-npm-bundler-loader-json-loader",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-json-loader",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"dependencies": {
-		"liferay-npm-build-tools-common": "2.19.3"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-sass-loader/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-sass-loader/package.json
@@ -1,21 +1,21 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bundler-loader-sass-loader",
-	"version": "2.19.3",
+	"dependencies": {
+		"resolve": "^1.8.1",
+		"sass": "^1.22.2"
+	},
 	"description": "A liferay-npm-bundler loader that runs `sass` or `node-sass` on source files.",
 	"main": "lib/index.js",
+	"name": "liferay-npm-bundler-loader-sass-loader",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-sass-loader",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"dependencies": {
-		"resolve": "^1.8.1",
-		"sass": "^1.22.2"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-style-loader/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-style-loader/package.json
@@ -1,20 +1,20 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bundler-loader-style-loader",
-	"version": "2.19.3",
+	"dependencies": {
+		"liferay-npm-build-tools-common": "2.19.3"
+	},
 	"description": "A liferay-npm-bundler loader that turns CSS files into JavaScript modules that inject the CSS into the HTML when they are required.",
 	"main": "lib/index.js",
+	"name": "liferay-npm-bundler-loader-style-loader",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-style-loader",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"dependencies": {
-		"liferay-npm-build-tools-common": "2.19.3"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-exclude-imports/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-exclude-imports/package.json
@@ -1,20 +1,20 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bundler-plugin-exclude-imports",
-	"version": "2.19.3",
+	"dependencies": {
+		"liferay-npm-build-tools-common": "2.19.3"
+	},
 	"description": "A liferay-npm-bundler plugin to exclude imported dependencies.",
 	"main": "lib/index.js",
+	"name": "liferay-npm-bundler-plugin-exclude-imports",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-exclude-imports",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"dependencies": {
-		"liferay-npm-build-tools-common": "2.19.3"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-inject-imports-dependencies/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-inject-imports-dependencies/package.json
@@ -1,20 +1,20 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bundler-plugin-inject-imports-dependencies",
-	"version": "2.19.3",
+	"dependencies": {
+		"liferay-npm-build-tools-common": "2.19.3"
+	},
 	"description": "A liferay-npm-bundler plugin to force injection of declared imports as dependencies.",
 	"main": "lib/index.js",
+	"name": "liferay-npm-bundler-plugin-inject-imports-dependencies",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-inject-imports-dependencies",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"dependencies": {
-		"liferay-npm-build-tools-common": "2.19.3"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-inject-peer-dependencies/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-inject-peer-dependencies/package.json
@@ -1,23 +1,23 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bundler-plugin-inject-peer-dependencies",
-	"version": "2.19.3",
+	"dependencies": {
+		"globby": "^10.0.1",
+		"liferay-npm-build-tools-common": "2.19.3",
+		"read-json-sync": "^2.0.1",
+		"resolve": "^1.8.1"
+	},
 	"description": "A liferay-npm-bundler plugin to force injection of dependencies in packages declaring peer dependencies.",
 	"main": "lib/index.js",
+	"name": "liferay-npm-bundler-plugin-inject-peer-dependencies",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-inject-peer-dependencies",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"dependencies": {
-		"globby": "^10.0.1",
-		"liferay-npm-build-tools-common": "2.19.3",
-		"read-json-sync": "^2.0.1",
-		"resolve": "^1.8.1"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-namespace-packages/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-namespace-packages/package.json
@@ -1,23 +1,23 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bundler-plugin-namespace-packages",
-	"version": "2.19.3",
+	"dependencies": {
+		"liferay-npm-build-tools-common": "2.19.3"
+	},
 	"description": "A liferay-npm-bundler plugin to namespace package names based on root project's name.",
+	"devDependencies": {
+		"read-json-sync": "^2.0.1"
+	},
 	"main": "lib/index.js",
+	"name": "liferay-npm-bundler-plugin-namespace-packages",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-namespace-packages",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"devDependencies": {
-		"read-json-sync": "^2.0.1"
-	},
-	"dependencies": {
-		"liferay-npm-build-tools-common": "2.19.3"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-replace-browser-modules/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-replace-browser-modules/package.json
@@ -1,22 +1,22 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bundler-plugin-replace-browser-modules",
-	"version": "2.19.3",
+	"dependencies": {
+		"dot-prop": "^5.0.1",
+		"fs-extra": "^8.1.0",
+		"liferay-npm-build-tools-common": "2.19.3"
+	},
 	"description": "A liferay-npm-bundler plugin to replace files listed under the browser/module entry of package.json files.",
 	"main": "lib/index.js",
+	"name": "liferay-npm-bundler-plugin-replace-browser-modules",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-replace-browser-modules",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"dependencies": {
-		"dot-prop": "^5.0.1",
-		"fs-extra": "^8.1.0",
-		"liferay-npm-build-tools-common": "2.19.3"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-resolve-linked-dependencies/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-resolve-linked-dependencies/package.json
@@ -1,22 +1,22 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bundler-plugin-resolve-linked-dependencies",
-	"version": "2.19.3",
+	"dependencies": {
+		"liferay-npm-build-tools-common": "2.19.3",
+		"read-json-sync": "^2.0.1",
+		"semver": "^6.3.0"
+	},
 	"description": "A liferay-npm-bundler plugin to replace linked dependencies versions by their real values..",
 	"main": "lib/index.js",
+	"name": "liferay-npm-bundler-plugin-resolve-linked-dependencies",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-resolve-linked-dependencies",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
 	},
 	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
 		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"dependencies": {
-		"liferay-npm-build-tools-common": "2.19.3",
-		"read-json-sync": "^2.0.1",
-		"semver": "^6.3.0"
-	}
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-angular-cli/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-angular-cli/package.json
@@ -1,18 +1,18 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bundler-preset-angular-cli",
-	"version": "2.19.3",
-	"description": "Configuration for liferay-npm-bundler to integrate with Angular CLI projects",
-	"main": "config.json",
 	"dependencies": {
 		"babel-preset-liferay-standard": "2.19.3",
 		"liferay-npm-build-support": "2.19.3",
 		"liferay-npm-bundler-loader-babel-loader": "2.19.3",
 		"liferay-npm-bundler-loader-copy-loader": "2.19.3"
 	},
+	"description": "Configuration for liferay-npm-bundler to integrate with Angular CLI projects",
+	"main": "config.json",
+	"name": "liferay-npm-bundler-preset-angular-cli",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-angular-cli",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
-	}
+	},
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-create-react-app/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-create-react-app/package.json
@@ -1,18 +1,18 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bundler-preset-create-react-app",
-	"version": "2.19.3",
-	"description": "Configuration for liferay-npm-bundler to integrate with create-react-app projects",
-	"main": "config.json",
 	"dependencies": {
 		"babel-preset-liferay-standard": "2.19.3",
 		"liferay-npm-bundler-loader-babel-loader": "2.19.3",
 		"liferay-npm-bundler-loader-copy-loader": "2.19.3",
 		"liferay-npm-bundler-plugin-resolve-linked-dependencies": "2.19.3"
 	},
+	"description": "Configuration for liferay-npm-bundler to integrate with create-react-app projects",
+	"main": "config.json",
+	"name": "liferay-npm-bundler-preset-create-react-app",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-create-react-app",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
-	}
+	},
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-standard/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-standard/package.json
@@ -1,9 +1,5 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bundler-preset-standard",
-	"version": "2.19.3",
-	"description": "Standard configuration for liferay-npm-bundler.",
-	"main": "config.json",
 	"dependencies": {
 		"babel-preset-liferay-standard": "2.19.3",
 		"liferay-npm-bundler-plugin-exclude-imports": "2.19.3",
@@ -13,9 +9,13 @@
 		"liferay-npm-bundler-plugin-replace-browser-modules": "2.19.3",
 		"liferay-npm-bundler-plugin-resolve-linked-dependencies": "2.19.3"
 	},
+	"description": "Standard configuration for liferay-npm-bundler.",
+	"main": "config.json",
+	"name": "liferay-npm-bundler-preset-standard",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-standard",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
-	}
+	},
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-vue-cli/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-vue-cli/package.json
@@ -1,18 +1,18 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bundler-preset-vue-cli",
-	"version": "2.19.3",
-	"description": "Configuration for liferay-npm-bundler to integrate with Vue CLI projects",
-	"main": "config.json",
 	"dependencies": {
 		"babel-preset-liferay-standard": "2.19.3",
 		"liferay-npm-build-support": "2.19.3",
 		"liferay-npm-bundler-loader-babel-loader": "2.19.3",
 		"liferay-npm-bundler-loader-copy-loader": "2.19.3"
 	},
+	"description": "Configuration for liferay-npm-bundler to integrate with Vue CLI projects",
+	"main": "config.json",
+	"name": "liferay-npm-bundler-preset-vue-cli",
 	"repository": {
 		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler-preset-vue-cli",
 		"type": "git",
 		"url": "https://github.com/liferay/liferay-frontend-projects.git"
-	}
+	},
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/package.json
@@ -1,24 +1,7 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bundler",
-	"version": "2.19.3",
-	"description": "A CLI utility to bundle NPM dependencies of a Liferay OSGi bundle.",
-	"main": "lib/index.js",
 	"bin": {
 		"liferay-npm-bundler": "bin/liferay-npm-bundler.js"
-	},
-	"repository": {
-		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler",
-		"type": "git",
-		"url": "https://github.com/liferay/liferay-frontend-projects.git"
-	},
-	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
-		"build": "tsc && yarn copyfiles",
-		"prepublish": "yarn build"
-	},
-	"devDependencies": {
-		"liferay-npm-bundler-preset-liferay-dev": "1.12.0"
 	},
 	"dependencies": {
 		"babel-core": "^6.26.3",
@@ -39,5 +22,22 @@
 		"semver": "^6.3.0",
 		"xml-js": "^1.6.8",
 		"yargs": "^14.0.0"
-	}
+	},
+	"description": "A CLI utility to bundle NPM dependencies of a Liferay OSGi bundle.",
+	"devDependencies": {
+		"liferay-npm-bundler-preset-liferay-dev": "1.12.0"
+	},
+	"main": "lib/index.js",
+	"name": "liferay-npm-bundler",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-bundler",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
+	"scripts": {
+		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
+		"prepublish": "yarn build"
+	},
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-imports-checker/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-imports-checker/package.json
@@ -1,20 +1,7 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-imports-checker",
-	"version": "2.19.3",
-	"description": "A CLI utility to check `imports` sections of `.npmbundlerrc` files in a multiproject source tree.",
 	"bin": {
 		"liferay-npm-imports-checker": "bin/liferay-npm-imports-checker.js"
-	},
-	"repository": {
-		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-imports-checker",
-		"type": "git",
-		"url": "https://github.com/liferay/liferay-frontend-projects.git"
-	},
-	"scripts": {
-		"copyfiles": "node ../../scripts/copyfiles.js",
-		"build": "tsc && yarn copyfiles",
-		"prepublish": "yarn build"
 	},
 	"dependencies": {
 		"chalk": "^2.4.2",
@@ -24,5 +11,18 @@
 		"read-json-sync": "^2.0.1",
 		"resolve": "^1.8.1",
 		"semver": "^6.3.0"
-	}
+	},
+	"description": "A CLI utility to check `imports` sections of `.npmbundlerrc` files in a multiproject source tree.",
+	"name": "liferay-npm-imports-checker",
+	"repository": {
+		"directory": "maintenance/projects/js-toolkit/packages/liferay-npm-imports-checker",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
+	"scripts": {
+		"build": "tsc && yarn copyfiles",
+		"copyfiles": "node ../../scripts/copyfiles.js",
+		"prepublish": "yarn build"
+	},
+	"version": "2.19.3"
 }

--- a/maintenance/projects/js-toolkit/resources/devtools/find-generator/package.json
+++ b/maintenance/projects/js-toolkit/resources/devtools/find-generator/package.json
@@ -1,12 +1,12 @@
 {
-	"name": "find-generator",
-	"version": "1.0.0",
-	"description": "",
 	"bin": {
 		"find-generator": "find-generator.js"
 	},
 	"dependencies": {
 		"yeoman-environment": "^2.4.0"
 	},
-	"private": true
+	"description": "",
+	"name": "find-generator",
+	"private": true,
+	"version": "1.0.0"
 }

--- a/maintenance/projects/js-toolkit/resources/devtools/link-js-toolkit/package.json
+++ b/maintenance/projects/js-toolkit/resources/devtools/link-js-toolkit/package.json
@@ -1,7 +1,4 @@
 {
-	"name": "link-js-toolkit",
-	"version": "1.0.0",
-	"description": "",
 	"bin": {
 		"link-js-toolkit": "link-js-toolkit.js"
 	},
@@ -10,8 +7,11 @@
 		"cross-spawn": "^6.0.5",
 		"read-json-sync": "^2.0.1"
 	},
-	"private": true,
+	"description": "",
 	"devDependencies": {
 		"yargs": "^14.0.0"
-	}
+	},
+	"name": "link-js-toolkit",
+	"private": true,
+	"version": "1.0.0"
 }

--- a/projects/js-toolkit/package.json
+++ b/projects/js-toolkit/package.json
@@ -1,19 +1,4 @@
 {
-	"private": true,
-	"scripts": {
-		"build": "tsc --build packages/*/tsconfig.json && yarn workspaces run copyfiles",
-		"check-deps": "node scripts/check-deps.js",
-		"ci": "yarn clean && yarn check-deps && yarn format:check && yarn lint && yarn build && yarn test",
-		"clean": "yarn workspaces run clean",
-		"format": "cd ../.. && yarn format",
-		"format:check": "cd ../.. && yarn format:check",
-		"level-deps": "node scripts/level-deps.js",
-		"lint": "cd ../.. && yarn lint",
-		"lint:fix": "cd ../.. && yarn lint:fix",
-		"qa": "node scripts/qa/index.js",
-		"test": "jest --runInBand",
-		"watch": "node scripts/watch.js"
-	},
 	"devDependencies": {
 		"@cnakazawa/watch": "^1.0.4",
 		"@types/jest": "^24.0.18",
@@ -32,5 +17,20 @@
 		"typescript": "^3.6.3",
 		"xml-js": "^1.6.8",
 		"yo": "^3.1.0"
+	},
+	"private": true,
+	"scripts": {
+		"build": "tsc --build packages/*/tsconfig.json && yarn workspaces run copyfiles",
+		"check-deps": "node scripts/check-deps.js",
+		"ci": "yarn clean && yarn check-deps && yarn format:check && yarn lint && yarn build && yarn test",
+		"clean": "yarn workspaces run clean",
+		"format": "cd ../.. && yarn format",
+		"format:check": "cd ../.. && yarn format:check",
+		"level-deps": "node scripts/level-deps.js",
+		"lint": "cd ../.. && yarn lint",
+		"lint:fix": "cd ../.. && yarn lint:fix",
+		"qa": "node scripts/qa/index.js",
+		"test": "jest --runInBand",
+		"watch": "node scripts/watch.js"
 	}
 }

--- a/projects/js-toolkit/packages/generator-liferay-js/package.json
+++ b/projects/js-toolkit/packages/generator-liferay-js/package.json
@@ -1,10 +1,20 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "generator-liferay-js",
-	"version": "3.0.0",
+	"dependencies": {
+		"dot-prop": "^5.0.1",
+		"fs-extra": "^8.1.0",
+		"liferay-js-toolkit-core": "3.0.0-alpha.2",
+		"read-json-sync": "^2.0.1",
+		"yargs": "^14.0.0",
+		"yeoman-generator": "^3.2.0"
+	},
 	"description": "Yeoman generators for Liferay DXP and Portal CE JavaScript projects.",
-	"license": "LGPL-3.0",
-	"main": "generators/app/index.js",
+	"devDependencies": {
+		"@types/yeoman-generator": "^3.1.4",
+		"mem-fs": "^1.1.3",
+		"mem-fs-editor": "^6.0.0",
+		"rimraf": "^3.0.0"
+	},
 	"files": [
 		"generators"
 	],
@@ -13,6 +23,9 @@
 		"liferay",
 		"liferay-js"
 	],
+	"license": "LGPL-3.0",
+	"main": "generators/app/index.js",
+	"name": "generator-liferay-js",
 	"repository": {
 		"directory": "projects/js-toolkit/packages/generator-liferay-js",
 		"type": "git",
@@ -24,18 +37,5 @@
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"devDependencies": {
-		"@types/yeoman-generator": "^3.1.4",
-		"mem-fs": "^1.1.3",
-		"mem-fs-editor": "^6.0.0",
-		"rimraf": "^3.0.0"
-	},
-	"dependencies": {
-		"dot-prop": "^5.0.1",
-		"fs-extra": "^8.1.0",
-		"liferay-js-toolkit-core": "3.0.0-alpha.2",
-		"read-json-sync": "^2.0.1",
-		"yargs": "^14.0.0",
-		"yeoman-generator": "^3.2.0"
-	}
+	"version": "3.0.0"
 }

--- a/projects/js-toolkit/packages/liferay-js-toolkit-core/package.json
+++ b/projects/js-toolkit/packages/liferay-js-toolkit-core/package.json
@@ -1,23 +1,5 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-js-toolkit-core",
-	"version": "3.0.0-alpha.2",
-	"description": "Utility library for Liferay NPM Build Tools.",
-	"license": "LGPL-3.0",
-	"main": "lib/index.js",
-	"repository": {
-		"directory": "projects/js-toolkit/packages/liferay-js-toolkit-core",
-		"type": "git",
-		"url": "https://github.com/liferay/liferay-frontend-projects.git"
-	},
-	"scripts": {
-		"build": "tsc && yarn copyfiles",
-		"ci": "cd ../.. && yarn ci",
-		"clean": "node ../../scripts/clean.js",
-		"copyfiles": "node ../../scripts/copyfiles.js",
-		"postversion": "npx liferay-js-publish",
-		"preversion": "yarn ci"
-	},
 	"dependencies": {
 		"acorn": "^6.2.1",
 		"chalk": "^2.4.2",
@@ -33,7 +15,25 @@
 		"source-map": "^0.7.3",
 		"webpack": "^4.41.6"
 	},
+	"description": "Utility library for Liferay NPM Build Tools.",
 	"devDependencies": {
 		"@types/estree": "^0.0.42"
-	}
+	},
+	"license": "LGPL-3.0",
+	"main": "lib/index.js",
+	"name": "liferay-js-toolkit-core",
+	"repository": {
+		"directory": "projects/js-toolkit/packages/liferay-js-toolkit-core",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
+	"scripts": {
+		"build": "tsc && yarn copyfiles",
+		"ci": "cd ../.. && yarn ci",
+		"clean": "node ../../scripts/clean.js",
+		"copyfiles": "node ../../scripts/copyfiles.js",
+		"postversion": "npx liferay-js-publish",
+		"preversion": "yarn ci"
+	},
+	"version": "3.0.0-alpha.2"
 }

--- a/projects/js-toolkit/packages/liferay-js-toolkit-scripts/package.json
+++ b/projects/js-toolkit/packages/liferay-js-toolkit-scripts/package.json
@@ -1,22 +1,7 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-js-toolkit-scripts",
-	"version": "3.0.0",
-	"description": "A library of helper scripts used by Liferay JavaScript projects.",
-	"license": "LGPL-3.0",
 	"bin": {
 		"js-toolkit": "bin/js-toolkit.js"
-	},
-	"repository": {
-		"directory": "projects/js-toolkit/packages/liferay-js-toolkit-scripts",
-		"type": "git",
-		"url": "https://github.com/liferay/liferay-frontend-projects.git"
-	},
-	"scripts": {
-		"build": "tsc && yarn copyfiles",
-		"clean": "node ../../scripts/clean.js",
-		"copyfiles": "node ../../scripts/copyfiles.js",
-		"prepublish": "yarn build"
 	},
 	"dependencies": {
 		"@babel/core": "^7.0.0",
@@ -33,5 +18,20 @@
 		"request": "^2.88.0",
 		"resolve": "^1.8.1",
 		"uuid": "^3.3.2"
-	}
+	},
+	"description": "A library of helper scripts used by Liferay JavaScript projects.",
+	"license": "LGPL-3.0",
+	"name": "liferay-js-toolkit-scripts",
+	"repository": {
+		"directory": "projects/js-toolkit/packages/liferay-js-toolkit-scripts",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
+	"scripts": {
+		"build": "tsc && yarn copyfiles",
+		"clean": "node ../../scripts/clean.js",
+		"copyfiles": "node ../../scripts/copyfiles.js",
+		"prepublish": "yarn build"
+	},
+	"version": "3.0.0"
 }

--- a/projects/js-toolkit/packages/liferay-npm-bridge-generator/package.json
+++ b/projects/js-toolkit/packages/liferay-npm-bridge-generator/package.json
@@ -1,12 +1,17 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bridge-generator",
-	"version": "3.0.0",
-	"description": "A CLI utility to generate module bridges (modules that re-export other modules).",
-	"license": "LGPL-3.0",
 	"bin": {
 		"liferay-npm-bridge-generator": "bin/liferay-npm-bridge-generator.js"
 	},
+	"dependencies": {
+		"fs-extra": "^8.1.0",
+		"globby": "^10.0.1",
+		"read-json-sync": "^2.0.1",
+		"yargs": "^14.0.0"
+	},
+	"description": "A CLI utility to generate module bridges (modules that re-export other modules).",
+	"license": "LGPL-3.0",
+	"name": "liferay-npm-bridge-generator",
 	"repository": {
 		"directory": "projects/js-toolkit/packages/liferay-npm-bridge-generator",
 		"type": "git",
@@ -18,10 +23,5 @@
 		"copyfiles": "node ../../scripts/copyfiles.js",
 		"prepublish": "yarn build"
 	},
-	"dependencies": {
-		"fs-extra": "^8.1.0",
-		"globby": "^10.0.1",
-		"read-json-sync": "^2.0.1",
-		"yargs": "^14.0.0"
-	}
+	"version": "3.0.0"
 }

--- a/projects/js-toolkit/packages/liferay-npm-bundler/package.json
+++ b/projects/js-toolkit/packages/liferay-npm-bundler/package.json
@@ -1,33 +1,7 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
-	"name": "liferay-npm-bundler",
-	"version": "3.0.0-alpha.5",
-	"description": "A CLI utility to bundle NPM dependencies of a Liferay OSGi bundle.",
-	"license": "LGPL-3.0",
-	"main": "lib/index.js",
 	"bin": {
 		"liferay-npm-bundler": "bin/liferay-npm-bundler.js"
-	},
-	"repository": {
-		"directory": "projects/js-toolkit/packages/liferay-npm-bundler",
-		"type": "git",
-		"url": "https://github.com/liferay/liferay-frontend-projects.git"
-	},
-	"scripts": {
-		"build": "tsc && yarn copyfiles",
-		"ci": "cd ../.. && yarn ci",
-		"clean": "node ../../scripts/clean.js",
-		"copyfiles": "node ../../scripts/copyfiles.js",
-		"postversion": "npx liferay-js-publish",
-		"preversion": "yarn ci"
-	},
-	"devDependencies": {
-		"@types/ejs": "^3.0.1",
-		"@types/escodegen": "^0.0.6",
-		"@types/estraverse": "^0.0.6",
-		"@types/estree": "^0.0.42",
-		"@types/fs-extra": "^8.1.0",
-		"@types/webpack": "^4.41.6"
 	},
 	"dependencies": {
 		"acorn": "^6.2.1",
@@ -45,5 +19,31 @@
 		"webpack": "^4.41.6",
 		"xml-js": "^1.6.8",
 		"yargs": "^14.0.0"
-	}
+	},
+	"description": "A CLI utility to bundle NPM dependencies of a Liferay OSGi bundle.",
+	"devDependencies": {
+		"@types/ejs": "^3.0.1",
+		"@types/escodegen": "^0.0.6",
+		"@types/estraverse": "^0.0.6",
+		"@types/estree": "^0.0.42",
+		"@types/fs-extra": "^8.1.0",
+		"@types/webpack": "^4.41.6"
+	},
+	"license": "LGPL-3.0",
+	"main": "lib/index.js",
+	"name": "liferay-npm-bundler",
+	"repository": {
+		"directory": "projects/js-toolkit/packages/liferay-npm-bundler",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects.git"
+	},
+	"scripts": {
+		"build": "tsc && yarn copyfiles",
+		"ci": "cd ../.. && yarn ci",
+		"clean": "node ../../scripts/clean.js",
+		"copyfiles": "node ../../scripts/copyfiles.js",
+		"postversion": "npx liferay-js-publish",
+		"preversion": "yarn ci"
+	},
+	"version": "3.0.0-alpha.5"
 }

--- a/projects/js-toolkit/resources/devtools/find-generator/package.json
+++ b/projects/js-toolkit/resources/devtools/find-generator/package.json
@@ -1,12 +1,12 @@
 {
-	"name": "find-generator",
-	"version": "1.0.0",
-	"description": "",
 	"bin": {
 		"find-generator": "find-generator.js"
 	},
 	"dependencies": {
 		"yeoman-environment": "^2.4.0"
 	},
-	"private": true
+	"description": "",
+	"name": "find-generator",
+	"private": true,
+	"version": "1.0.0"
 }

--- a/projects/js-toolkit/resources/devtools/link-js-toolkit/package.json
+++ b/projects/js-toolkit/resources/devtools/link-js-toolkit/package.json
@@ -1,7 +1,4 @@
 {
-	"name": "link-js-toolkit",
-	"version": "1.0.0",
-	"description": "",
 	"bin": {
 		"link-js-toolkit": "link-js-toolkit.js"
 	},
@@ -10,8 +7,11 @@
 		"cross-spawn": "^6.0.5",
 		"read-json-sync": "^2.0.1"
 	},
-	"private": true,
+	"description": "",
 	"devDependencies": {
 		"yargs": "^14.0.0"
-	}
+	},
+	"name": "link-js-toolkit",
+	"private": true,
+	"version": "1.0.0"
 }

--- a/support/sortJSON.js
+++ b/support/sortJSON.js
@@ -1,4 +1,9 @@
 /**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
  * Companion tool to Prettier that sorts JSON files.
  */
 

--- a/support/sortJSON.js
+++ b/support/sortJSON.js
@@ -1,0 +1,96 @@
+/**
+ * Companion tool to Prettier that sorts JSON files.
+ */
+
+const fs = require('fs');
+
+const HELP_REGEXP = /^--?h(?:elp)?/;
+
+const STDIN = 0;
+
+const TAB_WIDTH = 4;
+
+function print(string = '') {
+	process.stdout.write(`${string}\n`);
+}
+
+/**
+ * Sort contents in-place.
+ *
+ * Obviously doesn't deal with anything crazy like circular references, but we
+ * won't have any of those because our input comes from `JSON.parse()`.
+ */
+function sort(json) {
+	if (Array.isArray(json)) {
+		json.forEach(sort);
+	} else if (Object.prototype.toString.call(json) === '[object Object]') {
+		const entries = Object.entries(json);
+
+		entries.sort(([a], [b]) => {
+			if (a < b) {
+				return -1;
+			} else if (a > b) {
+				return 1;
+			} else {
+				return 0;
+			}
+		});
+
+		entries.forEach(([key, value]) => {
+			delete json[key];
+
+			sort(value);
+		});
+
+		entries.forEach(([key, value]) => {
+			json[key] = value;
+		});
+	}
+}
+
+function usage() {
+	print(`${__filename}:`);
+	print();
+	print('Read filenames from STDIN, and writes sorted JSON in-place.');
+	print();
+	print('Example:');
+	print();
+	print('  find . \\');
+	print('    -name package.json \\');
+	print("    -path '*/js-toolkit/*' \\");
+	print("    -not -path '*/node_modules/*' \\");
+	print("    -not -path '*/__tests__/*' \\");
+	print("    -not -path '*/__fixtures/__*' \\");
+	print("    -not -path '*/qa/samples/*' | node support/sortJSON.js");
+	print();
+
+	process.exit();
+}
+
+if (process.argv.some((arg) => HELP_REGEXP.test(arg))) {
+	usage();
+}
+
+print('Reading filenames from STDIN... [Ctrl-D to exit]');
+
+const filenames = fs.readFileSync(STDIN).toString().split(/\n/).filter(Boolean);
+
+if (!filenames.length) {
+	usage();
+}
+
+filenames.forEach((filename) => {
+	const contents = JSON.parse(fs.readFileSync(filename));
+
+	sort(contents);
+
+	const stringified = JSON.stringify(contents, null, 4) + '\n';
+
+	const tabbed = stringified.replace(/^ +/gm, (match) => {
+		return '\t'.repeat(Math.floor(match.length / TAB_WIDTH));
+	});
+
+	fs.writeFileSync(filename, tabbed);
+
+	print(`Wrote ${filename}`);
+});


### PR DESCRIPTION
Done using:

    find . \
      -name package.json \
      -path '*/js-toolkit/*' \
      -not -path '*/node_modules/*' \
      -not -path '*/__tests__/*' \
      -not -path '*/__fixtures/__*' \
      -not -path '*/qa/samples/*' | node support/sortJSON.js

and the included helper script.

We may want to eventually integrate something like the `sortJSON.js` script into our formatting runs, but I expect these package.json files to stay in order for at least a while now, so I don't want to prematurely overcomplicate things.

Test plan: Make this commit and visually inspect the changes.