### PR TITLE
docs(js-toolkit): remove another stale line from the documentation

### DIFF
--- a/projects/js-toolkit/CONTRIBUTING.md
+++ b/projects/js-toolkit/CONTRIBUTING.md
@@ -24,8 +24,6 @@ Other auxiliary folders are:
 
 ## Pull requests & Github issues
 
-All pull requests should be sent to the `3.x-WIP` branch, as the `master` branch is currently for version 2.x. We will rename the `3.x-WIP` branch as `master` once we release the first production version.
-
 Before sending a PR it is wise to run:
 
 ```shell

--- a/projects/js-toolkit/CONTRIBUTING.md
+++ b/projects/js-toolkit/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 This guide only covers contributions to the bundler 3.x development while it is in its initial phase (prior to the first production release). Once it is released to the general public, they will be updated and some things may change.
 
+The source for the 2.x series of the JS toolkit can be found [under the `maintenance` directory](../../maintenance/projects/js-toolkit).
+
 ## Setup
 
 After cloning the repo, run:


### PR DESCRIPTION
Missed this one when I updated the docs in https://github.com/liferay/liferay-frontend-projects/pull/158
