### PR TITLE
refactor: prepend './' to binary scripts path

### DIFF
--- a/projects/js-toolkit/packages/js-toolkit-scripts/package.json
+++ b/projects/js-toolkit/packages/js-toolkit-scripts/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"bin": {
-		"js-toolkit": "bin/js-toolkit.js"
+		"js-toolkit": "./bin/js-toolkit.js"
 	},
 	"dependencies": {
 		"@babel/core": "^7.0.0",

--- a/projects/js-toolkit/packages/npm-bridge-generator/package.json
+++ b/projects/js-toolkit/packages/npm-bridge-generator/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"bin": {
-		"liferay-npm-bridge-generator": "bin/liferay-npm-bridge-generator.js"
+		"liferay-npm-bridge-generator": "./bin/liferay-npm-bridge-generator.js"
 	},
 	"dependencies": {
 		"fs-extra": "^8.1.0",

--- a/projects/js-toolkit/packages/npm-bundler/package.json
+++ b/projects/js-toolkit/packages/npm-bundler/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
 	"bin": {
-		"liferay-npm-bundler": "bin/liferay-npm-bundler.js"
+		"liferay-npm-bundler": "./bin/liferay-npm-bundler.js"
 	},
 	"dependencies": {
 		"@liferay/js-toolkit-core": "3.0.1-pre.0",


### PR DESCRIPTION
It is not mandatory, but after the failed PR at https://github.com/liferay/liferay-frontend-projects/pull/218 we have decided to merge at least this change.