### PR TITLE
feat(npm-scripts): add minification to build process

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/package.json
+++ b/projects/npm-tools/packages/npm-scripts/package.json
@@ -60,6 +60,7 @@
 		"style-ext-html-webpack-plugin": "4.1.2",
 		"style-loader": "^1.1.3",
 		"stylelint": "^13.2.0",
+		"terser": "5.3.8",
 		"ts-loader": "^8.0.4",
 		"typescript": "^4.0.3",
 		"webpack": "^5.4.0",

--- a/projects/npm-tools/packages/npm-scripts/src/config/terser.config.js
+++ b/projects/npm-tools/packages/npm-scripts/src/config/terser.config.js
@@ -8,8 +8,6 @@ module.exports = {
 		defaults: true,
 	},
 	mangle: {
-		properties: {
-			reserved: [],
-		},
+		properties: false,
 	},
 };

--- a/projects/npm-tools/packages/npm-scripts/src/config/terser.config.js
+++ b/projects/npm-tools/packages/npm-scripts/src/config/terser.config.js
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+module.exports = {
+	compress: {
+		defaults: true,
+	},
+	mangle: {
+		properties: {
+			reserved: [],
+		},
+	},
+};

--- a/projects/npm-tools/packages/npm-scripts/src/index.js
+++ b/projects/npm-tools/packages/npm-scripts/src/index.js
@@ -13,7 +13,7 @@ module.exports = async function () {
 	} = minimist(ARGS_ARRAY);
 
 	const PUBLIC_COMMANDS = {
-		build() {
+		async build() {
 			require('./scripts/build')();
 		},
 

--- a/projects/npm-tools/packages/npm-scripts/src/index.js
+++ b/projects/npm-tools/packages/npm-scripts/src/index.js
@@ -25,8 +25,8 @@ module.exports = async function () {
 			await require('./scripts/fix')();
 		},
 
-		prettier() {
-			require('./scripts/prettier')(...ARGS_ARRAY.slice(1));
+		async prettier() {
+			await require('./scripts/prettier')(...ARGS_ARRAY.slice(1));
 		},
 
 		storybook() {
@@ -61,12 +61,12 @@ module.exports = async function () {
 	};
 
 	const PRIVATE_COMMANDS = {
-		format() {
-			require('./scripts/format')();
+		async format() {
+			await require('./scripts/format')();
 		},
 
-		'format:check': function formatCheck() {
-			require('./scripts/format')({check: true});
+		'format:check': async function formatCheck() {
+			await require('./scripts/format')({check: true});
 		},
 
 		async lint() {

--- a/projects/npm-tools/packages/npm-scripts/src/jsp/README.md
+++ b/projects/npm-tools/packages/npm-scripts/src/jsp/README.md
@@ -2,7 +2,7 @@
 
 This document provides a brief table of contents for the main items in [the npm-scripts/src/format directory](../format), which is responsible for formatting and linting JS inside JSP files.
 
-The main workhorse is [the `processJSP()` function](./processJSP.js), which takes a JSP source string and extracts the contents of any script tags contained within so that they can be processed by Prettier and/or ESLint. Formatting is handled by calling the Prettier API from an `onFormat` callback passed to `processJSP()`; linting is handled by calling the ESLint API from an `onLint` callback. The overall sequence is:
+The main workhorse is [the `processJSP()` function](./processJSP.js), which takes a JSP source string and extracts the contents of any script tags contained within so that they can be processed by Prettier, ESLint, or Terser. Formatting is handled by calling the Prettier API from an `onFormat` callback passed to `processJSP()`; linting is handled by calling the ESLint API from an `onLint` callback; minifying is handled by calling the Terser API from an `onMinify` callback. The overall sequence is:
 
 1. Extract blocks of JS (ie. code inside `<script>` and `<aui:script>` tags) using [the `extractJS()` function](./extractJS.js).
 2. For each block of JS:
@@ -11,7 +11,7 @@ The main workhorse is [the `processJSP()` function](./processJSP.js), which take
     3. Turn JSP tags, expressions, scriptlets (etc) — which are not JavaScript — into valid JS placeholders that allow Prettier and ESLint to parse each block as JavaScript without errors. Peculiar Unicode characters are used in replacements to ensure that the substitutions can be reversed after Prettier has finished formatting. This is done by [the `substituteTags()` function](./substituteTags.js).
     4. Strip indents inside JSP tags (eg. `<c:if>`/`</c:if>` tags) using [the `stripIndents()` function](./stripIndents.js).
     5. Pad the block with a number of lines containing empty statements so that any errors reported by Prettier or ESLint correspond to the source line numbers in the original JSP input, using [the `padLines()` function](./padLines.js).
-    6. Via the `onFormat` callback, actually format the code via the Prettier API; via the `onLint` callback pass the code to the ESLint API for linting. Both callbacks are optional, but in practice we always pass at least one so that `processJSP()` can actually do something useful.
+    6. Via the `onFormat` callback, actually format the code via the Prettier API; via the `onLint` callback pass the code to the ESLint API for linting; via the `onMinify` callback pass the code to the Terser API for minification. All callbacks are optional, but in practice we always pass at least one so that `processJSP()` can actually do something useful.
     7. Remove the padding lines inserted in Step 5.
     8. Swap out the placeholder items inserted in Step 3 for the original JSP tags, expressions and scriptlets, using [the `restoreTags()` function](./restoreTags.js).
     9. Restore the base indent that was removed in Step 2, using [the `indent()` function](./indent.js).

--- a/projects/npm-tools/packages/npm-scripts/src/jsp/formatJSP.js
+++ b/projects/npm-tools/packages/npm-scripts/src/jsp/formatJSP.js
@@ -12,13 +12,13 @@ const processJSP = require('./processJSP');
  *
  * Currently, the only formattable elements are script tags.
  */
-function formatJSP(source, prettierConfig = getMergedConfig('prettier')) {
+async function formatJSP(source, prettierConfig = getMergedConfig('prettier')) {
 	const prettierOptions = {
 		...prettierConfig,
 		parser: 'babel',
 	};
 
-	return processJSP(source, {
+	return await processJSP(source, {
 		onFormat: (input) => {
 			return prettier.format(input, prettierOptions);
 		},

--- a/projects/npm-tools/packages/npm-scripts/src/jsp/lintJSP.js
+++ b/projects/npm-tools/packages/npm-scripts/src/jsp/lintJSP.js
@@ -41,10 +41,10 @@ const SEVERITY = {
  *
  * Currently, the only lintable elements are script tags.
  */
-function lintJSP(source, onReport, options = {}) {
+async function lintJSP(source, onReport, options = {}) {
 	const {fix, quiet} = options;
 
-	return processJSP(source, {
+	return await processJSP(source, {
 		onLint: (input) => {
 			let messages;
 			let output;

--- a/projects/npm-tools/packages/npm-scripts/src/jsp/padLines.js
+++ b/projects/npm-tools/packages/npm-scripts/src/jsp/padLines.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+const PADDING_MARKER = '\u00abpad\u00bb';
+
 /**
  * The default padding string: a valid JS statement and reasonably unlikely
  * to exist organically anywhere in the liferay-portal repo.
@@ -11,9 +13,9 @@
  * "Mark" («) and Right-Pointing Double Angle Quotation Mark" (»)
  * "respectively.
  */
-const DEFAULT_PADDING = 'void 0; /* \u00abpad\u00bb */';
+const DEFAULT_PADDING = `void 0; /* ${PADDING_MARKER} */`;
 
-const PADDING_LINE = /\s*void\s+0;\s*\/\*\s*\u00abpad\u00bb\s*\*\/\n/g;
+const PADDING_LINE = /(?:\s*void\s+0;\s*)?\/\*\s*\u00abpad\u00bb\s*\*\/\n/g;
 
 /**
  * Prefixes `string` with lines containing the `padding` string such that the
@@ -27,6 +29,7 @@ function padLines(string, startLine, padding = DEFAULT_PADDING) {
 	return `${padding}\n`.repeat(startLine) + string;
 }
 
+padLines.PADDING_MARKER = PADDING_MARKER;
 padLines.PADDING_LINE = PADDING_LINE;
 
 module.exports = padLines;

--- a/projects/npm-tools/packages/npm-scripts/src/jsp/processJSP.js
+++ b/projects/npm-tools/packages/npm-scripts/src/jsp/processJSP.js
@@ -81,14 +81,14 @@ async function processJSP(source, {onFormat, onLint, onMinify}) {
 
 		// Restore base indent.
 
-		const indented = indent(restored, baseIndent);
+		const indented = onMinify ? restored : indent(restored, baseIndent);
 
 		transformed.push({
 			...block,
 			contents:
-				(prefix || '\n') +
+				(onMinify ? '' : prefix || '\n') +
 				indented +
-				(suffix || '\t'.repeat(baseIndent - 1)),
+				(onMinify ? '' : suffix || '\t'.repeat(baseIndent - 1)),
 		});
 	}
 

--- a/projects/npm-tools/packages/npm-scripts/src/jsp/processJSP.js
+++ b/projects/npm-tools/packages/npm-scripts/src/jsp/processJSP.js
@@ -19,7 +19,7 @@ const {PADDING_LINE} = padLines;
  *
  * Currently, the only processable elements are script tags.
  */
-function processJSP(source, {onFormat, onLint}) {
+async function processJSP(source, {onFormat, onLint, onMinify}) {
 	const blocks = extractJS(source);
 
 	// TODO: may want to pass filename here too, but I am not sure.
@@ -30,7 +30,9 @@ function processJSP(source, {onFormat, onLint}) {
 
 	// TODO: lint for <(aui:)?script> not followed by newline (there are basically none in liferay-portal)
 
-	const transformed = blocks.map((block) => {
+	const transformed = [];
+
+	for (const block of blocks) {
 		const {contents, openTag, range} = block;
 
 		// Script content should be indented one tab more than the opening tag.
@@ -65,9 +67,13 @@ function processJSP(source, {onFormat, onLint}) {
 
 		const formatted = onFormat ? onFormat(fixed) : fixed;
 
+		// (Optionally) actually minify.
+
+		const minified = onMinify ? await onMinify(formatted) : formatted;
+
 		// Remove previously inserted padding lines.
 
-		const unpadded = formatted.replace(PADDING_LINE, '');
+		const unpadded = minified.replace(PADDING_LINE, '');
 
 		// Replace placeholders with their corresponding original JSP tokens.
 
@@ -77,14 +83,14 @@ function processJSP(source, {onFormat, onLint}) {
 
 		const indented = indent(restored, baseIndent);
 
-		return {
+		transformed.push({
 			...block,
 			contents:
 				(prefix || '\n') +
 				indented +
 				(suffix || '\t'.repeat(baseIndent - 1)),
-		};
-	});
+		});
+	}
 
 	let result = '';
 	let lastIndex = 0;

--- a/projects/npm-tools/packages/npm-scripts/src/presets/standard/index.js
+++ b/projects/npm-tools/packages/npm-scripts/src/presets/standard/index.js
@@ -32,6 +32,7 @@ module.exports = {
 		// - `babel` executable (via `runBabel()`).
 		// - `jest` executable (via resolver.js).
 		// - `translateSoy()`.
+		// - `minify()`.
 
 		output: 'build/node/packageRunBuild/resources',
 

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
@@ -8,6 +8,7 @@ const path = require('path');
 const rimraf = require('rimraf');
 
 const getMergedConfig = require('../utils/getMergedConfig');
+const minify = require('../utils/minify');
 const runBabel = require('../utils/runBabel');
 const runBundler = require('../utils/runBundler');
 const setEnv = require('../utils/setEnv');
@@ -70,8 +71,9 @@ function runBridge() {
  * liferay-npm-bridge-generator and webpack are run if the corresponding
  * ".npmbridgerc" and "webpack.config.js" files, respectively, are
  * present, and soy is run when soy files are detected.
+ * `minify()` is run unless `NODE_ENV` is `development`.
  */
-module.exports = function () {
+module.exports = async function () {
 	setEnv('production');
 
 	validateConfig(
@@ -107,5 +109,9 @@ module.exports = function () {
 
 	if (useSoy) {
 		cleanSoy();
+	}
+
+	if (process.env.NODE_ENV !== 'development') {
+		await minify();
 	}
 };

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/prettier.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/prettier.js
@@ -18,7 +18,7 @@ const IGNORE_FILE = '.prettierignore';
  * Exposes a version of our augumented Prettier suitable for use within editors
  * and editor plugins.
  */
-function main(...args) {
+async function main(...args) {
 	let i;
 
 	let files = [];
@@ -184,7 +184,11 @@ function main(...args) {
 
 	let status = 0;
 
-	files.forEach(({contents, filepath}) => {
+	for (const file of files) {
+		const {filepath} = file;
+
+		let {contents} = file;
+
 		contents =
 			contents === null ? fs.readFileSync(filepath, 'utf8') : contents;
 
@@ -196,7 +200,7 @@ function main(...args) {
 		let formattedContents;
 
 		if (isJSP(filepath)) {
-			formattedContents = formatJSP(contents, prettierOptions);
+			formattedContents = await formatJSP(contents, prettierOptions);
 		}
 		else {
 			formattedContents = format(contents, prettierOptions);
@@ -221,7 +225,7 @@ function main(...args) {
 		if (!options.write && !options.listDifferent) {
 			write(formattedContents);
 		}
-	});
+	}
 
 	if (options.listDifferent && status) {
 		process.exit(status);

--- a/projects/npm-tools/packages/npm-scripts/src/utils/getMergedConfig.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/getMergedConfig.js
@@ -130,13 +130,6 @@ function getMergedConfig(type, property) {
 			]);
 			break;
 
-		case 'stylelint':
-			mergedConfig = deepMerge([
-				require('../config/stylelint'),
-				getUserConfig('stylelint'),
-			]);
-			break;
-
 		case 'eslint':
 			mergedConfig = deepMerge([
 				require('../config/eslint.config'),
@@ -184,6 +177,13 @@ function getMergedConfig(type, property) {
 
 			break;
 		}
+
+		case 'stylelint':
+			mergedConfig = deepMerge([
+				require('../config/stylelint'),
+				getUserConfig('stylelint'),
+			]);
+			break;
 
 		default:
 			throw new Error(`'${type}' is not a valid config`);

--- a/projects/npm-tools/packages/npm-scripts/src/utils/getMergedConfig.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/getMergedConfig.js
@@ -185,6 +185,13 @@ function getMergedConfig(type, property) {
 			]);
 			break;
 
+		case 'terser':
+			mergedConfig = deepMerge([
+				require('../config/terser.config'),
+				getUserConfig('terser'),
+			]);
+			break;
+
 		default:
 			throw new Error(`'${type}' is not a valid config`);
 	}

--- a/projects/npm-tools/packages/npm-scripts/src/utils/getPaths.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/getPaths.js
@@ -14,13 +14,22 @@ const log = require('../utils/log');
 const preprocessGlob = require('../utils/preprocessGlob');
 const readIgnoreFile = require('../utils/readIgnoreFile');
 
+const DEFAULT_OPTIONS = {
+	useDefaultIgnores: true,
+};
+
 /**
  * Given a set of `globs`, the file `extensions` we are interested
  * in, and the name of an `ignoreFile` (eg. '.prettierignore' or
  * '.eslintignore'), returns a list of matching files on the file
  * system.
  */
-function getPaths(globs, extensions, ignoreFile) {
+function getPaths(globs, extensions, ignoreFile, options = {}) {
+	options = {
+		...DEFAULT_OPTIONS,
+		...options,
+	};
+
 	const root = findRoot();
 
 	ignoreFile = ignoreFile ? path.join(root || '.', ignoreFile) : '';
@@ -29,7 +38,10 @@ function getPaths(globs, extensions, ignoreFile) {
 
 	// Match Prettier behavior and ignore node_modules by default.
 
-	if (ignores.indexOf('node_modules/**') === -1) {
+	if (
+		options.useDefaultIgnores &&
+		ignores.indexOf('node_modules/**') === -1
+	) {
 		ignores.unshift('node_modules/**');
 	}
 

--- a/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
@@ -75,13 +75,19 @@ async function minify() {
 					try {
 						const result = await terser(input, {
 							...MINIFIER_CONFIG,
-							format: {
-								comments: JSP_COMMENT_REGEXP,
-							},
 
 							// We can't risk renaming anything because
 							// JSP's may contain "hidden" code (via
 							// interpolation).
+
+							compress: {
+								keep_classnames: true,
+								keep_fnames: true,
+							},
+
+							format: {
+								comments: JSP_COMMENT_REGEXP,
+							},
 
 							mangle: false,
 						});

--- a/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
@@ -75,16 +75,15 @@ async function minify() {
 					try {
 						const result = await terser(input, {
 							...MINIFIER_CONFIG,
+							format: {
+								comments: JSP_COMMENT_REGEXP,
+							},
 
 							// We can't risk renaming anything because
 							// JSP's may contain "hidden" code (via
 							// interpolation).
 
 							mangle: false,
-
-							format: {
-								comments: JSP_COMMENT_REGEXP,
-							},
 						});
 
 						return result.code;

--- a/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
@@ -15,12 +15,16 @@ const log = require('./log');
 
 const BUILD_CONFIG = getMergedConfig('npmscripts', 'build');
 
+const BUILD = BUILD_CONFIG.output;
+
+const CLASSES = BUILD.replace(/^build\/.*/, 'classes/');
+
 const MINIFIER_CONFIG = getMergedConfig('terser');
 
 const MINIFY_GLOBS = [
-	path.posix.join(BUILD_CONFIG.output, '**', '*.js'),
-	path.posix.join(BUILD_CONFIG.output, '**', '*.jsp'),
-	path.posix.join(BUILD_CONFIG.output, '**', '*.jspf'),
+	path.posix.join(BUILD, '**', '*.js'),
+	path.posix.join(CLASSES, '**', '*.jsp'),
+	path.posix.join(CLASSES, '**', '*.jspf'),
 	'!*-min.js',
 	'!*.min.js',
 ];

--- a/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
@@ -1,0 +1,87 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const fs = require('fs');
+const path = require('path');
+const {minify: terser} = require('terser');
+
+const getMergedConfig = require('./getMergedConfig');
+const getPaths = require('./getPaths');
+const log = require('./log');
+
+const BUILD_CONFIG = getMergedConfig('npmscripts', 'build');
+
+const MINIFIER_CONFIG = getMergedConfig('terser');
+
+const MINIFY_GLOBS = [
+	path.posix.join(BUILD_CONFIG.output, '**', '*.js'),
+	'!*-min.js',
+	'!*.min.js',
+];
+
+async function minify() {
+	const start = Date.now();
+
+	const paths = getPaths(MINIFY_GLOBS, [], '', {useDefaultIgnores: false});
+
+	let successes = 0;
+	let errors = 0;
+	let before = 0;
+	let after = 0;
+
+	for (const source of paths) {
+		const contents = fs.readFileSync(source, 'utf8');
+
+		before += contents.length;
+
+		const sourceMap = {
+			url: path.basename(source) + '.map',
+		};
+
+		if (fs.existsSync(source + '.map')) {
+			sourceMap.content = fs.readFileSync(source + '.map', 'utf8');
+		}
+
+		try {
+			const result = await terser(contents, {
+				...MINIFIER_CONFIG,
+				sourceMap,
+			});
+
+			if (result.code !== contents) {
+				fs.writeFileSync(source, result.code);
+				fs.writeFileSync(source + '.map', result.map);
+
+				if (process.env.DEBUG) {
+					log(
+						`${contents.length} -> ${result.code.length}: ${source}`
+					);
+				}
+			}
+
+			after += result.code.length;
+			successes++;
+		}
+		catch (error) {
+			if (process.env.DEBUG) {
+				log(`[ignored: ${error}]: ${source}`);
+			}
+
+			errors++;
+		}
+	}
+
+	log(
+		'Summary:',
+		`  Files minified: ${successes}`,
+		`  Files skipped:  ${errors}`,
+		`  Before size:    ${before}`,
+		`  After size:     ${after}`,
+		`  Delta:          ${before - after}`,
+		`  Elapsed:        ${((Date.now() - start) / 1000).toFixed(2)}`
+	);
+}
+
+module.exports = minify;

--- a/projects/npm-tools/packages/npm-scripts/test/jsp/formatJSP.js
+++ b/projects/npm-tools/packages/npm-scripts/test/jsp/formatJSP.js
@@ -9,7 +9,7 @@ const formatJSP = require('../../src/jsp/formatJSP');
 const getFixture = require('../../support/getFixture');
 
 describe('formatJSP()', () => {
-	it('deals with interleaved JS control structures and JSP tags', () => {
+	it('deals with interleaved JS control structures and JSP tags', async () => {
 
 		// eg. an `if()` that is conditionally added augmented with an `else()`
 		// based on a tag.
@@ -32,7 +32,9 @@ describe('formatJSP()', () => {
 		// due to special casing explained in the notes in the
 		// `tagReplacements()` implementation.
 
-		expect(formatJSP(source)).toBe(`
+		const formatted = await formatJSP(source);
+
+		expect(formatted).toBe(`
 			<p>Hi!</p>
 			<script>
 				if (richEditor.getEditor().getSession().getUndoManager().hasUndo()) {
@@ -47,7 +49,7 @@ describe('formatJSP()', () => {
 		`);
 	});
 
-	it('pads input so that Prettier syntax errors have accurate line numbers', () => {
+	it('pads input so that Prettier syntax errors have accurate line numbers', async () => {
 		const source = `
 			<p>Hi!</p>
 
@@ -69,10 +71,12 @@ describe('formatJSP()', () => {
 			</script>
 		`;
 
-		expect(() => formatJSP(source)).toThrow(/Unexpected token \(18:1\)/);
+		await expect(formatJSP(source)).rejects.toThrow(
+			/Unexpected token \(18:1\)/
+		);
 	});
 
-	it('trims unwanted leading blank lines', () => {
+	it('trims unwanted leading blank lines', async () => {
 		const source = `
 			<aui:script require="metal-dom/src/dom">
 
@@ -86,7 +90,9 @@ describe('formatJSP()', () => {
 			</aui:script>
 		`;
 
-		expect(formatJSP(source)).toBe(expected);
+		const formatted = await formatJSP(source);
+
+		expect(formatted).toBe(expected);
 	});
 
 	describe('fixing problems with indentation relative to script tag (#437)', () => {
@@ -94,7 +100,7 @@ describe('formatJSP()', () => {
 		// ie. each line is correct with respect to its neighbors, but overall,
 		// the code is wrong relative to the script tag.
 
-		it('corrects script content that is insufficiently indented', () => {
+		it('corrects script content that is insufficiently indented', async () => {
 			const source = `
 				<aui:script>
 				function <portlet:namespace />deleteOrganization(
@@ -125,10 +131,12 @@ describe('formatJSP()', () => {
 				</aui:script>
 			`;
 
-			expect(formatJSP(source)).toBe(expected);
+			const formatted = await formatJSP(source);
+
+			expect(formatted).toBe(expected);
 		});
 
-		it('corrects script content that is excessively indented', () => {
+		it('corrects script content that is excessively indented', async () => {
 
 			// Note that it works for <script> as well.
 
@@ -162,10 +170,12 @@ describe('formatJSP()', () => {
 				</script>
 			`;
 
-			expect(formatJSP(source)).toBe(expected);
+			const formatted = await formatJSP(source);
+
+			expect(formatted).toBe(expected);
 		});
 
-		it('corrects script content that is "negatively" indented', () => {
+		it('corrects script content that is "negatively" indented', async () => {
 			const source = `
 				<aui:script>
 			function <portlet:namespace />deleteOrganization(
@@ -196,10 +206,12 @@ describe('formatJSP()', () => {
 				</aui:script>
 			`;
 
-			expect(formatJSP(source)).toBe(expected);
+			const formatted = await formatJSP(source);
+
+			expect(formatted).toBe(expected);
 		});
 
-		it('fixes content that is on the same line as the script tag', () => {
+		it('fixes content that is on the same line as the script tag', async () => {
 
 			// source-formatter doesn't behave well with one-line scripts like
 			// this, so let's fix them for it.
@@ -231,11 +243,13 @@ describe('formatJSP()', () => {
 				</aui:script>
 			`;
 
-			expect(formatJSP(source)).toBe(expected);
+			const formatted = await formatJSP(source);
+
+			expect(formatted).toBe(expected);
 		});
 	});
 
-	it('correctly handles internal indentation inside control structures', () => {
+	it('correctly handles internal indentation inside control structures', async () => {
 
 		// This is a reduced example of what's in the source.jsp fixture.
 
@@ -274,7 +288,9 @@ describe('formatJSP()', () => {
 			</aui:script>
 		`;
 
-		expect(formatJSP(source)).toBe(`
+		const formatted = await formatJSP(source);
+
+		expect(formatted).toBe(`
 			<aui:script require="metal-dom/src/dom as dom">
 				var sourcePanel = document.querySelector('.source-container');
 
@@ -314,7 +330,7 @@ describe('formatJSP()', () => {
 		`);
 	});
 
-	it('respects indentation within a nested control structures', () => {
+	it('respects indentation within a nested control structures', async () => {
 
 		// This is a reduced example of what's in the source.jsp fixture.
 
@@ -374,10 +390,12 @@ describe('formatJSP()', () => {
 			</aui:script>
 		`;
 
-		expect(formatJSP(source)).toBe(expected);
+		const formatted = await formatJSP(source);
+
+		expect(formatted).toBe(expected);
 	});
 
-	it('returns the source unmodified if there are no JSP tags', () => {
+	it('returns the source unmodified if there are no JSP tags', async () => {
 		const source = `
 			<%--
 			/**
@@ -392,10 +410,12 @@ describe('formatJSP()', () => {
 			<h1><%= heading %></h1>
 		`;
 
-		expect(formatJSP(source)).toBe(source);
+		const formatted = await formatJSP(source);
+
+		expect(formatted).toBe(source);
 	});
 
-	it('handles an edge case (#258)', () => {
+	it('handles an edge case (#258)', async () => {
 
 		// Reduced example of what's in
 		// modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -431,7 +451,9 @@ describe('formatJSP()', () => {
 			</aui:script>
 		`;
 
-		expect(formatJSP(source)).toBe(`
+		const formatted = await formatJSP(source);
+
+		expect(formatted).toBe(`
 			<aui:script>
 
 				<%
@@ -485,12 +507,14 @@ describe('formatJSP()', () => {
 		])('%s matches snapshot', async (fixture) => {
 			const source = await getFixture(path.join('jsp', fixture));
 
-			expect(formatJSP(source)).toMatchSnapshot();
+			const formatted = await formatJSP(source);
+
+			expect(formatted).toMatchSnapshot();
 		});
 	});
 
 	describe('known limitations', () => {
-		it('cannot deal with conditionals at the end of object literals', () => {
+		it('cannot deal with conditionals at the end of object literals', async () => {
 
 			// This one from "edit_content_redirect.jsp": note that without
 			// trailing commas after the "redirect" and "refresh" properties,
@@ -518,7 +542,7 @@ describe('formatJSP()', () => {
 				</aui:script>
 			`;
 
-			expect(() => formatJSP(source)).toThrow(
+			await expect(formatJSP(source)).rejects.toThrow(
 				/Unexpected token, expected ","/
 			);
 		});

--- a/projects/npm-tools/packages/npm-scripts/test/jsp/lintJSP.js
+++ b/projects/npm-tools/packages/npm-scripts/test/jsp/lintJSP.js
@@ -42,28 +42,28 @@ describe('lintJSP()', () => {
 		);
 	}
 
-	it('passes valid code straight through', () => {
+	it('passes valid code straight through', async () => {
 		const source = dedent(3)`
 			<script>
 				Liferay.fire('someEvent');
 			</script>
 		`;
 
-		const result = lintJSP(source, onReport);
+		const result = await lintJSP(source, onReport);
 
 		expect(result).toBe(source);
 
 		expect(onReport).not.toBeCalled();
 	});
 
-	it('reports simple problems (eg. no-extra-boolean-cast rule)', () => {
+	it('reports simple problems (eg. no-extra-boolean-cast rule)', async () => {
 		const source = dedent(3)`
 			<script>
 				var bool = !!!other;
 			</script>
 		`;
 
-		const result = lintJSP(source, onReport);
+		const result = await lintJSP(source, onReport);
 
 		// Note: did not autofix because we didn't pass `{fix: true}`.
 
@@ -92,14 +92,14 @@ describe('lintJSP()', () => {
 		});
 	});
 
-	it('reports debugger statements (eg. no-debugger rule)', () => {
+	it('reports debugger statements (eg. no-debugger rule)', async () => {
 		const source = dedent(3)`
 			<script>
 				debugger;
 			</script>
 		`;
 
-		const result = lintJSP(source, onReport);
+		const result = await lintJSP(source, onReport);
 
 		// No autofix.
 
@@ -127,7 +127,7 @@ describe('lintJSP()', () => {
 		});
 	});
 
-	it('deals with a mixture of fixable and not-fixable errors', () => {
+	it('deals with a mixture of fixable and not-fixable errors', async () => {
 
 		// eg: 1 autofix and 1 not-autofix
 
@@ -138,7 +138,7 @@ describe('lintJSP()', () => {
 			</script>
 		`;
 
-		const result = lintJSP(source, onReport);
+		const result = await lintJSP(source, onReport);
 
 		// No autofix.
 
@@ -182,14 +182,14 @@ describe('lintJSP()', () => {
 			process.chdir(modules);
 		});
 
-		it('rejects const declarations as syntax errors', () => {
+		it('rejects const declarations as syntax errors', async () => {
 			const source = dedent(3)`
 				<script>
 					const x = 1;
 				</script>
 			`;
 
-			const result = lintJSP(source, onReport);
+			const result = await lintJSP(source, onReport);
 
 			// No autofix.
 
@@ -219,14 +219,14 @@ describe('lintJSP()', () => {
 			});
 		});
 
-		it('rejects arrow functions as syntax errors', () => {
+		it('rejects arrow functions as syntax errors', async () => {
 			const source = dedent(3)`
 				<script>
 					var x = () => 1;
 				</script>
 			`;
 
-			const result = lintJSP(source, onReport);
+			const result = await lintJSP(source, onReport);
 
 			// No autofix.
 
@@ -263,28 +263,28 @@ describe('lintJSP()', () => {
 			process.chdir(modules);
 		});
 
-		it('permits const declarations', () => {
+		it('permits const declarations', async () => {
 			const source = dedent(3)`
 				<script>
 					const x = 1;
 				</script>
 			`;
 
-			const result = lintJSP(source, onReport);
+			const result = await lintJSP(source, onReport);
 
 			expect(result).toBe(source);
 
 			expect(onReport).not.toBeCalled();
 		});
 
-		it('permits arrow functions', () => {
+		it('permits arrow functions', async () => {
 			const source = dedent(3)`
 				<script>
 					var x = () => 1;
 				</script>
 			`;
 
-			const result = lintJSP(source, onReport);
+			const result = await lintJSP(source, onReport);
 
 			expect(result).toBe(source);
 
@@ -293,28 +293,28 @@ describe('lintJSP()', () => {
 	});
 
 	describe('`fix` option', () => {
-		it('passes valid code straight through', () => {
+		it('passes valid code straight through', async () => {
 			const source = dedent(3)`
 				<script>
 					Liferay.fire('someEvent');
 				</script>
 			`;
 
-			const result = lintJSP(source, onReport, {fix: true});
+			const result = await lintJSP(source, onReport, {fix: true});
 
 			expect(result).toBe(source);
 
 			expect(onReport).not.toBeCalled();
 		});
 
-		it('fixes simple problems (eg. no-extra-boolean-cast rule)', () => {
+		it('fixes simple problems (eg. no-extra-boolean-cast rule)', async () => {
 			const source = dedent(3)`
 				<script>
 					var bool = !!!other;
 				</script>
 			`;
 
-			const result = lintJSP(source, onReport, {fix: true});
+			const result = await lintJSP(source, onReport, {fix: true});
 
 			expect(result).toBe(dedent(3)`
 				<script>
@@ -327,14 +327,14 @@ describe('lintJSP()', () => {
 			expect(onReport).not.toBeCalled();
 		});
 
-		it('does not fix when `fix` is `false`', () => {
+		it('does not fix when `fix` is `false`', async () => {
 			const source = dedent(3)`
 				<script>
 					var bool = !!!other;
 				</script>
 			`;
 
-			const result = lintJSP(source, onReport, {fix: false});
+			const result = await lintJSP(source, onReport, {fix: false});
 
 			expect(result).toBe(source);
 
@@ -357,14 +357,14 @@ describe('lintJSP()', () => {
 			});
 		});
 
-		it('does not fix when `fix` is not explicitly passed', () => {
+		it('does not fix when `fix` is not explicitly passed', async () => {
 			const source = dedent(3)`
 				<script>
 					var bool = !!!other;
 				</script>
 			`;
 
-			const result = lintJSP(source, onReport);
+			const result = await lintJSP(source, onReport);
 
 			expect(result).toBe(source);
 
@@ -387,7 +387,7 @@ describe('lintJSP()', () => {
 			});
 		});
 
-		it('deals with a mixture of fixable and not-fixable errors', () => {
+		it('deals with a mixture of fixable and not-fixable errors', async () => {
 
 			// eg: 1 autofix and 1 not-autofix
 
@@ -398,7 +398,7 @@ describe('lintJSP()', () => {
 				</script>
 			`;
 
-			const result = lintJSP(source, onReport, {fix: true});
+			const result = await lintJSP(source, onReport, {fix: true});
 
 			expect(result).toBe(dedent(3)`
 				<script>
@@ -432,7 +432,7 @@ describe('lintJSP()', () => {
 		// "warn"  at all in liferay-portal; so we just show that it basically
 		// works the same as above.
 
-		it('works', () => {
+		it('works', async () => {
 
 			// eg: 1 autofix and 1 not-autofix
 
@@ -443,7 +443,10 @@ describe('lintJSP()', () => {
 				</script>
 			`;
 
-			const result = lintJSP(source, onReport, {fix: true, quiet: true});
+			const result = await lintJSP(source, onReport, {
+				fix: true,
+				quiet: true,
+			});
 
 			expect(result).toBe(dedent(3)`
 				<script>

--- a/projects/npm-tools/packages/npm-scripts/test/jsp/padLines.js
+++ b/projects/npm-tools/packages/npm-scripts/test/jsp/padLines.js
@@ -18,4 +18,30 @@ describe('padLines()', () => {
 	it('uses the supplied padding string', () => {
 		expect(padLines('{}', 2, 'void 0;')).toBe('void 0;\nvoid 0;\n{}');
 	});
+
+	it('exports a RegExp that can be used to strip padding lines', () => {
+		expect(
+			(
+				'void 0; /* «pad» */\n' +
+				'void 0; /* «pad» */\n' +
+				'someCode();\n' +
+				'otherCode();'
+			).replace(padLines.PADDING_LINE, '')
+		).toBe('someCode();\n' + 'otherCode();');
+	});
+
+	it('can strip padding comments even after minification', () => {
+
+		// Minification strips the "void 0;" statements, but we can still remove
+		// the comments.
+
+		expect(
+			(
+				'/* «pad» */\n' +
+				'/* «pad» */\n' +
+				'someCode();\n' +
+				'otherCode();'
+			).replace(padLines.PADDING_LINE, '')
+		).toBe('someCode();\n' + 'otherCode();');
+	});
 });

--- a/projects/npm-tools/packages/npm-scripts/test/jsp/processJSP.js
+++ b/projects/npm-tools/packages/npm-scripts/test/jsp/processJSP.js
@@ -1,0 +1,112 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const processJSP = require('../../src/jsp/processJSP');
+
+describe('processJSP()', () => {
+	const source = `
+				Prologue
+
+				<script>
+					// Do stuff!
+
+					(function () {
+						var message = 'thing';
+
+						alert(message);
+					})();
+				</script>
+
+				Epilogue
+			`;
+
+	describe('with an onFormat callback', () => {
+		it('passes the script contents through the callback', async () => {
+
+			// "Formatter" that upper-cases comments.
+
+			const result = await processJSP(source, {
+				onFormat(input) {
+					return (
+						input.replace(/\/\/.+/, (match) =>
+							match.toUpperCase()
+						) + '\n'
+					);
+				},
+			});
+
+			expect(result).toBe(`
+				Prologue
+
+				<script>
+					// DO STUFF!
+
+					(function () {
+						var message = 'thing';
+
+						alert(message);
+					})();
+				</script>
+
+				Epilogue
+			`);
+		});
+	});
+
+	describe('with an onLint callback', () => {
+		it('passes the script contents through the callback', async () => {
+
+			// "Linter" that autofixes `var` to `const`.
+
+			const result = await processJSP(source, {
+				onLint(input) {
+					return input.replace('var', 'const') + '\n';
+				},
+			});
+
+			expect(result).toBe(`
+				Prologue
+
+				<script>
+					// Do stuff!
+
+					(function () {
+						const message = 'thing';
+
+						alert(message);
+					})();
+				</script>
+
+				Epilogue
+			`);
+		});
+	});
+
+	describe('with an onMinify callback', () => {
+		it('passes the script contents through the callback', async () => {
+
+			// "Minifier" that strips line comments and empty line.
+
+			const result = await processJSP(source, {
+				onMinify(input) {
+					return input.replace(/^\n/gm, '').replace(/\/\/.+\n/, '');
+				},
+			});
+
+			// Note that *base indent* gets stripped automatically.
+
+			expect(result).toBe(`
+				Prologue
+
+				<script>(function () {
+	var message = 'thing';
+	alert(message);
+})();</script>
+
+				Epilogue
+			`);
+		});
+	});
+});

--- a/projects/npm-tools/packages/npm-scripts/test/prettier/index.js
+++ b/projects/npm-tools/packages/npm-scripts/test/prettier/index.js
@@ -71,7 +71,7 @@ describe('code``', () => {
 
 describe('prettier/index.js', () => {
 	describe('prettier.format()', () => {
-		it('does not choke on SCSS files', () => {
+		it('does not choke on SCSS files', async () => {
 			function format(source, options = {}) {
 				return prettier.format(source, {
 					...config,
@@ -80,9 +80,8 @@ describe('prettier/index.js', () => {
 				});
 			}
 
-			expect(
-				format(
-					code`
+			const formatted = await format(
+				code`
 					@mixin button-base()
 					{
 						@include typography(button);
@@ -105,8 +104,9 @@ describe('prettier/index.js', () => {
 						}
 					}
 			`
-				)
-			).toBe(code`
+			);
+
+			expect(formatted).toBe(code`
 					@mixin button-base() {
 						@include typography(button);
 						@include ripple-surface;
@@ -142,12 +142,12 @@ describe('prettier/index.js', () => {
 					});
 				}
 
-				it('does standard prettier formatting', () => {
-					expect(
-						format(code`
+				it('does standard prettier formatting', async () => {
+					const formatted = await format(code`
 						if (test) { exit(); }
-				`)
-					).toBe(code`
+				`);
+
+					expect(formatted).toBe(code`
 						if (test) {
 							exit();
 						}
@@ -155,9 +155,8 @@ describe('prettier/index.js', () => {
 				});
 
 				describe('new-line-before-block-statements', () => {
-					it('breaks before "else"', () => {
-						expect(
-							format(code`
+					it('breaks before "else"', async () => {
+						const formatted = await format(code`
 							// Random ES6 to prove that custom lint rule can handle
 							// it without choking.
 
@@ -170,8 +169,9 @@ describe('prettier/index.js', () => {
 									return 2;
 								}
 							}
-					`)
-						).toBe(code`
+					`);
+
+						expect(formatted).toBe(code`
 							// Random ES6 to prove that custom lint rule can handle
 							// it without choking.
 
@@ -188,9 +188,8 @@ describe('prettier/index.js', () => {
 					`);
 					});
 
-					it('breaks before "else if"', () => {
-						expect(
-							format(code`
+					it('breaks before "else if"', async () => {
+						const formatted = await format(code`
 							function thing() {
 								if (test) {
 									return 1;
@@ -200,8 +199,9 @@ describe('prettier/index.js', () => {
 									return 3;
 								}
 							}
-					`)
-						).toBe(code`
+					`);
+
+						expect(formatted).toBe(code`
 							function thing() {
 								if (test) {
 									return 1;
@@ -216,21 +216,21 @@ describe('prettier/index.js', () => {
 					`);
 					});
 
-					it('preserves inline comments before alternates', () => {
+					it('preserves inline comments before alternates', async () => {
 
 						// Prettier does some "crazy" things with comments (moving them
 						// in and out of blocks) but this is one case where it leaves
 						// them alone.
 
-						expect(
-							format(code`
+						const formatted = await format(code`
 							if (test) {
 								a();
 							} /* comment */ else {
 								b();
 							}
-					`)
-						).toBe(code`
+					`);
+
+						expect(formatted).toBe(code`
 							if (test) {
 								a();
 							} /* comment */
@@ -240,7 +240,7 @@ describe('prettier/index.js', () => {
 					`);
 					});
 
-					it('preserves alone-on-a-line comments before alternates', () => {
+					it('preserves alone-on-a-line comments before alternates', async () => {
 
 						// This is a regression test.
 						//
@@ -270,8 +270,7 @@ describe('prettier/index.js', () => {
 						// We were incorrectly stripping the comment before the
 						// alternate (ie. the first one).
 
-						expect(
-							format(code`
+						const formatted = await format(code`
 							if (test) {
 								a();
 							}
@@ -283,8 +282,9 @@ describe('prettier/index.js', () => {
 							}
 
 							// closing JSP tag comment
-					`)
-						).toBe(code`
+					`);
+
+						expect(formatted).toBe(code`
 							if (test) {
 								a();
 							}
@@ -299,22 +299,22 @@ describe('prettier/index.js', () => {
 					`);
 					});
 
-					it('does not re-fix alternates that are already correct', () => {
+					it('does not re-fix alternates that are already correct', async () => {
 
 						// Prettier will first move the "else" here back onto
 						// the preceding line, then our wrapper moves it back down
 						// again.
 
-						expect(
-							format(code`
+						const formatted = await format(code`
 							if (test) {
 								a();
 							}
 							else {
 								b();
 							}
-					`)
-						).toBe(code`
+					`);
+
+						expect(formatted).toBe(code`
 							if (test) {
 								a();
 							}
@@ -324,16 +324,16 @@ describe('prettier/index.js', () => {
 					`);
 					});
 
-					it('breaks before "catch" (with catch binding)', () => {
-						expect(
-							format(code`
+					it('breaks before "catch" (with catch binding)', async () => {
+						const formatted = await format(code`
 							try {
 								a();
 							} catch (error) {
 								log(error);
 							}
-					`)
-						).toBe(code`
+					`);
+
+						expect(formatted).toBe(code`
 							try {
 								a();
 							}
@@ -345,16 +345,16 @@ describe('prettier/index.js', () => {
 
 					// Disabled until we switch our ESLint ecmaVersion to '2019'.
 
-					it.skip('breaks before "catch" (without optional catch binding)', () => {
-						expect(
-							format(code`
+					it.skip('breaks before "catch" (without optional catch binding)', async () => {
+						const formatted = await format(code`
 							try {
 								b();
 							} catch {
 								c();
 							}
-					`)
-						).toBe(code`
+					`);
+
+						expect(formatted).toBe(code`
 							try {
 								b();
 							}
@@ -364,9 +364,8 @@ describe('prettier/index.js', () => {
 					`);
 					});
 
-					it('breaks before "finally" (after a "catch" handler)', () => {
-						expect(
-							format(code`
+					it('breaks before "finally" (after a "catch" handler)', async () => {
+						const formatted = await format(code`
 							try {
 								a();
 							} catch (error) {
@@ -374,8 +373,9 @@ describe('prettier/index.js', () => {
 							} finally {
 								dispose();
 							}
-					`)
-						).toBe(code`
+					`);
+
+						expect(formatted).toBe(code`
 							try {
 								a();
 							}
@@ -388,16 +388,16 @@ describe('prettier/index.js', () => {
 					`);
 					});
 
-					it('breaks before "finally" (when no "catch" handler)', () => {
-						expect(
-							format(code`
+					it('breaks before "finally" (when no "catch" handler)', async () => {
+						const formatted = await format(code`
 							try {
 								a();
 							} finally {
 								dispose();
 							}
-					`)
-						).toBe(code`
+					`);
+
+						expect(formatted).toBe(code`
 							try {
 								a();
 							}
@@ -407,13 +407,12 @@ describe('prettier/index.js', () => {
 					`);
 					});
 
-					it('copes with comments near "try"/"catch" constructs', () => {
+					it('copes with comments near "try"/"catch" constructs', async () => {
 
 						// Note: the movement of "comment 2" below is Prettier
 						// craziness and not the fault of our post-processor.
 
-						expect(
-							format(code`
+						const formatted = await format(code`
 							try {
 								a();
 							} /* comment 1 */ catch /* comment 2 */ (error) {
@@ -421,8 +420,9 @@ describe('prettier/index.js', () => {
 							} /* comment 3 */ finally /* comment 4 */ {
 								dispose();
 							}
-					`)
-						).toBe(code`
+					`);
+
+						expect(formatted).toBe(code`
 							try {
 								a();
 							} /* comment 1 */
@@ -435,9 +435,8 @@ describe('prettier/index.js', () => {
 					`);
 					});
 
-					it('copes with import statements', () => {
-						expect(
-							format(code`
+					it('copes with import statements', async () => {
+						const formatted = await format(code`
 							import {a, b} from './a';
 
 							if (test) {
@@ -445,8 +444,9 @@ describe('prettier/index.js', () => {
 							} else {
 								b();
 							}
-					`)
-						).toBe(code`
+					`);
+
+						expect(formatted).toBe(code`
 							import {a, b} from './a';
 
 							if (test) {
@@ -458,9 +458,8 @@ describe('prettier/index.js', () => {
 					`);
 					});
 
-					it('copes with static class properties', () => {
-						expect(
-							format(code`
+					it('copes with static class properties', async () => {
+						const formatted = await format(code`
 							class Thing extends React.Component {
 								static propTypes = {};
 
@@ -472,8 +471,9 @@ describe('prettier/index.js', () => {
 									}
 								}
 							}
-					`)
-						).toBe(code`
+					`);
+
+						expect(formatted).toBe(code`
 							class Thing extends React.Component {
 								static propTypes = {};
 
@@ -489,10 +489,9 @@ describe('prettier/index.js', () => {
 					`);
 					});
 
-					it('copes with JSX', () => {
+					it('copes with JSX', async () => {
 						if (extension === '.js' || extension === '.tsx') {
-							expect(
-								format(code`
+							const formatted = await format(code`
 							class Thing extends React.Component {
 								render() {
 									if (x()) {
@@ -502,8 +501,9 @@ describe('prettier/index.js', () => {
 									}
 								}
 							}
-					`)
-							).toBe(code`
+					`);
+
+							expect(formatted).toBe(code`
 							class Thing extends React.Component {
 								render() {
 									if (x()) {

--- a/projects/npm-tools/packages/npm-scripts/test/scripts/format.js
+++ b/projects/npm-tools/packages/npm-scripts/test/scripts/format.js
@@ -46,24 +46,27 @@ describe('scripts/format.js', () => {
 		process.chdir(cwd);
 	});
 
-	it('invokes check() on our prettier.check() wrapper', () => {
-		format();
+	it('invokes check() on our prettier.check() wrapper', async () => {
+		await format();
+
 		expect(prettier.check).toHaveBeenCalledWith(
 			source.js,
 			expect.objectContaining({filepath: 'src/example.js'})
 		);
 	});
 
-	it('invokes format() on our prettier.format() wrapper', () => {
-		format();
+	it('invokes format() on our prettier.format() wrapper', async () => {
+		await format();
+
 		expect(prettier.format).toHaveBeenCalledWith(
 			source.js,
 			expect.objectContaining({filepath: 'src/example.js'})
 		);
 	});
 
-	it('invokes formatJSP()', () => {
-		format();
+	it('invokes formatJSP()', async () => {
+		await format();
+
 		expect(formatJSP).toHaveBeenCalledWith(
 			source.jsp,
 			expect.objectContaining({filepath: 'src/example.jsp'})
@@ -81,20 +84,23 @@ describe('scripts/format.js', () => {
 			fs.writeFileSync('npmscripts.config.js', config);
 		});
 
-		it('logs a message indicating how to configure globs', () => {
-			format();
+		it('logs a message indicating how to configure globs', async () => {
+			await format();
+
 			expect(log).toHaveBeenCalledWith(
 				expect.stringContaining('No globs applicable')
 			);
 		});
 
-		it('does not invoke prettier.check', () => {
-			format();
+		it('does not invoke prettier.check', async () => {
+			await format();
+
 			expect(prettier.check).not.toHaveBeenCalled();
 		});
 
-		it('does not invoke formatJSP', () => {
-			format();
+		it('does not invoke formatJSP', async () => {
+			await format();
+
 			expect(formatJSP).not.toHaveBeenCalled();
 		});
 	});

--- a/projects/npm-tools/packages/npm-scripts/test/utils/minify.js
+++ b/projects/npm-tools/packages/npm-scripts/test/utils/minify.js
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const minify = require('../../src/utils/minify');
+
+describe('minify()', () => {
+	let cwd;
+	let temp;
+
+	beforeEach(() => {
+		cwd = process.cwd();
+
+		temp = fs.mkdtempSync(path.join(os.tmpdir(), 'format-'));
+
+		process.chdir(temp);
+
+		fs.mkdirSync('build');
+		fs.mkdirSync('build/node');
+		fs.mkdirSync('build/node/packageRunBuild');
+		fs.mkdirSync('build/node/packageRunBuild/resources');
+
+		fs.mkdirSync('classes');
+		fs.mkdirSync('classes/resources');
+
+		fs.writeFileSync(
+			'build/node/packageRunBuild/resources/script.js',
+			`
+			alert( 'minify this' );
+		`
+		);
+
+		fs.writeFileSync(
+			'classes/resources/page.jsp',
+			`
+			<h1>Hi</h1>
+
+			<script>
+				alert( 'minify this too' );
+			</script>
+		`
+		);
+	});
+
+	afterEach(() => {
+		process.chdir(cwd);
+	});
+
+	it('minifies JS in a JS file in the "build/" directory', async () => {
+		await minify();
+
+		expect(
+			fs.readFileSync(
+				'build/node/packageRunBuild/resources/script.js',
+				'utf8'
+			)
+		).toBe(
+			'alert("minify this");\n' + '//# sourceMappingURL=script.js.map'
+		);
+	});
+
+	it('creates a source map for a JS file in the "build/" directory', async () => {
+		await minify();
+
+		expect(
+			JSON.parse(
+				fs.readFileSync(
+					'build/node/packageRunBuild/resources/script.js.map',
+					'utf8'
+				)
+			)
+		).toEqual(
+			expect.objectContaining({
+				mappings: expect.anything(),
+				names: expect.anything(),
+				sources: expect.anything(),
+				version: expect.anything(),
+			})
+		);
+	});
+
+	it('minifies JS in a JSP file in the "classes/" directory', async () => {
+		await minify();
+
+		expect(fs.readFileSync('classes/resources/page.jsp', 'utf8')).toBe(`
+			<h1>Hi</h1>
+
+			<script>alert("minify this too");</script>
+		`);
+	});
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -13967,6 +13967,15 @@ terser-webpack-plugin@^5.0.3:
     source-map "^0.6.1"
     terser "^5.3.8"
 
+terser@5.3.8, terser@^5.3.8:
+  version "5.3.8"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.3.8.tgz#991ae8ba21a3d990579b54aa9af11586197a75dd"
+  integrity sha512-zVotuHoIfnYjtlurOouTazciEfL7V38QMAOhGqpXDEg6yT13cF4+fEP9b0rrCEQTn+tT46uxgFsTZzhygk+CzQ==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.7.2"
+    source-map-support "~0.5.19"
+
 terser@^4.6.3:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
@@ -13975,15 +13984,6 @@ terser@^4.6.3:
     commander "^2.20.0"
     source-map "~0.6.1"
     source-map-support "~0.5.12"
-
-terser@^5.3.8:
-  version "5.3.8"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.3.8.tgz#991ae8ba21a3d990579b54aa9af11586197a75dd"
-  integrity sha512-zVotuHoIfnYjtlurOouTazciEfL7V38QMAOhGqpXDEg6yT13cF4+fEP9b0rrCEQTn+tT46uxgFsTZzhygk+CzQ==
-  dependencies:
-    commander "^2.20.0"
-    source-map "~0.7.2"
-    source-map-support "~0.5.19"
 
 test-exclude@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
~This is a far-from-finished WIP, but parking it here anyway for safe-keeping:~ (upgrading this from WIP to POC)

Final status:

-    [Discussed in Slack here](https://liferay.slack.com/archives/C04D8HMEF/p1606233408059000):
    -   The JS-in-JSP minification works if you run `yarn build` by hand, but when run as part of a `gradle` invocation the jobs happen in the wrong order for our purposes — we can't minify the JS in JSP in `classes/` because it only gets put there _after_ `packageRunBuild`. The conclusion of the Slack thread is that we can leave the code in here as a kind of benign no-op, and if we decide to prioritize the necessary changes on the Gradle side it will "magically" start working. If it's still there months from now and it looks like we're never going to get to it we can just rip it out.
    
        Excerpts from the Slack thread:
    
        > its possible
        >
        > we would need to change the src path to the new output files first when we compile
        >
        > and also replace the jsps used to build the jars
    
        and:
    
        > in terms of whether or not it's worth doing. my quick-and-dirty metrics show that for typical JS we see a reduction of about 42.7% (in pre-gzip byte count), and in terms of how much JS-in-JSP we have on the table, at the moment it is about this much under modules/:
        >
        > - Files: 890
        > - Tags: 1102 (<script> or <aui:script>)
        > - Lines: 43634 (inside tags)
        > - Bytes: 1237555 (inside tags)
        >
        > so, at the moment with runtime minification done by the Java JS minifier, we get a fair bit of compression for that stuff, but once LPS-122883 is done the expectation is that we turn runtime minification off by default and do it all ahead of time as I'm describing above.

-   Also discussed release [here](https://liferay.slack.com/archives/G3JBR21HA/p1606290393489100). I still haven't got source maps working, but so as to keep this rolling forward I am going to proceed with the merge and fast-follow with a fix as soon as I find it. Otherwise this could drag on for days or more.

---

Here's the gist. This implements the first couple of parts of the idea described [in the research doc](https://docs.google.com/document/d/1JYSSSVFQlEwy1CRv1ZD6hfql8AzuXTS39qY5HMnvUe4/edit).

Namely, if we're not in development mode, we pre-minify JS resources before they are served. Using [Terser](https://www.npmjs.com/package/terser) because it's the current king (16.7 M weekly downloads) and the former champion (Uglify) is no longer maintained. [babel-minify](https://github.com/babel/minify) is still labeled as in beta and sees little activity. For some more context, [here is a comparison from 2019](https://blog.logrocket.com/uglify-vs-babel-minify-vs-terser-a-mini-battle-royale/).

![Screenshot 2020-11-11 -143053-7SdueySE@2x](https://user-images.githubusercontent.com/7074/100201684-9fa79e80-2f00-11eb-9e0d-1e4dce5f2ff3.png)

At the moment, I developed this just enough to get some numbers. Here is what we see in `frontend-js-react-web`, which is a good example of an OSGi module containing some "own JS" + dependencies in `node_modules`.

    Summary:
      Files minified:    806
      Files with errors: 169
      Before size:       3561639
      After size:        878708
      Delta:             2682931
      Elapsed:           8.88

Sizes are just raw bytes, ignoring gzip, so the "real" size in a production environment would be much less, obviously (but so will the savings).

Lots of files with errors, but at a glance, most of those look legit, because our bundler will take every file in the graph and AMD wrap it even if it shouldn't be wrapped (due to config, or whatever), so we wind up with illegal JS in the JAR that will never get used (like files with `import` statements inside AMD factory definitions).

The approach is to minify all the JS as a last step in the build process. This way we cover JS that came in from `yarn install` and the bundler, JS that we wrote and built with Babel, and even JS that came out of webpack. This way we don't have to figure out how to jam a minifier into three places, and it also means that we might be able to do some better minification (eg. by minifying pre-bundled source where we are more likely to be able to detect useful amounts of dead code etc). Note that this also helps "future proof" us a little bit for the arrival of Bundler v3 or v4 or whatever it ends up being called, because the approach can be applied there as well with few or no modifications.

Sub-tasks:

- [x] Try this out on other modules.
- [x] Actually write out the changed files.
- [x] Investigate errors to be sure they are all benign like I think they are.
- [x] Tweak Terser settings to strike right balance of aggressive/small and safe/stable.
- [x] More documentation here (like, on why Terser etc).
- [x] Minify JS in JSP.
- [x] Check/tweak comment/whitespace handling (for JS in JSP).
- [x] Add unit tests.
- [x] Get before and after numbers across DXP to get sense of expected benefit.
- [x] Update this description with "final" status.