### PR TITLE
feat(npm-scripts): add jest mock for createRange and createContextualFragment

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/jest/setup.js
+++ b/projects/npm-tools/packages/npm-scripts/src/jest/setup.js
@@ -10,3 +10,22 @@ global.Liferay = require('./mocks/Liferay');
 global.fetch = require('jest-fetch-mock');
 
 global.themeDisplay = global.Liferay.ThemeDisplay;
+
+if (!global.createRange) {
+	global.createRange = () => ({
+		createContextualFragment(htmlString) {
+			const tempDiv = document.createElement('div'); // eslint-disable-line no-undef
+
+			tempDiv.innerHTML = `<br>${htmlString}`;
+			tempDiv.removeChild(tempDiv.firstChild);
+
+			const fragment = document.createDocumentFragment(); // eslint-disable-line no-undef
+
+			while (tempDiv.firstChild) {
+				fragment.appendChild(tempDiv.firstChild);
+			}
+
+			return fragment;
+		},
+	});
+}

--- a/projects/npm-tools/packages/npm-scripts/src/jest/setup.js
+++ b/projects/npm-tools/packages/npm-scripts/src/jest/setup.js
@@ -7,10 +7,6 @@ global.Headers = require('./mocks/Headers');
 
 global.Liferay = require('./mocks/Liferay');
 
-global.fetch = require('jest-fetch-mock');
-
-global.themeDisplay = global.Liferay.ThemeDisplay;
-
 if (!global.createRange) {
 	global.createRange = () => ({
 		createContextualFragment(htmlString) {
@@ -29,3 +25,7 @@ if (!global.createRange) {
 		},
 	});
 }
+
+global.fetch = require('jest-fetch-mock');
+
+global.themeDisplay = global.Liferay.ThemeDisplay;

--- a/projects/npm-tools/packages/npm-scripts/src/jest/setup.js
+++ b/projects/npm-tools/packages/npm-scripts/src/jest/setup.js
@@ -9,6 +9,9 @@ global.Headers = require('./mocks/Headers');
 
 global.Liferay = require('./mocks/Liferay');
 
+// Temporary `createRange` mock until we update Jest 26 and jsdom >= 16.
+// See: https://github.com/liferay/liferay-frontend-projects/issues/46
+
 if (!global.createRange) {
 	global.createRange = () => ({
 		createContextualFragment(htmlString) {

--- a/projects/npm-tools/packages/npm-scripts/src/jest/setup.js
+++ b/projects/npm-tools/packages/npm-scripts/src/jest/setup.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+/* eslint-env browser */
+
 global.Headers = require('./mocks/Headers');
 
 global.Liferay = require('./mocks/Liferay');
@@ -10,12 +12,12 @@ global.Liferay = require('./mocks/Liferay');
 if (!global.createRange) {
 	global.createRange = () => ({
 		createContextualFragment(htmlString) {
-			const div = document.createElement('div'); // eslint-disable-line no-undef
+			const div = document.createElement('div');
 
 			div.innerHTML = `<br>${htmlString}`;
 			div.removeChild(div.firstChild);
 
-			const fragment = document.createDocumentFragment(); // eslint-disable-line no-undef
+			const fragment = document.createDocumentFragment();
 
 			while (div.firstChild) {
 				fragment.appendChild(div.firstChild);

--- a/projects/npm-tools/packages/npm-scripts/src/jest/setup.js
+++ b/projects/npm-tools/packages/npm-scripts/src/jest/setup.js
@@ -10,15 +10,15 @@ global.Liferay = require('./mocks/Liferay');
 if (!global.createRange) {
 	global.createRange = () => ({
 		createContextualFragment(htmlString) {
-			const tempDiv = document.createElement('div'); // eslint-disable-line no-undef
+			const div = document.createElement('div'); // eslint-disable-line no-undef
 
-			tempDiv.innerHTML = `<br>${htmlString}`;
-			tempDiv.removeChild(tempDiv.firstChild);
+			div.innerHTML = `<br>${htmlString}`;
+			div.removeChild(div.firstChild);
 
 			const fragment = document.createDocumentFragment(); // eslint-disable-line no-undef
 
-			while (tempDiv.firstChild) {
-				fragment.appendChild(tempDiv.firstChild);
+			while (div.firstChild) {
+				fragment.appendChild(div.firstChild);
 			}
 
 			return fragment;


### PR DESCRIPTION
This PR has a handful of failing unit tests due to createRange not existing in js-dom. Rather than add a setupfile for each module to include this, I figured its best to have as a global mock.

https://github.com/liferay-frontend/liferay-portal/pull/468