### PR TITLE
chore(js-toolkit): configure release messages consistently

### DIFF
--- a/maintenance/projects/js-toolkit/lerna.json
+++ b/maintenance/projects/js-toolkit/lerna.json
@@ -3,6 +3,9 @@
 	"command": {
 		"publish": {
 			"exact": true
+		},
+		"version": {
+			"message": "chore: prepare liferay-js-toolkit/%s release"
 		}
 	},
 	"npmClient": "yarn",

--- a/projects/js-toolkit/packages/generator-liferay-js/.yarnrc
+++ b/projects/js-toolkit/packages/generator-liferay-js/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "generator-liferay-js/v"
+version-git-message "chore: prepare generator-liferay-js/v%s release"

--- a/projects/js-toolkit/packages/liferay-js-toolkit-core/.yarnrc
+++ b/projects/js-toolkit/packages/liferay-js-toolkit-core/.yarnrc
@@ -1,3 +1,3 @@
 # Make `yarn version` produce the right commit message and tag for this package.
 version-tag-prefix "liferay-js-toolkit-core/v"
-version-git-message "chore: prepare liferay-js-toolkit-core/v%s"
+version-git-message "chore: prepare liferay-js-toolkit-core/v%s release"

--- a/projects/js-toolkit/packages/liferay-js-toolkit-scripts/.yarnrc
+++ b/projects/js-toolkit/packages/liferay-js-toolkit-scripts/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "liferay-js-toolkit-scripts/v"
+version-git-message "chore: prepare liferay-js-toolkit-scripts/v%s release"

--- a/projects/js-toolkit/packages/liferay-npm-bridge-generator/.yarnrc
+++ b/projects/js-toolkit/packages/liferay-npm-bridge-generator/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "liferay-npm-bridge-generator/v"
+version-git-message "chore: prepare liferay-npm-bridge-generator/v%s release"

--- a/projects/js-toolkit/packages/liferay-npm-bundler/.yarnrc
+++ b/projects/js-toolkit/packages/liferay-npm-bundler/.yarnrc
@@ -1,3 +1,3 @@
 # Make `yarn version` produce the right commit message and tag for this package.
 version-tag-prefix "liferay-npm-bundler/v"
-version-git-message "chore: prepare liferay-npm-bundler/v%s"
+version-git-message "chore: prepare liferay-npm-bundler/v%s release"


### PR DESCRIPTION
- Adjust existing .yarnrc files so that the release commit message matches the format used by other packages in this monorepo.
- Add .yarnrc files for packages that don't have them yet.
- Configure Lerna (still used in v2 of the js-toolkit) to produce commit messages that match the format produced by yarn; previously they produced commit messages consisting just of the bare version number (eg. see b493e109afa2c706ce5fcea79b81a54ac72578d9), which isn't appropriate for a multi-project monorepo.