### PR TITLE
fix(eslint-config): special case import of "."

### DIFF
--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/copy.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/copy.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-import {Project} from '.';
 import prop from 'dot-prop';
 
+import {Project} from '.';
 import {BundlerCopyPluginState} from '../api/plugins';
 import PkgDesc from '../pkg-desc';
 import {BundlerPluginDescriptor} from './types';

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/jar.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/jar.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-import {Project} from '.';
 import prop from 'dot-prop';
 import readJsonSync from 'read-json-sync';
 
+import {Project} from '.';
 import FilePath from '../file-path';
 import {getFeaturesFilePath} from './util';
 

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/localization.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/localization.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-import {Project} from '.';
 import fs from 'fs';
 import path from 'path';
 import properties from 'properties';
 
+import {Project} from '.';
 import FilePath from '../file-path';
 import {getFeaturesFilePath} from './util';
 

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/misc.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/misc.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-import {Project} from '.';
 import prop from 'dot-prop';
 import fs from 'fs';
 import path from 'path';
 
+import {Project} from '.';
 import FilePath from '../file-path';
 
 /**

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/rules.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/rules.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-import {Project} from '.';
 import clone from 'clone';
 import path from 'path';
 
+import {Project} from '.';
 import {BundlerLoaderEntryPoint, BundlerLoaderMetadata} from '../api/loaders';
 import FilePath from '../file-path';
 import {splitModuleName} from '../modules';

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/transform.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/transform.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-import {Project} from '.';
 import prop from 'dot-prop';
 import path from 'path';
 
+import {Project} from '.';
 import {BundlerTransformPluginState} from '../api/plugins';
 import {splitModuleName} from '../modules';
 import PkgDesc from '../pkg-desc';

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/util.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/util.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-import {Project} from '.';
 import prop from 'dot-prop';
 import fs from 'fs';
 
+import {Project} from '.';
 import FilePath from '../file-path';
 import {splitModuleName} from '../modules';
 import PkgDesc from '../pkg-desc';

--- a/projects/eslint-config/plugins/liferay/lib/common/imports.js
+++ b/projects/eslint-config/plugins/liferay/lib/common/imports.js
@@ -152,7 +152,7 @@ function isLocal(source) {
  * Returns true if `source` is a relative path (ie. starts with "./" or "../").
  */
 function isRelative(source) {
-	return /^\.\.?\//.test(source);
+	return source === '.' || /^\.\.?\//.test(source);
 }
 
 /**

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/sort-imports.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/sort-imports.js
@@ -276,6 +276,27 @@ ruleTester.run('sort-imports', rule, {
 				import dom from 'metal-dom';
 			`,
 		},
+		{
+			// Regression test: "." alone was not considered to be relative.
+			// https://github.com/liferay/liferay-frontend-projects/issues/129
+
+			code: `
+				import {Project} from '.';
+				import prop from 'dot-prop';
+			`,
+			errors: [
+				{
+					message:
+						'imports must be sorted by module name ' +
+						'(expected: "dot-prop" << ".")',
+					type: 'ImportDeclaration',
+				},
+			],
+			output: `
+				import prop from 'dot-prop';
+				import {Project} from '.';
+			`,
+		},
 	],
 
 	valid: [

--- a/projects/js-toolkit/packages/liferay-npm-bundler/src/report/html.ts
+++ b/projects/js-toolkit/packages/liferay-npm-bundler/src/report/html.ts
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-import {Report} from '.';
 import {LogLevel} from 'liferay-js-toolkit-core';
 import pretty from 'pretty-time';
+
+import {Report} from '.';
 
 export function htmlDump(report: Report): string {
 	const {


### PR DESCRIPTION
I don't like these "." imports as there are not very idiomatic; I guess they're not common because they are subtle and potentially confusing. If you are in a folder and "./index" is the manifest of everything exportable in that folder, then that would normally include the file doing the import, which is circular. So the cognitive load of thinking that through is higher than it need be.

Anyway, even though I don't like them, it doesn't mean I shouldn't fix the bug. So here goes.

Closes: https://github.com/liferay/liferay-frontend-projects/issues/129