### PR TITLE
feat(monorepo): complain if lockfile is not fresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,27 @@ env:
     yarn-cache-path: .yarn
 
 jobs:
+    check-lockfile:
+        runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                node-version: [12.x]
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v1
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - name: Use or update Yarn cache
+              uses: actions/cache@v2
+              with:
+                  path: ${{ env.yarn-cache-path }}
+                  key: ${{ runner.os }}-${{ env.yarn-cache-name }}-${{ hashFiles('**/yarn.lock') }}
+            - run: yarn --cache-folder=${{ env.yarn-cache-path }}
+            - run: git diff --quiet -- yarn.lock
+
     format-check:
         runs-on: ubuntu-latest
 


### PR DESCRIPTION
This should ensure that we don't run into the kind of issue [mentioned here](https://github.com/liferay/liferay-frontend-projects/pull/233#issuecomment-727938944).

Note that `--frozen-lockfile` is supposed to take care of this for us, but it is [a known issue](https://github.com/yarnpkg/yarn/issues/5840) that it doesn't work properly in monorepos. There is [a fix for it](https://github.com/yarnpkg/yarn/pull/6554), but the issue is nearly two years old and the PR is almost as old. Maintainer [replies here](https://github.com/yarnpkg/yarn/pull/6554#issuecomment-532667774) that:

> The change appears sound, but we're currently working on the v2 (scheduled before the end of the year) and I'm somewhat worried about introducing subtle bugs right before releasing the next major (the way I see it, the current v1 is, despite its shortcomings, relatively stable)."

We face a similar concern in liferay-portal and have [an LPS ticket](https://issues.liferay.com/browse/LPS-110313) for that.

    