### PR TITLE
fix(changelog-generator): match `yarn version` behavior more closely

### DIFF
--- a/projects/npm-tools/packages/changelog-generator/bin/liferay-changelog-generator.js
+++ b/projects/npm-tools/packages/changelog-generator/bin/liferay-changelog-generator.js
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const main = require('../src');
+const {main} = require('../src');
 
 main(...process.argv).catch((err) => {
 	process.stderr.write(`${err}\n`);

--- a/projects/npm-tools/packages/changelog-generator/package.json
+++ b/projects/npm-tools/packages/changelog-generator/package.json
@@ -23,7 +23,7 @@
 		"ci": "cd ../.. && yarn ci",
 		"postversion": "node ../js-publish/bin/liferay-js-publish.js",
 		"preversion": "yarn ci",
-		"test": "echo 'No tests currently defined for @liferay/changelog-generator'"
+		"test": "cd ../.. && yarn test changelog-generator"
 	},
 	"version": "1.6.0"
 }

--- a/projects/npm-tools/packages/changelog-generator/src/index.js
+++ b/projects/npm-tools/packages/changelog-generator/src/index.js
@@ -285,7 +285,7 @@ async function getVersion(options) {
 			currentVersion.match(/^(\d+)\.(\d+)\.(\d+)(?:-(\w+)\.(\d+))?$/) ||
 			[];
 
-		if (typeof major !== 'string') {
+		if (major === undefined) {
 			throw new Error(
 				'Unable to extract version from "package.json"; ' +
 					'please pass --version explicitly'
@@ -306,25 +306,50 @@ async function getVersion(options) {
 		const prefix = await getVersionTagPrefix();
 
 		switch (options.version) {
-			case 'major':
 			case 'premajor':
 				major++;
 				minor = 0;
 				patch = 0;
-				prerelease = options.version === 'major' ? undefined : 0;
+				prerelease = 0;
 				break;
 
-			case 'minor':
+			case 'major':
+				if (
+					prerelease === undefined ||
+					minor !== '0' ||
+					patch !== '0'
+				) {
+					major++;
+				}
+				minor = 0;
+				patch = 0;
+				prerelease = undefined;
+				break;
+
 			case 'preminor':
 				minor++;
 				patch = 0;
-				prerelease = options.version === 'minor' ? undefined : 0;
+				prerelease = 0;
+				break;
+
+			case 'minor':
+				if (prerelease === undefined || patch !== '0') {
+					minor++;
+				}
+				patch = 0;
+				prerelease = undefined;
 				break;
 
 			case 'prepatch':
-			case 'patch':
 				patch++;
-				prerelease = options.version === 'patch' ? undefined : 0;
+				prerelease = 0;
+				break;
+
+			case 'patch':
+				if (prerelease === undefined) {
+					patch++;
+				}
+				prerelease = undefined;
 				break;
 
 			case 'prerelease':
@@ -861,4 +886,7 @@ async function write(options, preview, contents) {
 	}
 }
 
-module.exports = main;
+module.exports = {
+	getVersion,
+	main,
+};

--- a/projects/npm-tools/packages/changelog-generator/src/readYarnrc.js
+++ b/projects/npm-tools/packages/changelog-generator/src/readYarnrc.js
@@ -67,15 +67,13 @@ async function readYarnrc() {
 
 		}
 
-		if (candidate === root) {
+		const index = candidate.lastIndexOf(path.sep);
+
+		if (candidate === root || index === -1) {
 			break;
 		}
 
-		const components = candidate.split(path.sep);
-
-		components.pop();
-
-		candidate = components.join(path.sep);
+		candidate = candidate.slice(0, index);
 	}
 
 	return settings;

--- a/projects/npm-tools/packages/changelog-generator/test/index.js
+++ b/projects/npm-tools/packages/changelog-generator/test/index.js
@@ -35,7 +35,7 @@ describe('getVersion()', () => {
 
 		process.chdir(project);
 
-		child_process.spawnSync('git', ['init']);
+		child_process.spawnSync('git', ['init'], {shell: true});
 
 		setPrefix();
 	});

--- a/projects/npm-tools/packages/changelog-generator/test/index.js
+++ b/projects/npm-tools/packages/changelog-generator/test/index.js
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const child_process = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {getVersion} = require('../src');
+
+describe('getVersion()', () => {
+	let cwd;
+	let project;
+
+	function setPrefix(prefix = 'v') {
+		fs.writeFileSync(
+			path.join(project, '.yarnrc'),
+			`version-tag-prefix "${prefix}"\n`
+		);
+	}
+
+	function setVersion(version = '1.2.3') {
+		fs.writeFileSync(
+			path.join(project, 'package.json'),
+			JSON.stringify({version})
+		);
+	}
+
+	beforeEach(() => {
+		cwd = process.cwd();
+
+		project = fs.mkdtempSync(path.join(os.tmpdir(), 'project-'));
+
+		process.chdir(project);
+
+		child_process.spawnSync('git', ['init']);
+
+		setPrefix();
+	});
+
+	afterEach(() => {
+		process.chdir(cwd);
+	});
+
+	test.each`
+		from             | version         | prefix        | expected
+		${'2.0.0'}       | ${'major'}      | ${'v'}        | ${'v3.0.0'}
+		${'2.1.0'}       | ${'major'}      | ${'v'}        | ${'v3.0.0'}
+		${'2.1.4'}       | ${'major'}      | ${'v'}        | ${'v3.0.0'}
+		${'2.0.0-pre.0'} | ${'major'}      | ${'v'}        | ${'v2.0.0'}
+		${'2.1.0-pre.0'} | ${'major'}      | ${'v'}        | ${'v3.0.0'}
+		${'2.1.4-pre.0'} | ${'major'}      | ${'v'}        | ${'v3.0.0'}
+		${'1.2.3'}       | ${'major'}      | ${'sample/v'} | ${'sample/v2.0.0'}
+		${'2.0.0'}       | ${'minor'}      | ${'v'}        | ${'v2.1.0'}
+		${'2.1.0'}       | ${'minor'}      | ${'v'}        | ${'v2.2.0'}
+		${'2.1.4'}       | ${'minor'}      | ${'v'}        | ${'v2.2.0'}
+		${'2.0.0-pre.0'} | ${'minor'}      | ${'v'}        | ${'v2.0.0'}
+		${'2.1.0-pre.0'} | ${'minor'}      | ${'v'}        | ${'v2.1.0'}
+		${'2.1.4-pre.0'} | ${'minor'}      | ${'v'}        | ${'v2.2.0'}
+		${'1.2.3'}       | ${'minor'}      | ${'sample/v'} | ${'sample/v1.3.0'}
+		${'2.0.0'}       | ${'patch'}      | ${'v'}        | ${'v2.0.1'}
+		${'2.1.0'}       | ${'patch'}      | ${'v'}        | ${'v2.1.1'}
+		${'2.1.4'}       | ${'patch'}      | ${'v'}        | ${'v2.1.5'}
+		${'2.0.0-pre.0'} | ${'patch'}      | ${'v'}        | ${'v2.0.0'}
+		${'2.1.0-pre.0'} | ${'patch'}      | ${'v'}        | ${'v2.1.0'}
+		${'2.1.4-pre.0'} | ${'patch'}      | ${'v'}        | ${'v2.1.4'}
+		${'1.2.3'}       | ${'patch'}      | ${'sample/v'} | ${'sample/v1.2.4'}
+		${'2.0.0'}       | ${'premajor'}   | ${'v'}        | ${'v3.0.0-pre.0'}
+		${'2.1.0'}       | ${'premajor'}   | ${'v'}        | ${'v3.0.0-pre.0'}
+		${'2.1.4'}       | ${'premajor'}   | ${'v'}        | ${'v3.0.0-pre.0'}
+		${'2.0.0-pre.0'} | ${'premajor'}   | ${'v'}        | ${'v3.0.0-pre.0'}
+		${'2.1.0-pre.0'} | ${'premajor'}   | ${'v'}        | ${'v3.0.0-pre.0'}
+		${'2.1.4-pre.0'} | ${'premajor'}   | ${'v'}        | ${'v3.0.0-pre.0'}
+		${'1.2.3'}       | ${'premajor'}   | ${'sample/v'} | ${'sample/v2.0.0-pre.0'}
+		${'2.0.0'}       | ${'preminor'}   | ${'v'}        | ${'v2.1.0-pre.0'}
+		${'2.1.0'}       | ${'preminor'}   | ${'v'}        | ${'v2.2.0-pre.0'}
+		${'2.1.4'}       | ${'preminor'}   | ${'v'}        | ${'v2.2.0-pre.0'}
+		${'2.0.0-pre.0'} | ${'preminor'}   | ${'v'}        | ${'v2.1.0-pre.0'}
+		${'2.1.0-pre.0'} | ${'preminor'}   | ${'v'}        | ${'v2.2.0-pre.0'}
+		${'2.1.4-pre.0'} | ${'preminor'}   | ${'v'}        | ${'v2.2.0-pre.0'}
+		${'1.2.3'}       | ${'preminor'}   | ${'sample/v'} | ${'sample/v1.3.0-pre.0'}
+		${'2.0.0'}       | ${'prepatch'}   | ${'v'}        | ${'v2.0.1-pre.0'}
+		${'2.1.0'}       | ${'prepatch'}   | ${'v'}        | ${'v2.1.1-pre.0'}
+		${'2.1.4'}       | ${'prepatch'}   | ${'v'}        | ${'v2.1.5-pre.0'}
+		${'2.0.0-pre.0'} | ${'prepatch'}   | ${'v'}        | ${'v2.0.1-pre.0'}
+		${'2.1.0-pre.0'} | ${'prepatch'}   | ${'v'}        | ${'v2.1.1-pre.0'}
+		${'2.1.4-pre.0'} | ${'prepatch'}   | ${'v'}        | ${'v2.1.5-pre.0'}
+		${'1.2.3'}       | ${'prepatch'}   | ${'sample/v'} | ${'sample/v1.2.4-pre.0'}
+		${'2.0.0'}       | ${'prerelease'} | ${'v'}        | ${'v2.0.1-pre.0'}
+		${'2.1.0'}       | ${'prerelease'} | ${'v'}        | ${'v2.1.1-pre.0'}
+		${'2.1.4'}       | ${'prerelease'} | ${'v'}        | ${'v2.1.5-pre.0'}
+		${'2.0.0-pre.0'} | ${'prerelease'} | ${'v'}        | ${'v2.0.0-pre.1'}
+		${'2.1.0-pre.0'} | ${'prerelease'} | ${'v'}        | ${'v2.1.0-pre.1'}
+		${'2.1.4-pre.0'} | ${'prerelease'} | ${'v'}        | ${'v2.1.4-pre.1'}
+		${'1.2.3'}       | ${'prerelease'} | ${'sample/v'} | ${'sample/v1.2.4-pre.0'}
+		${'1.2.3'}       | ${'10.11.12'}   | ${'v'}        | ${'10.11.12'}
+		${'1.2.3'}       | ${'10.11.12'}   | ${'v'}        | ${'10.11.12'}
+		${'1.2.3'}       | ${'v10.11.12'}  | ${'v'}        | ${'v10.11.12'}
+		${'1.2.3'}       | ${'10.11.12'}   | ${'sample/v'} | ${'10.11.12'}
+		${'1.2.3'}       | ${'10.11.12'}   | ${'sample/v'} | ${'10.11.12'}
+		${'1.2.3'}       | ${'v10.11.12'}  | ${'sample/v'} | ${'v10.11.12'}
+	`(
+		'from "$from" with version "$version" and prefix "$prefix" returns "$expected"',
+		async ({expected, from, prefix, version}) => {
+			setPrefix(prefix);
+
+			setVersion(from);
+
+			expect(await getVersion({version})).toBe(expected);
+		}
+	);
+
+	test.each`
+		from            | version         | throws
+		${'100.0-cool'} | ${'major'}      | ${true}
+		${'100.0-cool'} | ${'minor'}      | ${true}
+		${'100.0-cool'} | ${'patch'}      | ${true}
+		${'100.0-cool'} | ${'premajor'}   | ${true}
+		${'100.0-cool'} | ${'preminor'}   | ${true}
+		${'100.0-cool'} | ${'prepatch'}   | ${true}
+		${'100.0-cool'} | ${'prerelease'} | ${true}
+		${'100.0-cool'} | ${'10.11.12'}   | ${false}
+	`(
+		'throws? ($throws) given version "$version" and a malformed package.json',
+		({from, throws, version}) => {
+			setVersion(from);
+
+			if (throws) {
+				return expect(() => getVersion({version})).rejects.toThrow(
+					/Unable to extract version/
+				);
+			}
+			else {
+				return expect(getVersion({version})).resolves.toBe(version);
+			}
+		}
+	);
+});

--- a/projects/npm-tools/packages/changelog-generator/test/index.js
+++ b/projects/npm-tools/packages/changelog-generator/test/index.js
@@ -113,28 +113,28 @@ describe('getVersion()', () => {
 	);
 
 	test.each`
-		from            | version         | throws
-		${'100.0-cool'} | ${'major'}      | ${true}
-		${'100.0-cool'} | ${'minor'}      | ${true}
-		${'100.0-cool'} | ${'patch'}      | ${true}
-		${'100.0-cool'} | ${'premajor'}   | ${true}
-		${'100.0-cool'} | ${'preminor'}   | ${true}
-		${'100.0-cool'} | ${'prepatch'}   | ${true}
-		${'100.0-cool'} | ${'prerelease'} | ${true}
-		${'100.0-cool'} | ${'10.11.12'}   | ${false}
+		from            | version
+		${'100.0-cool'} | ${'major'}
+		${'100.0-cool'} | ${'minor'}
+		${'100.0-cool'} | ${'patch'}
+		${'100.0-cool'} | ${'premajor'}
+		${'100.0-cool'} | ${'preminor'}
+		${'100.0-cool'} | ${'prepatch'}
+		${'100.0-cool'} | ${'prerelease'}
 	`(
-		'throws? ($throws) given version "$version" and a malformed package.json',
-		({from, throws, version}) => {
+		'throws given version "$version" and a malformed package.json',
+		({from, version}) => {
 			setVersion(from);
 
-			if (throws) {
-				return expect(() => getVersion({version})).rejects.toThrow(
-					/Unable to extract version/
-				);
-			}
-			else {
-				return expect(getVersion({version})).resolves.toBe(version);
-			}
+			return expect(() => getVersion({version})).rejects.toThrow(
+				/Unable to extract version/
+			);
 		}
 	);
+
+	it('ignores a malformed package.json when a concrete version is supplied', async () => {
+		setVersion('100.0-cool');
+
+		expect(await getVersion({version: '10.11.12'})).toBe('10.11.12');
+	});
 });


### PR DESCRIPTION
So I noticed while preparing the 3.0.1 release of the npm-bundler that we had a discrepancy between how we determine the next version number and how Yarn does it.

Namely:

- We were at 3.0.1-pre.1.
- We ran `yarn run liferay-changelog-generator -i` and selected a "patch" release; that bumped the version number to 3.0.2 in the changelog.
- We then ran `yarn version --patch` and that bumped the version number to 3.0.1 in the package.json; you can see both of those changes in 113b7addc894.
- We then fixed the mismatching number by editing the changelog in 54b66db412b8.

So, I went back and ran `yarn version` in a test project in a bunch of combinations and observed the behavior. Added some tests to show what the expected behavior is (the list of combinations is long so I won't repeat it here, but you can see it in the table in the tests).

Test plan: run the tests.