### PR TITLE
chore(js-toolkit): update dependencies on js-toolkit-core

### DIFF
--- a/projects/js-toolkit/packages/generator-js/package.json
+++ b/projects/js-toolkit/packages/generator-js/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"dependencies": {
-		"@liferay/js-toolkit-core": "3.0.0-alpha.2",
+		"@liferay/js-toolkit-core": "3.0.1-pre.0",
 		"dot-prop": "^5.0.1",
 		"fs-extra": "^8.1.0",
 		"read-json-sync": "^2.0.1",

--- a/projects/js-toolkit/packages/js-toolkit-scripts/package.json
+++ b/projects/js-toolkit/packages/js-toolkit-scripts/package.json
@@ -5,7 +5,7 @@
 	},
 	"dependencies": {
 		"@babel/core": "^7.0.0",
-		"@liferay/js-toolkit-core": "3.0.0-alpha.2",
+		"@liferay/js-toolkit-core": "3.0.1-pre.0",
 		"babel-template": "^6.26.0",
 		"cpr": "^3.0.1",
 		"cross-spawn": "^7.0.0",

--- a/projects/js-toolkit/packages/npm-bundler/package.json
+++ b/projects/js-toolkit/packages/npm-bundler/package.json
@@ -4,7 +4,7 @@
 		"liferay-npm-bundler": "bin/liferay-npm-bundler.js"
 	},
 	"dependencies": {
-		"@liferay/js-toolkit-core": "3.0.0-alpha.2",
+		"@liferay/js-toolkit-core": "3.0.1-pre.0",
 		"acorn": "^6.2.1",
 		"cross-spawn": "^7.0.0",
 		"ejs": "^2.6.1",


### PR DESCRIPTION
Seeing as I just cut a release, want to keep everything up-to-date.