### PR TITLE
docs(monorepo): make CONTRIBUTING.md docs more consistent

### DIFF
--- a/projects/amd-loader/CONTRIBUTING.md
+++ b/projects/amd-loader/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing guidelines
+
+## Release process
+
+To publish a new version perform the following steps; these assume a remote called `upstream` but should be modified use whatever remote name you've chosen in your local repository:
+
+```sh
+# Make sure the local "master" branch is up-to-date:
+git checkout master
+git pull --ff-only upstream master
+
+# See all checks pass locally:
+yarn ci
+
+# If any checks fail, fix them, submit a PR, and when it is merged,
+# start again. Otherwise...
+
+# Preview the changelog changes, to decide on release type (major, minor etc),
+# and stage them:
+yarn run liferay-changelog-generator --interactive
+
+# Update the version number using the same release type as decided in previous step:
+yarn version --minor # or --major, or --patch
+```
+
+Running `yarn version` has the following effects:
+
+-   The "preversion" script will run, which effectively runs `yarn ci` again.
+-   The "package.json" gets updated with the new version number.
+-   A tagged commit is created, including the changes to the changelog that you previously staged.
+-   The "postversion" script will run, which automatically does `git push` and performs a `yarn publish`, prompting for confirmation along the way.
+
+Copy the relevant section from the changelog to the corresponding entry on the [releases page](https://github.com/liferay/liferay-frontend-projects/releases).
+
+After the release, you can confirm that the package is correctly listed in the npm registry:
+
+-   https://www.npmjs.com/package/@liferay/amd-loader

--- a/projects/eslint-config/CONTRIBUTING.md
+++ b/projects/eslint-config/CONTRIBUTING.md
@@ -14,30 +14,26 @@
 
     Run [`@liferay/changelog-generator`](https://www.npmjs.com/package/@liferay/changelog-generator):
 
-        yarn run liferay-changelog-generator --version=v4.1.0
+        yarn run liferay-changelog-generator --interactive
 
-    If you're not sure what version number to supply (ie. because you don't know exactly what changes will be included), you can pass the `--dry-run` switch to get a preview printed to standard output:
+    This will show a preview of the changes, prompt you to enter a release type (eg. major, minor etc, or a specific version), and then stage the changes for inclusion in the release commit.
 
-        yarn run liferay-changelog-generator --dry-run
-
-4.  Review the changes.
-
-    Use `git diff` to confirm that the CHANGELOG.md looks correct. Feel free to edit it if you want to make improvements. Then stage the changes:
+    Feel free to edit if you want to make improvements; if you do, remember to stage the changes:
 
         git add CHANGELOG.md
 
-5.  Tag and publish the new release.
+4.  Tag and publish the new release.
 
-    Run `yarn version --minor` (or `--major`, or `--patch`, as appropriate).
+    Run `yarn version --minor` (or `--major`, or `--patch`, using the same release type that you selected in the previous step).
 
     This will update the package.json and create a tagged commit, including the updates to the CHANGELOG that you previously made.
 
         We use [@liferay/js-publish](https://github.com/liferay/liferay-frontend-projects/tree/master/projects/npm-tools/packages/js-publish) from the "postversion" script to take care of pushing to the repo, and actually publishing to the NPM registry; just follow the prompts.
 
-6.  Update the release notes.
+5.  Update the release notes.
 
     Take the new section from the top of the CHANGELOG and add it to [the release page](https://github.com/liferay/liferay-frontend-projects/releases) on GitHub.
 
-7.  Sanity check [the @liferay/eslint-config page](https://www.npmjs.com/package/@liferay/eslint-config) on npmjs.com
+6.  Sanity check [the @liferay/eslint-config page](https://www.npmjs.com/package/@liferay/eslint-config) on npmjs.com
 
     Specifically, you should see the version you just released under the "Versions" tab on that page.

--- a/projects/js-toolkit/CONTRIBUTING.md
+++ b/projects/js-toolkit/CONTRIBUTING.md
@@ -36,15 +36,7 @@ This runs locally the same tests we run in our CI servers so that, in case anyth
 
 We track all discussions and decisions in GitHub issues and try to explain final decisions in git commits so that they are easily available without any need to visit GitHub.
 
-To maintain cross referenceability all commits must follow the [semantic commit convention](http://karma-runner.github.io/0.10/dev/git-commit-msg.html) and use `#nnn` as the first word in the subject (where `nnn` is the number of the issue associated to the commit).
-
-For example:
-
-```
-chore: #517 Fix yarn dependencies
-```
-
-No commit may be pushed without a reference to an issue unless it is self-evident and of type `chore`.
+All commits must follow [our commit message guidelines](https://github.com/liferay/liferay-frontend-guidelines/blob/master/general/commit_messages.md).
 
 ## Tests
 
@@ -121,13 +113,10 @@ yarn ci
 # Change to the directory of the package you wish to publish:
 cd packages/npm-bundler
 
-# Update the changelog:
-npx @liferay/changelog-generator --version=3.0.0
+# Preview, update, and stage the changelog:
+npx @liferay/changelog-generator --interactive
 
-# Review and stage the generated changes:
-git add -p
-
-# Update the version number:
+# Update the version number, using the same update type as decided in the previous step:
 yarn version --minor # or --major, or --patch
 ```
 

--- a/projects/npm-tools/CONTRIBUTING.md
+++ b/projects/npm-tools/CONTRIBUTING.md
@@ -9,7 +9,8 @@
 ## Normal releases
 
 > **Note:** @liferay/npm-scripts can be published independently, but if you update the preset, or the reporter, you need to update @liferay/npm-scripts as well, because it depends on the others. When doing this, it is important to publish the packages in order; with @liferay/npm-scripts always going last.
-> To publish a new version of a package:
+
+To publish a new version of a package:
 
 ```sh
 # Make sure the local "master" branch is up-to-date:
@@ -25,16 +26,11 @@ yarn ci
 # Change to the directory of the package you wish to publish:
 cd packages/npm-scripts
 
-# Preview the changelog changes, to decide on an appropriate version numbers:
-yarn run liferay-changelog-generator --dry-run
+# Preview the changelog changes, to decide on release type (major, minor etc),
+# and stage them:
+yarn run liferay-changelog-generator --interactive
 
-# Update the changelog:
-yarn run liferay-changelog-generator --version=29.0.1
-
-# Review and stage the generated changes:
-git add -p
-
-# Update the version number:
+# Update the version number using the same release type as decided in previous step:
 yarn version --minor # or --major, or --patch
 ```
 
@@ -97,8 +93,8 @@ yarn ci
 # Move into the package's directory
 cd packages/npm-scripts
 
-# Update the changelog.
-yarn run liferay-changelog-generator --version=$PACKAGE_NAME/v9.5.0-beta.1
+# Preview, update, and stage the changelog changes
+yarn run liferay-changelog-generator --interactive
 
 # Bump to the prerelease version number
 yarn version --new-version 9.5.0-beta.1


### PR DESCRIPTION
- Added one for amd-loader because it didn't have one.
- Recommend the use of the new `--interactive` switch to `@liferay/changelog-generator`.
- Tweak the js-toolkit one to reflect our monorepo-wide commit conventions.

One small thing to note: in the amd-loader document I refer to the project as `@liferay/amd-loader` because we're about to migrate it into the named scope and we may as well skate towards where the puck is going.