### PR TITLE
feat(changelog-generator): add --major, --minor etc convenience switches

### DIFF
--- a/projects/npm-tools/packages/changelog-generator/src/console.js
+++ b/projects/npm-tools/packages/changelog-generator/src/console.js
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const {createInterface} = require('readline');
+
+const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
+const RESET = '\x1b[0m';
+const YELLOW = '\x1b[33m';
+
+let readline;
+
+/**
+ * Releases any previously acquired readline resources.
+ */
+function cleanup() {
+	if (readline) {
+		readline.close();
+
+		readline = undefined;
+	}
+}
+
+/**
+ * Log a line to stderr, using error formatting.
+ */
+function error(...args) {
+	log(`${RED}error: ${args.join('\n')}${RESET}`);
+}
+
+/**
+ * Log a line to stderr, using green formatting.
+ */
+function info(...args) {
+	log(`${GREEN}${args.join('\n')}${RESET}`);
+}
+
+/**
+ * Log a line to stderr.
+ */
+function log(...args) {
+	process.stderr.write(`${args.join('\n')}\n`);
+}
+
+/**
+ * Prompt the user for input.
+ */
+function prompt(question, choices) {
+	if (!readline) {
+		readline = createInterface({
+			input: process.stdin,
+			output: process.stdout,
+		});
+	}
+
+	if (choices.length) {
+		log('');
+
+		choices.forEach((choice, i) => {
+			log(`${i + 1}. ${choice}`);
+		});
+
+		log('');
+	}
+
+	return new Promise((resolve) => {
+		readline.question(`${question} `, resolve);
+	}).then((result) => {
+		if (result.match(/^\s*-?\d+\s*$/)) {
+			const number = result;
+
+			if (number > 0 && number <= choices.length) {
+				return choices[number - 1];
+			}
+			else {
+				log('');
+
+				warn(`Valid choices lie between 1 and ${choices.length}`);
+
+				return prompt(question, choices);
+			}
+		}
+		else {
+			return result.trim();
+		}
+	});
+}
+
+/**
+ * Log a line to stderr, using warning formatting.
+ */
+function warn(...args) {
+	log(`${YELLOW}warning: ${args.join('\n')}${RESET}`);
+}
+
+module.exports = {
+	cleanup,
+	error,
+	info,
+	log,
+	prompt,
+	warn,
+};

--- a/projects/npm-tools/packages/changelog-generator/src/git.js
+++ b/projects/npm-tools/packages/changelog-generator/src/git.js
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const child_process = require('child_process');
+
+const {log} = require('./console');
+
+/**
+ * Convenience wrapper for running a Git command and returning its
+ * output (via a Promise).
+ */
+function git(...args) {
+	return run('git', ...args);
+}
+
+/**
+ * Run `command` and return its stdout (via a Promise).
+ */
+function run(command, ...args) {
+	return new Promise((resolve, reject) => {
+		child_process.execFile(command, args, (error, stdout, stderr) => {
+			if (error) {
+				const invocation = `${command} ${args.join(' ')}`;
+
+				log(
+					`command: ${invocation}`,
+					`stdout: ${stdout}`,
+					`stderr: ${stderr}`
+				);
+
+				reject(new Error(`Command: "${invocation}" failed: ${error}`));
+			}
+			else {
+				resolve(stdout);
+			}
+		});
+	});
+}
+
+module.exports = git;

--- a/projects/npm-tools/packages/changelog-generator/src/index.js
+++ b/projects/npm-tools/packages/changelog-generator/src/index.js
@@ -9,6 +9,7 @@ const {promisify} = require('util');
 
 const {cleanup, error, info, log, prompt, warn} = require('./console');
 const git = require('./git');
+const printBanner = require('./printBanner');
 const readYarnrc = require('./readYarnrc');
 
 const readFileAsync = promisify(fs.readFile);
@@ -251,56 +252,6 @@ async function formatChanges(changes, remote) {
 		})
 		.filter(Boolean)
 		.join('\n\n');
