### PR TITLE
test(monorepo): consistently run local tests scoped to project/package

### DIFF
--- a/projects/amd-loader/package.json
+++ b/projects/amd-loader/package.json
@@ -43,7 +43,7 @@
 		"prepublishOnly": "yarn build",
 		"preversion": "yarn ci",
 		"proxyPortal": "webpack-dev-server --config webpack.proxyPortal.js",
-		"test": "cd ../.. && yarn test"
+		"test": "cd ../.. && yarn test amd-loader"
 	},
 	"version": "4.3.1"
 }

--- a/projects/eslint-config/package.json
+++ b/projects/eslint-config/package.json
@@ -56,7 +56,7 @@
 		"postinstall": "node scripts/postinstall.js",
 		"postversion": "node ../npm-tools/packages/js-publish/bin/liferay-js-publish.js",
 		"preversion": "yarn ci",
-		"test": "cd ../.. && yarn test"
+		"test": "cd ../.. && yarn test eslint-config"
 	},
 	"version": "21.2.1"
 }

--- a/projects/js-toolkit/package.json
+++ b/projects/js-toolkit/package.json
@@ -12,7 +12,7 @@
 		"lint": "cd ../.. && yarn lint",
 		"lint:fix": "cd ../.. && yarn lint:fix",
 		"qa": "node scripts/qa/index.js",
-		"test": "cd ../.. && yarn test",
+		"test": "cd ../.. && yarn test js-toolkit",
 		"watch": "node scripts/watch.js"
 	},
 	"version": "0.1.0"

--- a/projects/npm-tools/package.json
+++ b/projects/npm-tools/package.json
@@ -17,7 +17,7 @@
 		"lint": "cd ../.. && yarn lint",
 		"lint:fix": "cd ../.. && yarn lint:fix",
 		"preversion": "echo Cannot version private package; false",
-		"test": "cd ../.. && yarn test"
+		"test": "cd ../.. && yarn test npm-tools"
 	},
 	"version": "0.1.0"
 }

--- a/projects/npm-tools/packages/npm-scripts/package.json
+++ b/projects/npm-tools/packages/npm-scripts/package.json
@@ -91,7 +91,7 @@
 		"ci": "cd ../.. && yarn ci",
 		"postversion": "node ../js-publish/bin/liferay-js-publish.js",
 		"preversion": "yarn ci",
-		"test": "jest"
+		"test": "cd ../.. && yarn test npm-scripts"
 	},
 	"version": "33.1.4"
 }


### PR DESCRIPTION
The idea is that when you run `yarn ci` from anywhere in the repo we run all the tests in the repo to make sure that everything works well together, but when you are inside a project or a package directory, you can run `yarn test` to run only the tests for that package and get a quicker feedback loop. Running `yarn test` at the top level continues to run everything. Running it at an intermediate level, like say, "projects/npm-tools/" will run it for all the packages nested below that point.