### PR TITLE
feat(js-toolkit): convert package.json version classfier to OSGi version classifer

### DIFF
--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/__tests__/manifest.test.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/__tests__/manifest.test.js
@@ -45,6 +45,34 @@ Tool: liferay-npm-bundler-${version}
 	);
 });
 
+it('includes Bundle-Version with valid simple classifier when provided', () => {
+	const manifest = new Manifest();
+
+	manifest.bundleVersion = '1.0.0-classifier';
+
+	expect(manifest.content).toEqual(
+		`Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Version: 1.0.0.classifier
+Tool: liferay-npm-bundler-${version}
+`
+	);
+});
+
+it('includes Bundle-Version with valid extended classifier when provided', () => {
+	const manifest = new Manifest();
+
+	manifest.bundleVersion = '1.0.0-classifier-1-2-3';
+
+	expect(manifest.content).toEqual(
+		`Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Version: 1.0.0.classifier-1-2-3
+Tool: liferay-npm-bundler-${version}
+`
+	);
+});
+
 it('includes Bundle-Name when provided', () => {
 	const manifest = new Manifest();
 

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/manifest.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/manifest.ts
@@ -30,8 +30,13 @@ export default class Manifest {
 		if (this._bundleVersion) {
 			throw new Error('BundleVersion can only be set once');
 		}
-
-		this._bundleVersion = bundleVersion;
+		const parts = bundleVersion.split('-');
+		if (parts.length > 1) {
+			this._bundleVersion = parts[0] + '.' + parts.slice(1).join('-');
+		}
+		else {
+			this._bundleVersion = bundleVersion;
+		}
 	}
 
 	set bundleName(bundleName: string) {


### PR DESCRIPTION
Hello there :-)

This small PR solves a problem with version numbers having a qualifier.

### The problem

None of these version numbers work:

```json
{
  "version": "7.12.0-clavis-17"
}
```

```json
{
  "version": "7.12.0.clavis-17"
}
```

### The errors

***`7.12.0-clavis-17`***

1. `yarn run build` works
2. The jar gets created
3. The `MANIFEST.MF` contains the `Bundle-Version: 7.12.0-clavis-17`
4. OSGi-Deployment fails because of an OSGi-incompatible version number

```
INFO  [com.liferay.portal.kernel.deploy.auto.AutoDeployScanner][AutoDeployDir:271] Processing xxx-7.12.0-clavis-17.jar
[...]
java.lang.IllegalArgumentException: invalid version "7.12.0-clavis-17": non-numeric "0-clavis-17"
[...]
```

***`7.12.0.clavis-17`***

1. Building fails because of an npm-incompatible version number

```bash
$ yarn run build
[...]
Error: Invalid version: "7.12.0.clavis-17"
    at Object.fixVersionField (/xxx/node_modules/normalize-package-data/lib/fixer.js:191:13)
    at /xxx/node_modules/normalize-package-data/lib/normalize.js:32:38
[...]
```

### Valid version ranges

It's possible to define a version qualifier in a `package.json` and in the `MANIFEST.MF` but the accepted format differs:

| *Version number in ...* | *package.json* | *OSGi MANIFEST.MF* |
| --- | --- | --- |
| 1.2.3 | valid | valid |
| 1.2.3-classifier | valid | invalid |
| 1.2.3-classifier-1 | valid | invalid |
| 1.2.3.classifier | invalid | valid |
| 1.2.3.classifier-1 | invalid | valid |

### The solution

The first occurence of an `-` in the version number will be converted to a `.`