-}
-
-/**
- * Prints `message` in a silly banner like this:
- *  ____________________________________
- * (_)                                  `
- *   |                                  |
- *   |   @liferay/changelog-generator   |
- *   |   ============                   |
- *   |                                  |
- *   |   Reporting for duty!            |
- *   |                                  |
- *   |__________________________________|
- *   (_)________________________________)
- *
- */
-function printBanner(message) {
-	const lines = message.split('\n').map((line) => line.trim());
-
-	const width = lines.reduce((max, line) => {
-		return Math.max(max, line.length);
-	}, 0);
-
-	const TEMPLATE = [
-		[' _____', '_', '___  '],
-		['(_)   ', ' ', '   ` '],
-		['  |   ', '*', '   | '],
-		['  |___', '_', '___| '],
-		['  (_)_', '_', '____)'],
-	];
-
-	let banner = '';
-
-	TEMPLATE.forEach(([left, middle, right]) => {
-		if (middle === '*') {
-			lines.forEach((line) => {
-				banner +=
-					left +
-					line +
-					' '.repeat(width - line.length) +
-					right +
-					'\n';
-			});
-		}
-		else {
-			banner += left + middle.repeat(width) + right + '\n';
-		}
-	});
-
-	log(banner);
 }
 
 function relative(filePath) {

--- a/projects/npm-tools/packages/changelog-generator/src/index.js
+++ b/projects/npm-tools/packages/changelog-generator/src/index.js
@@ -3,47 +3,17 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const {promisify} = require('util');
 
 const {cleanup, error, info, log, prompt, warn} = require('./console');
+const git = require('./git');
 
 const readFileAsync = promisify(fs.readFile);
 const writeFileAsync = promisify(fs.writeFile);
 
 const PLACEHOLDER_VERSION = '0.0.0-placeholder.0';
-
-/**
- * Run `command` and return its stdout (via a Promise).
- */
-function run(command, ...args) {
-	return new Promise((resolve, reject) => {
-		child_process.execFile(command, args, (err, stdout, stderr) => {
-			if (err) {
-				const invocation = `${command} ${args.join(' ')}`;
-				log(
-					`command: ${invocation}`,
-					`stdout: ${stdout}`,
-					`stderr: ${stderr}`
-				);
-				reject(new Error(`Command: "${invocation}" failed: ${err}`));
-			}
-			else {
-				resolve(stdout);
-			}
-		});
-	});
-}
-
-/**
- * Convenience wrapper for running a Git command and returning its output (via a
- * Promise).
- */
-function git(...args) {
-	return run('git', ...args);
-}
 
 /**
  * Return the date corresponding to the supplied `commitish`.

--- a/projects/npm-tools/packages/changelog-generator/src/index.js
+++ b/projects/npm-tools/packages/changelog-generator/src/index.js
@@ -255,14 +255,10 @@ async function formatChanges(changes, remote) {
 		.join('\n\n');
 }
 
-function relative(filePath) {
-	return path.relative('.', filePath);
-}
-
 function printUsage() {
 	log(
 		'',
-		`${relative(__filename)} [option...]`,
+		`${path.relative('.', __filename)} [option...]`,
 		'',
 		'Required options (at least one of):',
 		'  --interactive|-i             Guided update (proposes version, shows preview etc)',

--- a/projects/npm-tools/packages/changelog-generator/src/index.js
+++ b/projects/npm-tools/packages/changelog-generator/src/index.js
@@ -362,17 +362,16 @@ async function formatChanges(changes, remote) {
 
 /**
  * Prints `message` in a silly banner like this:
- *  ____________________
- * (_)                  `
- *   |                  |
- *   |   changelog.js   |
- *   |   ============   |
- *   |                  |
- *   |   Reporting      |
- *   |   for duty!      |
- *   |                  |
- *   |__________________|
- *   (_)_________________)
+ *  ____________________________________
+ * (_)                                  `
+ *   |                                  |
+ *   |   @liferay/changelog-generator   |
+ *   |   ============                   |
+ *   |                                  |
+ *   |   Reporting for duty!            |
+ *   |                                  |
+ *   |__________________________________|
+ *   (_)________________________________)
  *
  */
 function printBanner(message) {

--- a/projects/npm-tools/packages/changelog-generator/src/index.js
+++ b/projects/npm-tools/packages/changelog-generator/src/index.js
@@ -178,7 +178,7 @@ function linkToVersion(version, remote) {
  *
  * @see https://www.conventionalcommits.org/en/v1.0.0/
  */
-const types = {
+const TYPES = {
 	/* eslint-disable sort-keys */
 
 	// Not a Conventional Commits type; we repeat breaking changes separately to
@@ -206,7 +206,7 @@ const types = {
 /**
  * Aliases mapping common mistakes to legit Conventional Commits types.
  */
-const aliases = {
+const ALIASES = {
 	bug: 'fix',
 	doc: 'docs',
 	feature: 'feat',
@@ -217,12 +217,12 @@ const TYPE_REGEXP = /^\s*(\w+)(\([^)]+\))?(!)?:\s+.+/;
 const BREAKING_TRAILER_REGEXP = /^BREAKING[ -]CHANGE:/m;
 
 async function formatChanges(changes, remote) {
-	const sections = new Map(Object.keys(types).map((type) => [type, []]));
+	const sections = new Map(Object.keys(TYPES).map((type) => [type, []]));
 
 	changes.forEach(({description, number}) => {
 		const match = description.match(TYPE_REGEXP);
 
-		const type = aliases[match && match[1]] || (match && match[1]);
+		const type = ALIASES[match && match[1]] || (match && match[1]);
 
 		const section = sections.get(type) || sections.get('misc');
 
@@ -245,7 +245,7 @@ async function formatChanges(changes, remote) {
 	return Array.from(sections.entries())
 		.map(([type, entries]) => {
 			if (entries.length) {
-				return `### ${types[type]}\n` + '\n' + entries.join('\n');
+				return `### ${TYPES[type]}\n` + '\n' + entries.join('\n');
 			}
 		})
 		.filter(Boolean)

--- a/projects/npm-tools/packages/changelog-generator/src/index.js
+++ b/projects/npm-tools/packages/changelog-generator/src/index.js
@@ -790,41 +790,20 @@ async function getVersion(options) {
 				major++;
 				minor = 0;
 				patch = 0;
-
-				if (options.version === 'major') {
-					preid = undefined;
-					prerelease = undefined;
-				}
-				else {
-					prerelease = 0;
-				}
+				prerelease = options.version === 'major' ? undefined : 0;
 				break;
 
 			case 'minor':
 			case 'preminor':
 				minor++;
 				patch = 0;
-
-				if (options.version === 'minor') {
-					preid = undefined;
-					prerelease = undefined;
-				}
-				else {
-					prerelease = 0;
-				}
+				prerelease = options.version === 'minor' ? undefined : 0;
 				break;
 
 			case 'prepatch':
 			case 'patch':
 				patch++;
-
-				if (options.version === 'patch') {
-					preid = undefined;
-					prerelease = undefined;
-				}
-				else {
-					prerelease = 0;
-				}
+				prerelease = options.version === 'patch' ? undefined : 0;
 				break;
 
 			case 'prerelease':

--- a/projects/npm-tools/packages/changelog-generator/src/index.js
+++ b/projects/npm-tools/packages/changelog-generator/src/index.js
@@ -1113,9 +1113,6 @@ async function go(options) {
 		if (/^y(es?)?$/i.test(answer)) {
 			await git('add', '--', options.outfile);
 		}
-
-		// we appear to hang here... why?
-
 	}
 }
 

--- a/projects/npm-tools/packages/changelog-generator/src/index.js
+++ b/projects/npm-tools/packages/changelog-generator/src/index.js
@@ -618,6 +618,7 @@ async function parseArgs(args) {
 
 	args.forEach((arg) => {
 		matchOption(arg, {
+			/* eslint-disable no-return-assign */
 			'dry-run|d': (value) => (options.dryRun = value),
 			'force|f': (value) => (options.force = value),
 			'from=': (value) => (options.from = value),
@@ -628,7 +629,6 @@ async function parseArgs(args) {
 			'interactive|i': (value) => (options.interactive = value),
 			major: (value) => value && (options.version = 'major'),
 			minor: (value) => value && (options.version = 'minor'),
-			'update-tags': (value) => (options.updateTags = value),
 			'outfile=': (value) => (options.outfile = value),
 			patch: (value) => value && (options.version = 'patch'),
 			'preid=': (value) => (options.preid = value),
@@ -639,7 +639,9 @@ async function parseArgs(args) {
 			regenerate: (value) => (options.regenerate = value),
 			'remote-url=': (value) => (options.remote = value),
 			'to=': (value) => (options.to = value),
+			'update-tags': (value) => (options.updateTags = value),
 			'version=': (value) => (options.version = value),
+			/* eslint-enable no-return-assign */
 		});
 	});
 

--- a/projects/npm-tools/packages/changelog-generator/src/index.js
+++ b/projects/npm-tools/packages/changelog-generator/src/index.js
@@ -729,11 +729,10 @@ async function getVersionTagPrefix() {
 
 async function main(_node, _script, ...args) {
 	printBanner(`
-		changelog.js
-		============
+		@liferay/changelog-generator
+		============================
 
-		Reporting
-		for duty!
+		Reporting for duty!
 	`);
 
 	const options = await parseArgs(args);

--- a/projects/npm-tools/packages/changelog-generator/src/index.js
+++ b/projects/npm-tools/packages/changelog-generator/src/index.js
@@ -375,6 +375,7 @@ function printUsage() {
 		'  --version=VERSION            Version being released',
 		'',
 		'Optional options:',
+		'  --dry-run|-d                 Preview changes without writing to disk',
 		'  --force|-f                   Disable safety checks',
 		'  --from=FROM                  Starting point (default: previous tag)',
 		'  --to=TO                      Ending point( default: "HEAD")',

--- a/projects/npm-tools/packages/changelog-generator/src/index.js
+++ b/projects/npm-tools/packages/changelog-generator/src/index.js
@@ -371,16 +371,20 @@ function printUsage() {
 		'',
 		`${relative(__filename)} [option...]`,
 		'',
-		'Options:',
-		'  --force|-f                   [optional: disable safety checks]',
-		'  --from=FROM                  [default: previous tag]',
-		'  --to=TO                      [default: HEAD]',
-		'  --help|-h',
-		'  --no-update-tags             [optional: disable tag prefetching]',
-		'  --outfile=FILE               [default: ./CHANGELOG.md]',
-		'  --remote-url=REPOSITORY_URL  [default: inferred]',
-		'  --regenerate                 [optional: replace entire changelog]',
-		'  --version=VERSION            [required: version being released]'
+		'Required options (at least one of):',
+		'  --version=VERSION            Version being released',
+		'',
+		'Optional options:',
+		'  --force|-f                   Disable safety checks',
+		'  --from=FROM                  Starting point (default: previous tag)',
+		'  --to=TO                      Ending point( default: "HEAD")',
+		'  --no-update-tags             Disable tag prefetching',
+		'  --outfile=FILE               Output filename (default: "./CHANGELOG.md")',
+		'  --regenerate                 Overwrite instead of appending',
+		'  --remote-url=REPOSITORY_URL  Remote repositor (default: inferred)',
+		'',
+		'Other options:',
+		'  --help|-h                    Show this help then exit'
 	);
 }
 

--- a/projects/npm-tools/packages/changelog-generator/src/matchOption.js
+++ b/projects/npm-tools/packages/changelog-generator/src/matchOption.js
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const {error} = require('./console');
+
+/**
+ * Checks `argument` against the supplied `matchers` object, where:
+ *
+ * - The keys describe option names using regular expression syntax (eg.
+ *   `force|f` for boolean options, or `from=` for options that expect a
+ *   parameter); and:
+ * - The values are callbacks that will be notified when the argument matches
+ *   the name described by the key. For boolean options the callback will
+ *   receive `true` or `false`; other callbacks will receive the passed value.
+ *
+ * Returns `true` when the argument successfully matches and false otherwise.
+ *
+ * Notes:
+ *
+ * - Boolean options may be negated with a `--no-` prefix (eg.
+ *   `--no-update-tags`).
+ * - If the argument does not match any matcher, an error message is printed
+ *   prompting the user to use the `--help` option (which should itself be
+ *   included in the `matchers` definition).
+ */
+function matchOption(argument, matchers) {
+	for (const [name, matcher] of Object.entries(matchers)) {
+		if (name.endsWith('=')) {
+			const match = new RegExp(`^(?:-{0,2})(?:${name})(.+)`, 'i').exec(
+				argument
+			);
+
+			if (match) {
+				matcher(match[1]);
+
+				return true;
+			}
+		}
+		else {
+			const match = new RegExp(`^(?:-{0,2})(no-)?(?:${name})$`, 'i').exec(
+				argument
+			);
+
+			if (match) {
+				matcher(!match[1]);
+
+				return true;
+			}
+		}
+	}
+
+	error(
+		`Unrecognized argument ${argument}; see --help for available options`
+	);
+
+	return false;
+}
+
+module.exports = matchOption;

--- a/projects/npm-tools/packages/changelog-generator/src/printBanner.js
+++ b/projects/npm-tools/packages/changelog-generator/src/printBanner.js
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const {log} = require('./console');
+
+/**
+ * Prints `message` in a silly banner like this:
+ *  ____________________________________
+ * (_)                                  `
+ *   |                                  |
+ *   |   @liferay/changelog-generator   |
+ *   |   ============                   |
+ *   |                                  |
+ *   |   Reporting for duty!            |
+ *   |                                  |
+ *   |__________________________________|
+ *   (_)________________________________)
+ *
+ */
+function printBanner(message) {
+	const lines = message.split('\n').map((line) => line.trim());
+
+	const width = lines.reduce((max, line) => {
+		return Math.max(max, line.length);
+	}, 0);
+
+	const TEMPLATE = [
+		[' _____', '_', '___  '],
+		['(_)   ', ' ', '   ` '],
+		['  |   ', '*', '   | '],
+		['  |___', '_', '___| '],
+		['  (_)_', '_', '____)'],
+	];
+
+	let banner = '';
+
+	TEMPLATE.forEach(([left, middle, right]) => {
+		if (middle === '*') {
+			lines.forEach((line) => {
+				banner +=
+					left +
+					line +
+					' '.repeat(width - line.length) +
+					right +
+					'\n';
+			});
+		}
+		else {
+			banner += left + middle.repeat(width) + right + '\n';
+		}
+	});
+
+	log(banner);
+}
+
+module.exports = printBanner;

--- a/projects/npm-tools/packages/changelog-generator/src/readYarnrc.js
+++ b/projects/npm-tools/packages/changelog-generator/src/readYarnrc.js
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const fs = require('fs');
+const path = require('path');
+const {promisify} = require('util');
+
+const git = require('./git');
+
+const readFileAsync = promisify(fs.readFile);
+
+const COMMENT_REGEXP = /^\s*#/;
+
+/**
+ * Reads any .yarnrc files between the repo root and in the current working
+ * directory, and returns a map representing their contents.
+ *
+ * Comments are ignored.
+ *
+ * Because local settings should override ones higher up in the hierarchy,
+ * duplicate settings are resolved by keeping only the last-seen instance of any
+ * given setting.
+ */
+async function readYarnrc() {
+	try {
+		fs.accessSync('package.json', fs.constants.R_OK);
+	}
+	catch (_error) {
+		throw new Error(
+			'Expected to run from a directory with a "package.json"'
+		);
+	}
+
+	const settings = new Map();
+
+	let candidate = process.cwd();
+
+	const root = (await git('rev-parse', '--show-toplevel')).trim();
+
+	// Will visit from most general to most local.
+
+	while (true) {
+		try {
+			const contents = await readFileAsync(
+				path.join(candidate, '.yarnrc'),
+				'utf8'
+			);
+
+			contents.split(/\r\n|\r|\n/).forEach((line) => {
+				if (COMMENT_REGEXP.test(line)) {
+					return;
+				}
+				else {
+					const match = line.match(/^\s*(\S+)\s+(.+)\s*$/);
+
+					if (match) {
+						settings.set(match[1], match[2]);
+					}
+				}
+			});
+		}
+		catch (_error) {
+
+			// No readable .yarnrc.
+
+		}
+
+		if (candidate === root) {
+			break;
+		}
+
+		const components = candidate.split(path.sep);
+
+		components.pop();
+
+		candidate = components.join(path.sep);
+	}
+
+	return settings;
+}
+
+module.exports = readYarnrc;


### PR DESCRIPTION
Still a draft because I want to refactor this to clean it up.

But in short, what this gives us is a set of new options:

- `--major`
- `--minor`
- `--patch`
- `--premajor`
- `--preminor`
- `--prepatch`
- `--prerelease`
- `--preid`

That match the options and behavior of the corresponding `yarn` ones.

These can be used to make the release process for most packages look like this:

    npx @liferay/changelog-generator --dry-run  # preview changes, decide on release type
    npx @liferay/changelog-generator --patch    # actually generate changes
    git add -p                                  # stage changes
    yarn version --patch                        # do release

And then on top of that, I added another switch:

- `--interactive`/`-i`

That turns the release process into this:

    npx @liferay/changelog-generator --interactive
    yarn version --patch

ie. it basically does this:

1. Run like `--dry-run`, and show a preview of what _would_ be changed without actually writing to disk; based on this, the user can decide on a release type (major, minor etc).
2. Prompt user for a version number (can be "major" etc or an explicit number).
3. Actually write out changes with the version number in effect.
4. Show `git diff` output and offer to `git add`.

Now, as I said above, there is a bit of refactoring to do before I'll be happy with this. The `index.js` is now getting cluttered enough that some of the peripheral bits could be swept under the carpet somewhere else (ie. into other files, never to be looked at again), and the whole "state-machine" aspect of `--interactive` could use some clean up. Once I've done that I'll take this out of draft.
