### PR TITLE
chore(amd-loader): prepare for releases via js-publish

### DIFF
--- a/projects/amd-loader/package.json
+++ b/projects/amd-loader/package.json
@@ -39,7 +39,9 @@
 		"format:check": "cd ../.. && yarn format:check",
 		"lint": "cd ../.. && yarn lint",
 		"lint:fix": "cd ../.. && yarn lint:fix",
-		"prepublishOnly": "yarn build && yarn build-demo && yarn test",
+		"postversion": "node ../npm-tools/packages/js-publish/bin/liferay-js-publish.js",
+		"prepublishOnly": "yarn build",
+		"preversion": "yarn ci",
 		"proxyPortal": "webpack-dev-server --config webpack.proxyPortal.js",
 		"test": "cd ../.. && yarn test"
 	},


### PR DESCRIPTION
Will use this to make one last non-named-scope release, and then [a named-scope one](https://github.com/liferay/liferay-frontend-projects/pull/200) after that.

