### PR TITLE
docs(amd-loader): add changelog

### DIFF
--- a/projects/amd-loader/CHANGELOG.md
+++ b/projects/amd-loader/CHANGELOG.md
@@ -1,0 +1,254 @@
+## [liferay-amd-loader/v4.3.0](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v4.3.0) (2020-05-22)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v4.2.0...liferay-amd-loader/v4.3.0)
+
+### :new: Features
+
+-   feat: #230 enhance resolution errors handling ([\#231](https://github.com/liferay/liferay-frontend-projects/pull/231))
+-   feat: update linting ([\#223](https://github.com/liferay/liferay-frontend-projects/pull/223))
+
+### :house: Chores
+
+-   chore: update for compliance with current Outbound Licensing Policy ([\#227](https://github.com/liferay/liferay-frontend-projects/pull/227))
+
+## [liferay-amd-loader/v4.2.0](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v4.2.0) (2019-09-17)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v4.1.0...liferay-amd-loader/v4.2.0)
+
+## [liferay-amd-loader/v4.1.0](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v4.1.0) (2019-07-23)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v4.0.0...liferay-amd-loader/v4.1.0)
+
+## [liferay-amd-loader/v4.0.0](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v4.0.0) (2019-05-21)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v4.0.0-alpha.5...liferay-amd-loader/v4.0.0)
+
+## [liferay-amd-loader/v4.0.0-alpha.5](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v4.0.0-alpha.5) (2019-03-28)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v4.0.0-alpha.4...liferay-amd-loader/v4.0.0-alpha.5)
+
+## [liferay-amd-loader/v4.0.0-alpha.4](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v4.0.0-alpha.4) (2019-03-25)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v4.0.0-alpha.3...liferay-amd-loader/v4.0.0-alpha.4)
+
+## [liferay-amd-loader/v4.0.0-alpha.3](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v4.0.0-alpha.3) (2019-03-21)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v4.0.0-alpha.2...liferay-amd-loader/v4.0.0-alpha.3)
+
+## [liferay-amd-loader/v4.0.0-alpha.2](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v4.0.0-alpha.2) (2019-02-18)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v4.0.0-alpha.1...liferay-amd-loader/v4.0.0-alpha.2)
+
+## [liferay-amd-loader/v4.0.0-alpha.1](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v4.0.0-alpha.1) (2019-02-14)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v4.0.0-alpha.0...liferay-amd-loader/v4.0.0-alpha.1)
+
+## [liferay-amd-loader/v4.0.0-alpha.0](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v4.0.0-alpha.0) (2019-02-01)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v3.1.2...liferay-amd-loader/v4.0.0-alpha.0)
+
+## [liferay-amd-loader/v3.1.2](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v3.1.2) (2018-08-17)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v3.1.1...liferay-amd-loader/v3.1.2)
+
+## [liferay-amd-loader/v3.1.1](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v3.1.1) (2018-02-21)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v3.1.0...liferay-amd-loader/v3.1.1)
+
+## [liferay-amd-loader/v3.1.0](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v3.1.0) (2018-02-20)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v3.0.1...liferay-amd-loader/v3.1.0)
+
+## [liferay-amd-loader/v3.0.1](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v3.0.1) (2018-02-19)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v3.0.0...liferay-amd-loader/v3.0.1)
+
+## [liferay-amd-loader/v3.0.0](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v3.0.0) (2018-02-13)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v2.3.0...liferay-amd-loader/v3.0.0)
+
+## [liferay-amd-loader/v2.3.0](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v2.3.0) (2017-12-19)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v2.2.0...liferay-amd-loader/v2.3.0)
+
+## [liferay-amd-loader/v2.2.0](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v2.2.0) (2017-07-20)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v2.1.0...liferay-amd-loader/v2.2.0)
+
+## [liferay-amd-loader/v2.1.0](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v2.1.0) (2017-06-29)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v2.0.0...liferay-amd-loader/v2.1.0)
+
+## [liferay-amd-loader/v2.0.0](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v2.0.0) (2017-05-11)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.6.0...liferay-amd-loader/v2.0.0)
+
+## [liferay-amd-loader/v1.6.0](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.6.0) (2017-04-03)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.5.9...liferay-amd-loader/v1.6.0)
+
+## [liferay-amd-loader/v1.5.9](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.5.9) (2017-03-09)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.5.8...liferay-amd-loader/v1.5.9)
+
+## [liferay-amd-loader/v1.5.8](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.5.8) (2017-02-21)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.5.7...liferay-amd-loader/v1.5.8)
+
+## [liferay-amd-loader/v1.5.7](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.5.7) (2016-11-26)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.5.6...liferay-amd-loader/v1.5.7)
+
+## [liferay-amd-loader/v1.5.6](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.5.6) (2016-10-26)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.5.5...liferay-amd-loader/v1.5.6)
+
+## [liferay-amd-loader/v1.5.5](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.5.5) (2016-10-06)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.5.4...liferay-amd-loader/v1.5.5)
+
+## [liferay-amd-loader/v1.5.4](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.5.4) (2016-09-21)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.5.3...liferay-amd-loader/v1.5.4)
+
+## [liferay-amd-loader/v1.5.3](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.5.3) (2016-08-24)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.5.2...liferay-amd-loader/v1.5.3)
+
+## [liferay-amd-loader/v1.5.2](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.5.2) (2016-05-30)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.5.1...liferay-amd-loader/v1.5.2)
+
+## [liferay-amd-loader/v1.5.1](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.5.1) (2016-05-20)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.5.0...liferay-amd-loader/v1.5.1)
+
+## [liferay-amd-loader/v1.5.0](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.5.0) (2016-04-29)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.4.4...liferay-amd-loader/v1.5.0)
+
+## [liferay-amd-loader/v1.4.4](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.4.4) (2016-04-14)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.4.3...liferay-amd-loader/v1.4.4)
+
+## [liferay-amd-loader/v1.4.3](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.4.3) (2016-02-11)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.4.2...liferay-amd-loader/v1.4.3)
+
+## [liferay-amd-loader/v1.4.2](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.4.2) (2016-02-05)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.4.1...liferay-amd-loader/v1.4.2)
+
+## [liferay-amd-loader/v1.4.1](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.4.1) (2016-02-01)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.4.0...liferay-amd-loader/v1.4.1)
+
+## [liferay-amd-loader/v1.4.0](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.4.0) (2016-01-23)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.3.9...liferay-amd-loader/v1.4.0)
+
+## [liferay-amd-loader/v1.3.9](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.3.9) (2015-12-20)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.3.7...liferay-amd-loader/v1.3.9)
+
+## [liferay-amd-loader/v1.3.7](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.3.7) (2015-12-20)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.3.6...liferay-amd-loader/v1.3.7)
+
+## [liferay-amd-loader/v1.3.6](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.3.6) (2015-12-09)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.3.5...liferay-amd-loader/v1.3.6)
+
+## [liferay-amd-loader/v1.3.5](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.3.5) (2015-08-04)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.3.4...liferay-amd-loader/v1.3.5)
+
+## [liferay-amd-loader/v1.3.4](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.3.4) (2015-07-31)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.3.3...liferay-amd-loader/v1.3.4)
+
+## [liferay-amd-loader/v1.3.3](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.3.3) (2015-07-30)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.3.2...liferay-amd-loader/v1.3.3)
+
+## [liferay-amd-loader/v1.3.2](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.3.2) (2015-07-29)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.3.1...liferay-amd-loader/v1.3.2)
+
+## [liferay-amd-loader/v1.3.1](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.3.1) (2015-07-15)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.3.0...liferay-amd-loader/v1.3.1)
+
+## [liferay-amd-loader/v1.3.0](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.3.0) (2015-07-12)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.2.3...liferay-amd-loader/v1.3.0)
+
+## [liferay-amd-loader/v1.2.3](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.2.3) (2015-07-11)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.2.2...liferay-amd-loader/v1.2.3)
+
+## [liferay-amd-loader/v1.2.2](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.2.2) (2015-07-10)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.2.1...liferay-amd-loader/v1.2.2)
+
+## [liferay-amd-loader/v1.2.1](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.2.1) (2015-07-10)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.2.0...liferay-amd-loader/v1.2.1)
+
+## [liferay-amd-loader/v1.2.0](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.2.0) (2015-07-09)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.1.9...liferay-amd-loader/v1.2.0)
+
+## [liferay-amd-loader/v1.1.9](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.1.9) (2015-07-08)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.1.8...liferay-amd-loader/v1.1.9)
+
+## [liferay-amd-loader/v1.1.8](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.1.8) (2015-06-26)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.1.6...liferay-amd-loader/v1.1.8)
+
+## [liferay-amd-loader/v1.1.6](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.1.6) (2015-06-16)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.1.5...liferay-amd-loader/v1.1.6)
+
+## [liferay-amd-loader/v1.1.5](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.1.5) (2015-04-29)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.1.4...liferay-amd-loader/v1.1.5)
+
+## [liferay-amd-loader/v1.1.4](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.1.4) (2015-04-29)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.0.9...liferay-amd-loader/v1.1.4)
+
+## [liferay-amd-loader/v1.0.9](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.0.9) (2015-03-17)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.0.8...liferay-amd-loader/v1.0.9)
+
+## [liferay-amd-loader/v1.0.8](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.0.8) (2015-02-01)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.0.7...liferay-amd-loader/v1.0.8)
+
+## [liferay-amd-loader/v1.0.7](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.0.7) (2015-02-01)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.0.6...liferay-amd-loader/v1.0.7)
+
+## [liferay-amd-loader/v1.0.6](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.0.6) (2015-01-26)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.0.5...liferay-amd-loader/v1.0.6)
+
+## [liferay-amd-loader/v1.0.5](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.0.5) (2015-01-26)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.0.4...liferay-amd-loader/v1.0.5)
+
+## [liferay-amd-loader/v1.0.4](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.0.4) (2015-01-26)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.0.3...liferay-amd-loader/v1.0.4)
+
+## [liferay-amd-loader/v1.0.3](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.0.3) (2015-01-24)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.0.2...liferay-amd-loader/v1.0.3)
+
+## [liferay-amd-loader/v1.0.2](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.0.2) (2015-01-23)
+
+[Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-amd-loader/v1.0.1...liferay-amd-loader/v1.0.2)
+
+## [liferay-amd-loader/v1.0.1](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v1.0.1) (2015-01-23)

--- a/projects/amd-loader/CHANGELOG.md
+++ b/projects/amd-loader/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 ### :new: Features
 
--   feat: #230 enhance resolution errors handling ([\#231](https://github.com/liferay/liferay-frontend-projects/pull/231))
--   feat: update linting ([\#223](https://github.com/liferay/liferay-frontend-projects/pull/223))
+-   feat: #230 enhance resolution errors handling ([\#231](https://github.com/liferay/liferay-amd-loader/pull/231))
+-   feat: update linting ([\#223](https://github.com/liferay/liferay-amd-loader/pull/223))
 
 ### :house: Chores
 
--   chore: update for compliance with current Outbound Licensing Policy ([\#227](https://github.com/liferay/liferay-frontend-projects/pull/227))
+-   chore: update for compliance with current Outbound Licensing Policy ([\#227](https://github.com/liferay/liferay-amd-loader/pull/227))
 
 ## [liferay-amd-loader/v4.2.0](https://github.com/liferay/liferay-frontend-projects/tree/liferay-amd-loader/v4.2.0) (2019-09-17)
 


### PR DESCRIPTION
This project has never had an in-repo changelog, so we generate one from scratch:

    git checkout 17a5ab58
    npx @liferay/changelog-generator --regenerate --minor
    git checkout master
    mv CHANGELOG.md projects/amd-loader
    git add projects/amd-loader/CHANGELOG.md

So, two or three oddities to note here:

- The use of `--minor` is arbirtrary; I just needed to pick a version that was above the previously released one. The changes that have been made since that last release get stripped out by hand and will be included in the next release.

- Given that the changelog generator relies on the `--first-parent` switch, I checked out 17a5ab58 because that is a commit that predates the subtree merge; it means we can look at the history from the perspective of what the project used to look like in the old repo.

- Anomalously, this project basically never used merge commits, so most of the versions don't have any info that can be extracted. Such is life; they will have it going forward.