### PR TITLE
chore(monorepo): add a .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,13 @@
+Carlos Lancha <carlos.lancha@liferay.com> <carloslancha@users.noreply.github.com>
+Chema Balsas <jose.balsas@liferay.com> <jbalsas@gmail.com>
+Eduardo Lundgren <eduardo.lundgren@liferay.com> <eduardo.lundgren@gmail.com>
+Greg Hurrell <greg.hurrell@liferay.com> <greg@hurrell.net>
+Iván Zaera Avellón <ivan.zaera@liferay.com> <ivan@baco.local>
+Iván Zaera Avellón <ivan.zaera@liferay.com> <izaera@gmail.com>
+Iván Zaera Avellón <ivan.zaera@liferay.com> <izaera@gmx.es>
+Iván Zaera Avellón <ivan.zaera@liferay.com> <izaera@users.noreply.github.com>
+John Co <john.co@liferay.com>
+Julien Castelain <julien.castelain@liferay.com> <julien@users.noreply.github.com>
+Robert Frampton <robert.frampton@liferay.com> <ROBERT.FRAMPTON@LIFERAY.COM>
+Saeed Sheikhi <SaeedSheikhi@outlook.com> <saeedsheikhi@Saeeds-MacBook-Pro.local>
+Saeed Sheikhi <SaeedSheikhi@outlook.com>


### PR DESCRIPTION
My OCD compels me to do this. It enables Git to dedupe authors that have created commits with multiple email addresses or name variations.

Before - 40 "unique authors":

    git shortlog -s -e | cut -f 2 | wc -l
          40

After - 27 unique authors:

    git shortlog -s -e | cut -f 2 | wc -l
          27