### PR TITLE
chore(amd-loader): remove an unnecessary line from the .gitignore

### DIFF
--- a/projects/amd-loader/.gitignore
+++ b/projects/amd-loader/.gitignore
@@ -1,2 +1,1 @@
 build
-node_modules


### PR DESCRIPTION
Because this one is covered by the top-level one in the root of the monorepo.