### PR TITLE
fix(js-toolkit): unbreak fragments toolkit

### DIFF
--- a/projects/js-toolkit/packages/npm-bundler/src/bundle/configure.ts
+++ b/projects/js-toolkit/packages/npm-bundler/src/bundle/configure.ts
@@ -38,7 +38,9 @@ export default function configure(): webpack.Configuration {
 				generatedFile = exportDependencyModule(id, moduleName);
 			}
 
-			entry[id] = generatedFile.asPosix;
+			entry[id] = generatedFile.isAbsolute()
+				? generatedFile.asPosix
+				: generatedFile.toDotRelative().asPosix;
 
 			log.debug(`Generated entry point with id ${id} for ${moduleName}`);
 


### PR DESCRIPTION
In the fragments toolkit, webpack will get a relative path of the form:

    build/liferay-npm-bundler-workdir/generated/sample-fragment.js

(via: https://github.com/liferay/generator-liferay-fragments/pull/167)

In DXP, we get a path of the form:

    $ABSOLUTE_PATH_TO_REPO_ROOT/modules/apps/frontend-js/frontend-js-recharts/build/node/bundler/bundler/generated/recharts.js

(via: https://github.com/liferay-frontend/liferay-portal/pull/429)

Unfortunately, webpack is fussy and won't accept the first form, demanding instead the `./` prefix; ie:

    ./build/liferay-npm-bundler-workdir/generated/sample-fragment.js

This means that the fix we applied in c204ca06ac3a982a1ca353b8652f9c71 unbreaks DXP at the expense of breaking the fragments toolkit.

So here, we add a ternary to handle both cases. Note that we have to do the `isAbsolute()` check because if we call `toDotRelative()` on an absolute path, [it will throw](https://github.com/liferay/liferay-frontend-projects/blob/afb4374a987d8a0a36f6e5cad5dee9a06d1c6582/projects/js-toolkit/packages/js-toolkit-core/src/file/FilePath.ts#L123-L127).