### PR TITLE
fix: make binaries work from npx

### DIFF
--- a/projects/js-toolkit/packages/js-toolkit-scripts/package.json
+++ b/projects/js-toolkit/packages/js-toolkit-scripts/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"bin": {
-		"js-toolkit": "./bin/js-toolkit"
+		"js-toolkit": "./bin/js-toolkit.js"
 	},
 	"dependencies": {
 		"@babel/core": "^7.0.0",

--- a/projects/js-toolkit/packages/js-toolkit-scripts/package.json
+++ b/projects/js-toolkit/packages/js-toolkit-scripts/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"bin": {
-		"js-toolkit": "bin/js-toolkit.js"
+		"js-toolkit": "./bin/js-toolkit"
 	},
 	"dependencies": {
 		"@babel/core": "^7.0.0",

--- a/projects/js-toolkit/packages/npm-bridge-generator/package.json
+++ b/projects/js-toolkit/packages/npm-bridge-generator/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"bin": {
-		"liferay-npm-bridge-generator": "bin/liferay-npm-bridge-generator.js"
+		"liferay-npm-bridge-generator": "./bin/liferay-npm-bridge-generator"
 	},
 	"dependencies": {
 		"fs-extra": "^8.1.0",

--- a/projects/js-toolkit/packages/npm-bridge-generator/package.json
+++ b/projects/js-toolkit/packages/npm-bridge-generator/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"bin": {
-		"liferay-npm-bridge-generator": "./bin/liferay-npm-bridge-generator"
+		"liferay-npm-bridge-generator": "./bin/liferay-npm-bridge-generator.js"
 	},
 	"dependencies": {
 		"fs-extra": "^8.1.0",

--- a/projects/js-toolkit/packages/npm-bundler/package.json
+++ b/projects/js-toolkit/packages/npm-bundler/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"bin": {
-		"liferay-npm-bundler": "./bin/liferay-npm-bundler"
+		"liferay-npm-bundler": "./bin/liferay-npm-bundler.js"
 	},
 	"dependencies": {
 		"@liferay/js-toolkit-core": "3.0.1-pre.0",

--- a/projects/js-toolkit/packages/npm-bundler/package.json
+++ b/projects/js-toolkit/packages/npm-bundler/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"bin": {
-		"liferay-npm-bundler": "bin/liferay-npm-bundler.js"
+		"liferay-npm-bundler": "./bin/liferay-npm-bundler"
 	},
 	"dependencies": {
 		"@liferay/js-toolkit-core": "3.0.1-pre.0",


### PR DESCRIPTION
Right now, `npx @liferay/npm-bundler` fails because it cannot find the executable `.js` script.

We have made a very deep, intelligent, exhaustive, and thorough investigation (basically just peeking [how `@angular/cli` declares its binary](https://github.com/angular/angular-cli/blob/4169e303c3075df3bdb8c7f500a2d034d6532537/packages/angular/cli/package.json#L7)) and have come to the conclusion that adding `./` to the left and maybe removing the `.js` may help.

Unfortunately we need to merge this PR and release a new version to test this :-(.