### PR TITLE
chore(npm-scripts): update npm-bundler-preset-liferay-dev to v4.6.4

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/package.json
+++ b/projects/npm-tools/packages/npm-scripts/package.json
@@ -16,7 +16,7 @@
 		"@babel/preset-typescript": "^7.10.4",
 		"@liferay/eslint-config": "21.2.1",
 		"@liferay/jest-junit-reporter": "1.2.0",
-		"@liferay/npm-bundler-preset-liferay-dev": "4.6.3",
+		"@liferay/npm-bundler-preset-liferay-dev": "4.6.4",
 		"@storybook/addon-a11y": "^5.1.9",
 		"@storybook/addon-actions": "^5.1.9",
 		"@storybook/addon-knobs": "^5.1.9",


### PR DESCRIPTION
[Release notes](https://github.com/liferay/liferay-frontend-projects/releases/tag/npm-bundler-preset-liferay-dev%2Fv4.6.4)

This is really just an integration test to make sure that we can release v2.x js-toolkit packages from the monorepo.

Updated with:

    cd projects/npm-tools/packages/npm-scripts
    yarn add @liferay/npm-bundler-preset-liferay-dev@4.6.4