### PR TITLE
docs(js-toolkit): clean some cruft out of changelog

### DIFF
--- a/maintenance/projects/js-toolkit/CHANGELOG.md
+++ b/maintenance/projects/js-toolkit/CHANGELOG.md
@@ -17,10 +17,6 @@
 -   chore(amd-loader): prepare to release under @liferay named scope ([\#200](https://github.com/liferay/liferay-frontend-projects/pull/200))
 -   chore(js-toolkit): make post-release tweaks ([\#141](https://github.com/liferay/liferay-frontend-projects/pull/141))
 
-### :package: Miscellaneous
-
--   Done using:
-
 ## [liferay-js-toolkit/v2.19.4](https://github.com/liferay/liferay-frontend-projects/tree/liferay-js-toolkit/v2.19.4) (2020-10-08)
 
 [Full changelog](https://github.com/liferay/liferay-frontend-projects/compare/liferay-js-toolkit/v2.19.3...liferay-js-toolkit/v2.19.4)


### PR DESCRIPTION
This cruft was in there because [we generate changelog messages by extracting the body from our merge commits](https://github.com/liferay/liferay-frontend-projects/blob/8c6cc33e718ac2f2bcd233d7310a72ffa2cd4785/projects/npm-tools/packages/changelog-generator/src/index.js#L172-L181). Normally, that works, because it means pulling in the pull request titles from merge commits that GitHub generates which look like this:

    commit db37808ad9c250ccd2511232d07d197b8c259cf9
    Merge: 35d260aa a12566f6
    Author: Iván Zaera Avellón <ivan.zaera@liferay.com>
    Date:   Fri Nov 6 13:18:59 2020 +0100

        Merge pull request #227 from izaera/issue-226

        feat: upgrade sample project to Angular 10

(ie. "feat: upgrade sample project to Angular 10" is extracted)

But in this case, it pulled in a rare manual merge that I made when importing the wiki history into this repo:

    commit 9d081a70116e08e75f4b3afc1d3210d972472d26
    Merge: 2bc7f870 dde2a8f9
    Author: Greg Hurrell <greg.hurrell@liferay.com>
    Date:   Thu Oct 8 13:55:18 2020 +0200

        chore(js-toolkit): merge wiki history into maintenance/projects/js-toolkit/docs/

        Done using:

        ... (etc)

(ie. "Done using:" is extracted)

By design, the changelog generator doesn't try to do anything clever here. We could consider making it skip over merge commits that don't have titles starting with "Merge pull request #", but that might be fragile in the face of GitHub changing the format in the future, so I think I prefer to leave it as-is and continue to just catch this kind of thing by manual review.