### PR TITLE
chore(amd-loader): prepare to release under @liferay named scope

### DIFF
--- a/maintenance/projects/js-toolkit/docs/How-to-create-mixed-Java-JavaScript-projects.md
+++ b/maintenance/projects/js-toolkit/docs/How-to-create-mixed-Java-JavaScript-projects.md
@@ -21,7 +21,7 @@ When you are ready to deploy your portlet, edit your `package.json` file and con
 
 The `build` script will be automatically run when you deploy your portlet to Liferay running `gradlew deploy`.
 
-After everything is transpiled (if necessary) to Ecmascript 5+ and CommonJS you must run the [liferay-npm-bundler](../packages/liferay-npm-bundler) tool to pack all JavaScript code (including npm dependencies) and transform it to AMD so that [Liferay AMD Loader](https://github.com/liferay/liferay-amd-loader) may grab it from the server to use it in the browser.
+After everything is transpiled (if necessary) to Ecmascript 5+ and CommonJS you must run the [liferay-npm-bundler](../packages/liferay-npm-bundler) tool to pack all JavaScript code (including npm dependencies) and transform it to AMD so that [Liferay AMD Loader](https://www.npmjs.com/package/@liferay/amd-loader) may grab it from the server to use it in the browser.
 
 ```
 👀 In essence, `liferay-npm-bundler` is a bundler (like webpack or Browserify)

--- a/maintenance/projects/js-toolkit/docs/How-to-deploy-npm-packages-to-Liferay.md
+++ b/maintenance/projects/js-toolkit/docs/How-to-deploy-npm-packages-to-Liferay.md
@@ -1,4 +1,4 @@
-[Liferay](https://github.com/liferay/liferay-portal) comes with a builtin support for npm packages. The main goal of this support is to be able to use npm modules from inside portlets with the help of the [Liferay AMD Loader](https://github.com/liferay/liferay-amd-loader). This includes a standard npm based development workflow and a specific deployment-runtime workflow that allows sharing npm packages from different portlets and honors the semantic versioned dependencies found in `package.json` files.
+[Liferay](https://github.com/liferay/liferay-portal) comes with a builtin support for npm packages. The main goal of this support is to be able to use npm modules from inside portlets with the help of the [Liferay AMD Loader](https://www.npmjs.com/package/@liferay/amd-loader). This includes a standard npm based development workflow and a specific deployment-runtime workflow that allows sharing npm packages from different portlets and honors the semantic versioned dependencies found in `package.json` files.
 
 OSGi bundles containing npm packages must have a specific structure, described in the following section.
 
@@ -56,7 +56,7 @@ Regarding the inline package, it can be present or absent too, though only one i
 
 ## AMDization of JavaScript modules
 
-Given that [Liferay AMD Loader](https://github.com/liferay/liferay-amd-loader) follows the [AMD specification](https://github.com/amdjs/amdjs-api/blob/master/AMD.md), all modules inside an npm OSGi bundle must be in AMD format but usually modules inside npm packages are in [CommonJS format](https://nodejs.org/api/modules.html). However, they can be easily converted to AMD by wrapping the module code inside a `define()` call.
+Given that [Liferay AMD Loader](https://www.npmjs.com/package/@liferay/amd-loader) follows the [AMD specification](https://github.com/amdjs/amdjs-api/blob/master/AMD.md), all modules inside an npm OSGi bundle must be in AMD format but usually modules inside npm packages are in [CommonJS format](https://nodejs.org/api/modules.html). However, they can be easily converted to AMD by wrapping the module code inside a `define()` call.
 
 Let's see an example with `isobject@2.1.0` package. This package has a main module called `index.js` which contains the following code:
 

--- a/maintenance/projects/js-toolkit/docs/How-to-use-liferay-npm-bundler.md
+++ b/maintenance/projects/js-toolkit/docs/How-to-use-liferay-npm-bundler.md
@@ -180,7 +180,7 @@ Checking the documentation of these plugins we find out that Babel will:
 5. Namespace module names in `define()` and `require()` calls with the project's package name.
 6. Prefix `define()` calls with `Liferay.Loader.`.
 
-Thus, after running `liferay-npm-bundler` on our project we will have a folder with all our npm dependencies extracted from the project's `node_modules` folder and modified to make them work on Liferay Portal under management of its [Liferay AMD Loader](https://github.com/liferay/liferay-amd-loader).
+Thus, after running `liferay-npm-bundler` on our project we will have a folder with all our npm dependencies extracted from the project's `node_modules` folder and modified to make them work on Liferay Portal under management of its [Liferay AMD Loader](https://www.npmjs.com/package/@liferay/amd-loader).
 
 A similar section for the project's root package (denoted by `/`) is also listed in the `.npmbundlerrc` which defines similar steps for the project's `package.json` and `.js` files.
 

--- a/projects/amd-loader/package.json
+++ b/projects/amd-loader/package.json
@@ -22,7 +22,7 @@
 		"Loader"
 	],
 	"license": "LGPL-3.0",
-	"name": "liferay-amd-loader",
+	"name": "@liferay/amd-loader",
 	"repository": {
 		"directory": "projects/amd-loader",
 		"type": "git",

--- a/projects/js-toolkit/packages/npm-bundler/src/liferay-npm-bundler.config.ts
+++ b/projects/js-toolkit/packages/npm-bundler/src/liferay-npm-bundler.config.ts
@@ -82,7 +82,7 @@ module.exports = {
 		},
 		'frontend-js-web': {
 			'/': '>=1.0.0',
-			'liferay-amd-loader': '>=4.1.0',
+			'@liferay/amd-loader': '>=4.3.1',
 			'lodash.escape': '>=4.0.1',
 			'lodash.groupby': '>=4.6.0',
 			'lodash.isequal': '>=4.5.0',

--- a/projects/npm-tools/packages/npm-bundler-preset-liferay-dev/config.json
+++ b/projects/npm-tools/packages/npm-bundler-preset-liferay-dev/config.json
@@ -96,7 +96,7 @@
 			},
 			"frontend-js-web": {
 				"/": ">=1.0.0",
-				"liferay-amd-loader": ">=4.1.0",
+				"@liferay/amd-loader": ">=4.3.1",
 				"lodash.escape": ">=4.0.1",
 				"lodash.groupby": ">=4.6.0",
 				"lodash.isequal": ">=4.5.0",


### PR DESCRIPTION
This is going to be one of the simpler projects to move, as far as I can tell, because:

- I already named the directory "amd-loader" instead of "liferay-amd-loader" when I imported the history.
- The autolabeler is already set up to use the "amd-loader" label for that directory.
- The .yarnrc file is already set up to assume the new name.

But note that we must touch two other projects in this commit:

- The preset needs to know about the new name and version.
- The toolkit needs to know for the same reason.
- We update some docs.

One of the nice things about the monorepo is that we can make an atomic commit like this that touches three projects in a single change. I believe all this is safe because the changes to the loader are all safe (ie. backportable), which means that in turn the changes to the toolkit and the preset are safe (because they can be backported too).