### PR TITLE
docs(js-tookit): update CHANGELOG files for first named scope releases

### DIFF
--- a/projects/js-toolkit/packages/generator-js/CHANGELOG.md
+++ b/projects/js-toolkit/packages/generator-js/CHANGELOG.md
@@ -1,0 +1,7 @@
+## [generator-js/v3.0.0-alpha.1](https://github.com/liferay/liferay-frontend-projects/tree/generator-js/v3.0.0-alpha.1) (2020-10-14)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-js-toolkit/v2.19.4...js-toolkit-core/v3.0.0-alpha.1)
+
+### :house: Chores
+
+-   chore(js-toolkit): move generator-liferay-js (v3.x) to @liferay/generator-js ([\#151](https://github.com/liferay/liferay-frontend-projects/pull/151))

--- a/projects/js-toolkit/packages/js-toolkit-core/CHANGELOG.md
+++ b/projects/js-toolkit/packages/js-toolkit-core/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [js-toolkit-core/v3.0.0-alpha.2](https://github.com/liferay/liferay-frontend-projects/tree/js-toolkit-core/v3.0.0-alpha.2) (2020-10-14)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-js-toolkit-core/v3.0.0-alpha.2...js-toolkit-core/v3.0.0-alpha.2)
+
+### :house: Chores
+
+-   chore(js-toolkit): move liferay-js-toolkit-core (v3.x) to @liferay/js-toolkit-core ([\#150](https://github.com/liferay/liferay-frontend-projects/pull/150))
+
 ## [liferay-js-toolkit-core/v3.0.0-alpha.2](https://github.com/liferay/liferay-js-toolkit/tree/liferay-js-toolkit-core/v3.0.0-alpha.2) (2020-09-29)
 
 [Full changelog](https://github.com/liferay/liferay-js-toolkit/compare/liferay-js-toolkit-core/v3.0.0-alpha.1...liferay-js-toolkit-core/v3.0.0-alpha.2)

--- a/projects/js-toolkit/packages/js-toolkit-scripts/CHANGELOG.md
+++ b/projects/js-toolkit/packages/js-toolkit-scripts/CHANGELOG.md
@@ -1,0 +1,5 @@
+## [js-toolkit-scripts/v3.0.0-alpha.1](https://github.com/liferay/liferay-frontend-projects/tree/js-toolkit-scripts/v3.0.0-alpha.1) (2020-10-14)
+
+### :house: Chores
+
+-   chore(js-toolkit): move liferay-js-toolkit-scripts (v3.x) to @liferay/js-toolkit-scripts ([\#152](https://github.com/liferay/liferay-frontend-projects/pull/152))

--- a/projects/js-toolkit/packages/npm-bridge-generator/CHANGELOG.md
+++ b/projects/js-toolkit/packages/npm-bridge-generator/CHANGELOG.md
@@ -1,0 +1,5 @@
+## [npm-bridge-generator/v3.0.0-alpha.1](https://github.com/liferay/liferay-frontend-projects/tree/npm-bridge-generator/v3.0.0-alpha.1) (2020-10-14)
+
+### :house: Chores
+
+-   chore(js-toolkit): move liferay-npm-bridge-generator (v3.x) to @liferay/npm-bridge-generator ([\#153](https://github.com/liferay/liferay-frontend-projects/pull/153))

--- a/projects/js-toolkit/packages/npm-bundler/CHANGELOG.md
+++ b/projects/js-toolkit/packages/npm-bundler/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [npm-bundler/v3.0.0-alpha.5](https://github.com/liferay/liferay-frontend-projects/tree/npm-bundler/v3.0.0-alpha.5) (2020-10-14)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-npm-bundler/v3.0.0-alpha.5...npm-bundler/v3.0.0-alpha.5)
+
+### :house: Chores
+
+-   chore(js-toolkit): move liferay-npm-bundler (v3.x) to @liferay/npm-bundler ([\#154](https://github.com/liferay/liferay-frontend-projects/pull/154))
+
 ## [liferay-npm-bundler/v3.0.0-alpha.5](https://github.com/liferay/liferay-js-toolkit/tree/liferay-npm-bundler/v3.0.0-alpha.5) (2020-09-30)
 
 [Full changelog](https://github.com/liferay/liferay-js-toolkit/compare/liferay-npm-bundler/v3.0.0-alpha.4...liferay-npm-bundler/v3.0.0-alpha.5)


### PR DESCRIPTION
As these first releases under the `@liferay` named scope are all a bit manual and weird, I'm batching the (basically manual) updates for all the packages into this one commit. Note that there were a couple of packages there that we never officially released, so they get CHANGELOG files for the first time. (We may not end up continuing to release those packages in the future — they may get refactored and cease to exist independently — but in the short term we want to respect the "Principle of Least Surprise" and ensure that everything under `packages` in the monorepo is both publishable and published, even if only as an ephemeral prerelease).

Other than that, these packages should all be basically identical to the non-named-scope cousins with the same version number. Only the names have changed.