### PR TITLE
refactor(js-publish): make package check less strict

### DIFF
--- a/projects/npm-tools/packages/js-publish/src/index.js
+++ b/projects/npm-tools/packages/js-publish/src/index.js
@@ -79,9 +79,7 @@ async function checkPackage(pkg) {
 	if (
 		!pkg.scripts ||
 		!pkg.scripts.postversion ||
-		!pkg.scripts.postversion.match(
-			/(?:\bliferay-js-publish|@liferay\/js-publish)\b/
-		)
+		!pkg.scripts.postversion.match(/\bpublish\b/)
 	) {
 		await confirm('No "postversion" script was found; proceed anyway?');
 	}


### PR DESCRIPTION
So, we added this check in a58c811125b, with the explanation that we wanted to make the publish script "more suitable for generic use". And if you look at the README in the parent commit, 7bd58103889, you see that our intent was that the user set up a `postversion` script that just called `npx liferay-js-publish`.

Fair enough, so that meant a somewhat loose substring check of:

    includes('liferay-js-publish')

When we moved the package into a named scope in 63222b948b1, we switched over to this regexp-based check:

    match(/(?:\bliferay-js-publish|@liferay\/js-publish)\b/)

Now, with the introduction of liferay-workspace-scripts, we'd need to add another possibility to that pattern, which would lead us to this monstrosity:

    match(/(?:@liferay\/js-publish|\bliferay-js-publish|\bliferay-workspace-scripts publish)\b/)

At this point, I think it's time we just simplified the check. Our intent here was never to exercise inescapable control over how the script is invoked; rather, we just wanted a cheap check to detect obviously wrong set-ups.

So, rather than hardcoding knowledge of the existence of `workspace-scripts` into `js-publish`, let's just simplify the check: if you have a `postversion` script, and it has the word `publish` in there somewhere, then we'll consider that to be good enough. That means that users won't see this possibly alarming prompt during publication from this repo:

    No "postversion" script was found; proceed anyway?