### PR TITLE
chore(js-toolkit): make post-release tweaks

### DIFF
--- a/CONTRIBUTING/importing-a-project.md
+++ b/CONTRIBUTING/importing-a-project.md
@@ -201,7 +201,7 @@ Examples include:
 
 -   Create labels for the project and any subpackages and add the to [the Pull Request Labeler's](https://github.com/actions/labeler) [configuration file](../.github/labeler.yml) ([example PR](https://github.com/liferay/liferay-frontend-projects/pull/122)).
 
--   Check for `.yarnrc` files (and the `lerna.json` file, in the rare case that you're importing a project that uses Lerna) to ensure that the tag configuration is consistent with the format using in the monorepo (see [this example PR](https://github.com/liferay/liferay-frontend-projects/pull/138), which shows modifying `.yarnrc` files to make them consistent, adding missing `.yarnrc` files, and configuring Lerna to create adequate commit messages).
+-   Check for `.yarnrc` files (and the `lerna.json` file, in the rare case that you're importing a project that uses Lerna) to ensure that the tag configuration is consistent with the format using in the monorepo (see [this example PR](https://github.com/liferay/liferay-frontend-projects/pull/138) and [its follow-up](https://github.com/liferay/liferay-frontend-projects/pull/141), which show modifying `.yarnrc` files to make them consistent, adding missing `.yarnrc` files, and configuring Lerna to create adequate commit messages).
 
 -   Hoist all `devDependencies` to the top level ([example PR](https://github.com/liferay/liferay-frontend-projects/pull/135)) to reduce the chances of duplicated or conflicting versions.
 

--- a/maintenance/projects/js-toolkit/CONTRIBUTING.md
+++ b/maintenance/projects/js-toolkit/CONTRIBUTING.md
@@ -94,7 +94,7 @@ If any checks fail, fix them, submit a PR, and when it is merged, start again. O
 Update the changelog:
 
 ```sh
-$ npx @liferay/changelog-generator --version=v2.19.0 ⏎
+$ npx @liferay/changelog-generator --version=v2.19.4 ⏎
 ```
 
 Review and stage the generated changes:
@@ -106,7 +106,7 @@ $ git add -p ⏎
 Commit the CHANGELOG:
 
 ```sh
-$ git commit -m "docs: Update CHANGELOG" ⏎
+$ git commit -m "docs(js-toolkit): update CHANGELOG.md for v2.19.4 release" ⏎
 ```
 
 Release a new version

--- a/maintenance/projects/js-toolkit/lerna.json
+++ b/maintenance/projects/js-toolkit/lerna.json
@@ -9,9 +9,7 @@
 		}
 	},
 	"npmClient": "yarn",
-	"packages": [
-		"packages/*"
-	],
+	"packages": ["packages/*"],
 	"tagVersionPrefix": "liferay-js-toolkit/v",
 	"useWorkspaces": true,
 	"version": "2.19.4"

--- a/maintenance/projects/js-toolkit/lerna.json
+++ b/maintenance/projects/js-toolkit/lerna.json
@@ -5,7 +5,7 @@
 			"exact": true
 		},
 		"version": {
-			"message": "chore: prepare liferay-js-toolkit/%s release"
+			"message": "chore: prepare %s release"
 		}
 	},
 	"npmClient": "yarn",


### PR DESCRIPTION
Just some small changes to reflect what I learned while doing our first release of the v2.x series from the monorepo context.

As a bonus, you get a free set of Conventional Commits types!

- "chore" to describe the overall feeling I had when preparing this PR.
- "fix" because the Lerna config was wrong.
- "docs" because I edited docs.
- "style" because Lerna seemed to mess up the formatting during publish, so I had to run `yarn format`.