### PR TITLE
docs(js-toolkit): update links prior to release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # liferay-frontend-projects monorepo
 
-![](https://github.com/liferay/liferay-frontend-projects/workflows/ci/badge.svg)
+![CI status](https://github.com/liferay/liferay-frontend-projects/workflows/ci/badge.svg)
 
 Welcome to the monorepo of the Liferay Frontend Infrastructure team.
 

--- a/maintenance/projects/js-toolkit/CONTRIBUTING.md
+++ b/maintenance/projects/js-toolkit/CONTRIBUTING.md
@@ -12,9 +12,9 @@ $ yarn ⏎
 
 Which will install all needed dependencies.
 
-## Repo organization
+## Project organization
 
-The repo is a yarn workspace with several projects contained in the `packages` folder.
+The project is a Yarn workspace with several projects contained in the `packages` folder.
 
 Other auxiliary folders are:
 
@@ -36,15 +36,7 @@ This runs locally the same tests we run in our CI servers so that, in case anyth
 
 We track all discussions and decisions in GitHub issues and PRs. We also try to explain final decisions in git commits so that they are easily available without any need to visit GitHub.
 
-To maintain cross referenceability all commits must follow the [semantic commit convention](http://karma-runner.github.io/0.10/dev/git-commit-msg.html) and use `#nnn` as the first word in the subject (where `nnn` is the number of the issue associated to the commit).
-
-For example:
-
-```
-chore: #517 Fix yarn dependencies
-```
-
-No commit may be pushed without a reference to an issue unless it is self-evident and of type `chore`.
+All commits must follow [our commit message guidelines](https://github.com/liferay/liferay-frontend-guidelines/blob/master/general/commit_messages.md).
 
 ## Tests
 
@@ -76,7 +68,7 @@ By default, the resulting JAR file will be placed in `/opt/bundles/deploy` so ma
 
 This command will download all the dependencies needed by the QA projects contained in the `qa/samples/packages` folder, and will point all JS Toolkit packages to the local project (as opposed to downloading them from npmjs.com). This is necessary since we want to use our local copy of the JS Toolkit and since we have not yet released any 3.x version, so it's impossible to download it from npmjs.com.
 
-Note that the `link-js-toolkit` will move all JS Toolkit dependencies in the QA projects to a `link-js-toolkit` section in the `package.json`. This is to prevent yarn from trying to download these packages from npmjs.com.
+Note that the `link-js-toolkit` will move all JS Toolkit dependencies in the QA projects to a `link-js-toolkit` section in the `package.json`. This is to prevent Yarn from trying to download these packages from npmjs.com.
 
 ## Releasing new versions
 
@@ -123,11 +115,9 @@ Release a new version
 $ yarn release ⏎
 ```
 
-Copy the relevant section from the changelog to the corresponding entry on the [releases page](https://github.com/liferay/liferay-js-toolkit/releases).
+Copy the relevant section from the changelog to the corresponding entry on the [releases page](https://github.com/liferay/liferay-frontend-projects/releases).
 
 After the release, you may want to confirm that the packages are correctly listed in the NPM registry.
-
-Finally, close [the corresponding milestone](https://github.com/liferay/liferay-js-toolkit/milestones) in GitHub.
 
 ## Releasing canary versions
 

--- a/maintenance/projects/js-toolkit/README.md
+++ b/maintenance/projects/js-toolkit/README.md
@@ -1,14 +1,12 @@
 # liferay-js-toolkit
 
-[![Build Status](https://travis-ci.org/liferay/liferay-js-toolkit.svg?branch=master)](https://travis-ci.org/liferay/liferay-js-toolkit)
+![CI status](https://github.com/liferay/liferay-frontend-projects/workflows/ci/badge.svg)
 
 ## Setup
 
-1. Install NodeJS >= [v6.11.0](http://nodejs.org/dist/v6.11.0/), if you don't
-   have it yet.
+1. Install NodeJS >= [v10.15.1](http://nodejs.org/dist/v10.15.1/), if you don't have it yet.
 
-2. Run the bootstrap script to install local dependencies and link packages
-   together:
+2. Run the bootstrap script to install local dependencies and link packages together:
 
 ```sh
 yarn install
@@ -28,13 +26,8 @@ yarn test
 
 ## Useful resources
 
-You can file any bug related to this project in the
-[issues page](https://github.com/liferay/liferay-js-toolkit/issues).
+You can file any bug related to this project in the [issues page](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Ajs-toolkit+label%3A2.x).
 
-You can also get information about released versions and their changes in the
-[closed milestones page](https://github.com/liferay/liferay-js-toolkit/milestones?state=closed).
-
-And if you want to know what's planned for the next versions, just visit the
-[open milestones page](https://github.com/liferay/liferay-js-toolkit/milestones?state=open).
+You can also get information about released versions and their changes in the [changelog](./CHANGELOG.md).
 
 To finish with, you can find the most up-to-date documentation in [the project's wiki](https://github.com/liferay/liferay-js-toolkit/wiki).


### PR DESCRIPTION
As I want to cut a release (just a patch release, to prove that releasing from the monorepo works, and to update the README and metadata on the package pages on the npm registry) I'm just sweeping through and updating links and other information that needs to be tweaked now that we're in the monorepo.

The one link I didn't update was the link to the wiki, because we haven't migrated that yet (we still need to decide whether to migrate it, or whether to move the contents into a `docs/` folder).

For consistency, snuck in one edit to the top-level README to make sure we use the same alt text on our CI badges everywhere.