### PR TITLE
chore(js-toolkit): make release process uniform

### DIFF
--- a/projects/js-toolkit/packages/generator-js/package.json
+++ b/projects/js-toolkit/packages/generator-js/package.json
@@ -29,6 +29,7 @@
 		"build": "tsc && yarn copyfiles",
 		"clean": "node ../../scripts/clean.js",
 		"copyfiles": "node ../../scripts/copyfiles.js",
+		"postversion": "node ../../../npm-tools/packages/js-publish/bin/liferay-js-publish.js",
 		"prepublishOnly": "yarn build"
 	},
 	"version": "3.0.0-alpha.1"

--- a/projects/js-toolkit/packages/js-toolkit-core/package.json
+++ b/projects/js-toolkit/packages/js-toolkit-core/package.json
@@ -29,9 +29,8 @@
 		"ci": "cd ../.. && yarn ci",
 		"clean": "node ../../scripts/clean.js",
 		"copyfiles": "node ../../scripts/copyfiles.js",
-		"postversion": "npx liferay-js-publish",
-		"prepublishOnly": "yarn build",
-		"preversion": "yarn ci"
+		"postversion": "node ../../../npm-tools/packages/js-publish/bin/liferay-js-publish.js",
+		"prepublishOnly": "yarn build"
 	},
 	"version": "3.0.1-pre.0"
 }

--- a/projects/js-toolkit/packages/js-toolkit-scripts/package.json
+++ b/projects/js-toolkit/packages/js-toolkit-scripts/package.json
@@ -31,6 +31,7 @@
 		"build": "tsc && yarn copyfiles",
 		"clean": "node ../../scripts/clean.js",
 		"copyfiles": "node ../../scripts/copyfiles.js",
+		"postversion": "node ../../../npm-tools/packages/js-publish/bin/liferay-js-publish.js",
 		"prepublishOnly": "yarn build"
 	},
 	"version": "3.0.0-alpha.1"

--- a/projects/js-toolkit/packages/npm-bridge-generator/package.json
+++ b/projects/js-toolkit/packages/npm-bridge-generator/package.json
@@ -21,6 +21,7 @@
 		"build": "tsc && yarn copyfiles",
 		"clean": "node ../../scripts/clean.js",
 		"copyfiles": "node ../../scripts/copyfiles.js",
+		"postversion": "node ../../../npm-tools/packages/js-publish/bin/liferay-js-publish.js",
 		"prepublishOnly": "yarn build"
 	},
 	"version": "3.0.0-alpha.1"

--- a/projects/js-toolkit/packages/npm-bundler/package.json
+++ b/projects/js-toolkit/packages/npm-bundler/package.json
@@ -34,9 +34,8 @@
 		"ci": "cd ../.. && yarn ci",
 		"clean": "node ../../scripts/clean.js",
 		"copyfiles": "node ../../scripts/copyfiles.js",
-		"postversion": "npx liferay-js-publish",
-		"prepublishOnly": "yarn build",
-		"preversion": "yarn ci"
+		"postversion": "node ../../../npm-tools/packages/js-publish/bin/liferay-js-publish.js",
+		"prepublishOnly": "yarn build"
 	},
 	"version": "3.0.1-pre.1"
 }


### PR DESCRIPTION
Do all of these the same way.

Note that we are not running `yarn ci` in preversion because we'll often wind up releasing more than one package in a batch, and we expect the maintainer to see a green CI run (and probably a local one too) before doing that. I expect that later on we'll have some Lerna-like automation in place around this (but not Lerna itself, because its dependency footprint is off the charts).