### PR TITLE
fix(npm-scripts): provide (inactive-by-default) tooling for formatting JS in JSP inside build

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/jsp/padLines.js
+++ b/projects/npm-tools/packages/npm-scripts/src/jsp/padLines.js
@@ -15,7 +15,7 @@ const PADDING_MARKER = '\u00abpad\u00bb';
  */
 const DEFAULT_PADDING = `void 0; /* ${PADDING_MARKER} */`;
 
-const PADDING_LINE = /(?:\s*void\s+0;\s*)?\/\*\s*\u00abpad\u00bb\s*\*\/\n/g;
+const PADDING_LINE = /(?:\s*void\s+0;?\s*)?\/\*\s*\u00abpad\u00bb\s*\*\/\n?/g;
 
 /**
  * Prefixes `string` with lines containing the `padding` string such that the

--- a/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
@@ -89,6 +89,7 @@ async function minify() {
 								// Add `beautify: true` here to debug tests, if
 								// necessary.
 
+								braces: true,
 								comments: JSP_COMMENT_REGEXP,
 							},
 

--- a/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
@@ -81,61 +81,7 @@ async function minify() {
 							// "hidden" code (via interpolation).
 
 							compress: {
-
-								// Start with all minification off.
-
 								defaults: false,
-
-								// Turn most things back on.
-
-								arrows: true,
-								booleans: true,
-								collapse_vars: true,
-								comparisons: true,
-								computed_props: true,
-								conditionals: true,
-								dead_code: true,
-								directives: true,
-								drop_debugger: true,
-								ecma: 5,
-								evaluate: true,
-								hoist_props: true,
-								if_return: true,
-								inline: true,
-								keep_fargs: true,
-								loops: true,
-								negate_iife: true,
-								passes: 1,
-								properties: true,
-								pure_getters: 'strict',
-								reduce_vars: true,
-								side_effects: true,
-								switches: true,
-								typeofs: true,
-
-								// Turn this one back off because it reorders
-								// statements/expressions and breaks our
-								// substitution and restoration of JSP syntax.
-
-								sequences: false,
-
-								//
-								// And for similar reasons, this one
-								// (which would join multiple variable
-								// declarations together with comma)
-								// needs to be off too, because it can re-order
-								// and move things.
-								//
-
-								join_vars: false,
-
-								//
-								// Not safe to drop "unused" functions and
-								// variables in JSP because usage may be
-								// invisible.
-								//
-
-								unused: false,
 							},
 
 							format: {

--- a/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
@@ -25,11 +25,16 @@ const MINIFIER_CONFIG = getMergedConfig('terser');
 
 const MINIFY_GLOBS = [
 	path.posix.join(BUILD, '**', '*.js'),
-	path.posix.join(BUILD, '**', '*.jsp'),
-	path.posix.join(BUILD, '**', '*.jspf'),
 	'!*-min.js',
 	'!*.min.js',
 ];
+
+if (process.env.MINIFY_JSP) {
+	MINIFY_GLOBS.push(
+		path.posix.join(BUILD, '**', '*.jsp'),
+		path.posix.join(BUILD, '**', '*.jspf')
+	);
+}
 
 /**
  * We need to keep "special" JSP comments so that we can reverse the various

--- a/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
@@ -71,16 +71,55 @@ async function minify() {
 			const processed = await processJSP(contents, {
 				async onMinify(input) {
 					try {
+						/* eslint-disable sort-keys */
+
 						const result = await terser(input, {
 							...MINIFIER_CONFIG,
 
-							// We can't risk renaming anything because
-							// JSP's may contain "hidden" code (via
-							// interpolation).
+							// We can't risk renaming or reordering
+							// anything because JSP's may contain
+							// "hidden" code (via interpolation).
 
 							compress: {
-								keep_classnames: true,
-								keep_fnames: true,
+
+								// Start with all minification off.
+
+								defaults: false,
+
+								// Turn most things back on.
+
+								arrows: true,
+								booleans: true,
+								collapse_vars: true,
+								comparisons: true,
+								computed_props: true,
+								conditionals: true,
+								dead_code: true,
+								directives: true,
+								drop_debugger: true,
+								ecma: 5,
+								evaluate: true,
+								hoist_props: true,
+								if_return: true,
+								inline: true,
+								join_vars: true,
+								keep_fargs: true,
+								loops: true,
+								negate_iife: true,
+								passes: 1,
+								properties: true,
+								pure_getters: 'strict',
+								reduce_vars: true,
+								side_effects: true,
+								switches: true,
+								typeofs: true,
+								unused: true,
+
+								// Turn this one back off because it reorders
+								// statements/expressions and breaks our
+								// substitution and restoration of JSP syntax.
+
+								sequences: false,
 							},
 
 							format: {
@@ -89,6 +128,8 @@ async function minify() {
 
 							mangle: false,
 						});
+
+						/* eslint-enable sort-keys */
 
 						return result.code;
 					}

--- a/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
@@ -102,7 +102,6 @@ async function minify() {
 								hoist_props: true,
 								if_return: true,
 								inline: true,
-								join_vars: true,
 								keep_fargs: true,
 								loops: true,
 								negate_iife: true,
@@ -113,16 +112,37 @@ async function minify() {
 								side_effects: true,
 								switches: true,
 								typeofs: true,
-								unused: true,
 
 								// Turn this one back off because it reorders
 								// statements/expressions and breaks our
 								// substitution and restoration of JSP syntax.
 
 								sequences: false,
+
+								//
+								// And for similar reasons, this one
+								// (which would join multiple variable
+								// declarations together with comma)
+								// needs to be off too, because it can re-order
+								// and move things.
+								//
+
+								join_vars: false,
+
+								//
+								// Not safe to drop "unused" functions and
+								// variables in JSP because usage may be
+								// invisible.
+								//
+
+								unused: false,
 							},
 
 							format: {
+
+								// Add `beautify: true` here to debug tests, if
+								// necessary.
+
 								comments: JSP_COMMENT_REGEXP,
 							},
 

--- a/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/minify.js
@@ -21,14 +21,12 @@ const BUILD_CONFIG = getMergedConfig('npmscripts', 'build');
 
 const BUILD = BUILD_CONFIG.output;
 
-const CLASSES = BUILD.replace(/^build\/.*/, 'classes/');
-
 const MINIFIER_CONFIG = getMergedConfig('terser');
 
 const MINIFY_GLOBS = [
 	path.posix.join(BUILD, '**', '*.js'),
-	path.posix.join(CLASSES, '**', '*.jsp'),
-	path.posix.join(CLASSES, '**', '*.jspf'),
+	path.posix.join(BUILD, '**', '*.jsp'),
+	path.posix.join(BUILD, '**', '*.jspf'),
 	'!*-min.js',
 	'!*.min.js',
 ];

--- a/projects/npm-tools/packages/npm-scripts/test/jsp/padLines.js
+++ b/projects/npm-tools/packages/npm-scripts/test/jsp/padLines.js
@@ -32,13 +32,25 @@ describe('padLines()', () => {
 
 	it('can strip padding comments even after minification', () => {
 
-		// Minification strips the "void 0;" statements, but we can still remove
-		// the comments.
+		// Minification may strip or alter the "void 0;" statements, but
+		// we can still remove the comments.
 
 		expect(
 			(
+				'void 0; /* «pad» */\n' +
+				'void 0; /* «pad» */' +
+				'void 0;/* «pad» */\n' +
+				'void 0;/* «pad» */' +
+				'void 0 /* «pad» */\n' +
+				'void 0 /* «pad» */' +
+				'void 0/* «pad» */\n' +
+				'void 0/* «pad» */' +
 				'/* «pad» */\n' +
 				'/* «pad» */\n' +
+				'/* «pad» */\n' +
+				'/* «pad» */' +
+				'/* «pad» */' +
+				'/* «pad» */' +
 				'someCode();\n' +
 				'otherCode();'
 			).replace(padLines.PADDING_LINE, '')

--- a/projects/npm-tools/packages/npm-scripts/test/utils/minify.js
+++ b/projects/npm-tools/packages/npm-scripts/test/utils/minify.js
@@ -96,42 +96,104 @@ describe('minify()', () => {
 		`);
 	});
 
-	// Regression test.
-	// See: https://github.com/liferay/liferay-frontend-projects/pull/251
+	describe('regressions documented in https://github.com/liferay/liferay-frontend-projects/pull/251', () => {
+		it('does not reorder or merge statements during minification', async () => {
 
-	it('does not re-order JSP syntax during minification', async () => {
+			// Reduced example from site-navigation-menu-web's configuration.jsp.
 
-		// Reduced example from site-navigation-menu-web's configuration.jsp.
-
-		fs.writeFileSync(
-			'build/node/packageRunBuild/resources/configuration.jsp',
-			`
-				<aui:script>
-					var form = document.<portlet:namespace />fm;
-
-					form.addEventListener('change', <portlet:namespace />resetPreview);
-
-					function <portlet:namespace />resetPreview() {
-						// Terser was hosting this function to the top,
-						// causing the JSP expressions and namespace
-						// tags to get restored back into the wrong
-						// slots.
-
-						var data = Liferay.Util.ns('_<%= HtmlUtil.escapeJS(portletResource) %>_', data);
-					}
-				</aui:script>
-		`
-		);
-
-		await minify();
-
-		expect(
-			fs.readFileSync(
+			fs.writeFileSync(
 				'build/node/packageRunBuild/resources/configuration.jsp',
-				'utf8'
-			)
-		).toBe(`
-				<aui:script>var form=document.<portlet:namespace />fm;form.addEventListener("change",<portlet:namespace />resetPreview);function <portlet:namespace />resetPreview(){var data=Liferay.Util.ns("_<%= HtmlUtil.escapeJS(portletResource) %>_",data)}</aui:script>
-		`);
+				`
+					<aui:script>
+						var form = document.<portlet:namespace />fm;
+
+						form.addEventListener('change', <portlet:namespace />resetPreview);
+
+						function <portlet:namespace />resetPreview() {
+							// Terser was hoisting this function to the top,
+							// causing the JSP expressions and namespace
+							// tags to get restored back into the wrong
+							// slots.
+
+							var data = Liferay.Util.ns('_<%= HtmlUtil.escapeJS(portletResource) %>_', data);
+						}
+					</aui:script>
+			`
+			);
+
+			await minify();
+
+			expect(
+				fs.readFileSync(
+					'build/node/packageRunBuild/resources/configuration.jsp',
+					'utf8'
+				)
+			).toBe(`
+					<aui:script>var form=document.<portlet:namespace />fm;form.addEventListener("change",<portlet:namespace />resetPreview);function <portlet:namespace />resetPreview(){var data=Liferay.Util.ns("_<%= HtmlUtil.escapeJS(portletResource) %>_",data)}</aui:script>
+			`);
+		});
+
+		it('does not reorder or merge variable declarations during minification', async () => {
+
+			// Reduced example from journal-web's template.jsp.
+
+			fs.writeFileSync(
+				'build/node/packageRunBuild/resources/template.jsp',
+				`
+					<aui:script>
+							previewWithTemplate.addEventListener('click', function (event) {
+								var url = '<%= previewArticleContentTemplateURL %>';
+
+								// Terser was merging the declarations
+								// of "url" and "ddmTemplateId" into
+								// a single statement, using a comma,
+								// which caused the multiline JSP
+								// scriptlet below to be inlined into
+								// a string, produce invalid syntax (a
+								// multiline string).
+
+								<%
+								long ddmTemplateId = 0;
+
+								if (ddmTemplate != null) {
+									if (ddmTemplate.getTemplateId() == 0) {
+										ddmTemplateId = -1;
+									}
+									else {
+										ddmTemplateId = ddmTemplate.getTemplateId();
+									}
+								}
+								%>
+
+								var ddmTemplateId = '<%= ddmTemplateId %>';
+							});
+					</aui:script>
+				`
+			);
+
+			await minify();
+
+			expect(
+				fs.readFileSync(
+					'build/node/packageRunBuild/resources/template.jsp',
+					'utf8'
+				)
+			).toBe(`
+					<aui:script>previewWithTemplate.addEventListener("click",(function(event){var url="<%= previewArticleContentTemplateURL %>";
+
+<%
+long ddmTemplateId = 0;
+
+if (ddmTemplate != null) {
+	if (ddmTemplate.getTemplateId() == 0) {
+		ddmTemplateId = -1;
+	}
+	else {
+		ddmTemplateId = ddmTemplate.getTemplateId();
+	}
+}
+%>var ddmTemplateId="<%= ddmTemplateId %>"}));</aui:script>
+				`);
+		});
 	});
 });

--- a/projects/npm-tools/packages/npm-scripts/test/utils/minify.js
+++ b/projects/npm-tools/packages/npm-scripts/test/utils/minify.js
@@ -81,22 +81,94 @@ describe('minify()', () => {
 		);
 	});
 
-	it('minifies JS in a JSP file in the "build/" directory', async () => {
-		await minify();
+	describe('when MINIFY_JSP is not set', () => {
+		let MINIFY_JSP;
+		let minify;
 
-		expect(
-			fs.readFileSync(
-				'build/node/packageRunBuild/resources/page.jsp',
-				'utf8'
-			)
-		).toBe(`
+		beforeEach(() => {
+			MINIFY_JSP = process.env.MINIFY_JSP;
+
+			delete process.env.MINIFY_JSP;
+
+			jest.resetModules();
+
+			minify = require('../../src/utils/minify');
+		});
+
+		afterEach(() => {
+			process.env.MINIFY_JSP = MINIFY_JSP;
+		});
+
+		it('does not minify JS in a JSP file in the "build/" directory', async () => {
+			await minify();
+
+			expect(
+				fs.readFileSync(
+					'build/node/packageRunBuild/resources/page.jsp',
+					'utf8'
+				)
+			).toBe(`
+			<h1>Hi</h1>
+
+			<script>
+				alert( 'minify this too' );
+			</script>
+		`);
+		});
+	});
+
+	describe('when MINIFY_JSP is set', () => {
+		let MINIFY_JSP;
+		let minify;
+
+		beforeEach(() => {
+			MINIFY_JSP = process.env.MINIFY_JSP;
+
+			process.env.MINIFY_JSP = '1';
+
+			jest.resetModules();
+
+			minify = require('../../src/utils/minify');
+		});
+
+		afterEach(() => {
+			process.env.MINIFY_JSP = MINIFY_JSP;
+		});
+
+		it('minifies JS in a JSP file in the "build/" directory', async () => {
+			await minify();
+
+			expect(
+				fs.readFileSync(
+					'build/node/packageRunBuild/resources/page.jsp',
+					'utf8'
+				)
+			).toBe(`
 			<h1>Hi</h1>
 
 			<script>alert("minify this too");</script>
 		`);
+		});
 	});
 
 	describe('regressions documented in https://github.com/liferay/liferay-frontend-projects/pull/251', () => {
+		let MINIFY_JSP;
+		let minify;
+
+		beforeEach(() => {
+			MINIFY_JSP = process.env.MINIFY_JSP;
+
+			process.env.MINIFY_JSP = '1';
+
+			jest.resetModules();
+
+			minify = require('../../src/utils/minify');
+		});
+
+		afterEach(() => {
+			process.env.MINIFY_JSP = MINIFY_JSP;
+		});
+
 		it('does not reorder or merge statements during minification', async () => {
 
 			// Reduced example from site-navigation-menu-web's configuration.jsp.

--- a/projects/npm-tools/packages/npm-scripts/test/utils/minify.js
+++ b/projects/npm-tools/packages/npm-scripts/test/utils/minify.js
@@ -25,9 +25,6 @@ describe('minify()', () => {
 		fs.mkdirSync('build/node/packageRunBuild');
 		fs.mkdirSync('build/node/packageRunBuild/resources');
 
-		fs.mkdirSync('classes');
-		fs.mkdirSync('classes/resources');
-
 		fs.writeFileSync(
 			'build/node/packageRunBuild/resources/script.js',
 			`
@@ -36,7 +33,7 @@ describe('minify()', () => {
 		);
 
 		fs.writeFileSync(
-			'classes/resources/page.jsp',
+			'build/node/packageRunBuild/resources/page.jsp',
 			`
 			<h1>Hi</h1>
 
@@ -84,10 +81,15 @@ describe('minify()', () => {
 		);
 	});
 
-	it('minifies JS in a JSP file in the "classes/" directory', async () => {
+	it('minifies JS in a JSP file in the "build/" directory', async () => {
 		await minify();
 
-		expect(fs.readFileSync('classes/resources/page.jsp', 'utf8')).toBe(`
+		expect(
+			fs.readFileSync(
+				'build/node/packageRunBuild/resources/page.jsp',
+				'utf8'
+			)
+		).toBe(`
 			<h1>Hi</h1>
 
 			<script>alert("minify this too");</script>

--- a/projects/npm-tools/packages/npm-scripts/test/utils/minify.js
+++ b/projects/npm-tools/packages/npm-scripts/test/utils/minify.js
@@ -195,5 +195,29 @@ if (ddmTemplate != null) {
 %>var ddmTemplateId="<%= ddmTemplateId %>"}));</aui:script>
 				`);
 		});
+
+		it('preserves braces', async () => {
+			fs.writeFileSync(
+				'build/node/packageRunBuild/resources/configuration.jsp',
+				`
+					<aui:script>
+						if (something()) {
+							proceed();
+						}
+					</aui:script>
+			`
+			);
+
+			await minify();
+
+			expect(
+				fs.readFileSync(
+					'build/node/packageRunBuild/resources/configuration.jsp',
+					'utf8'
+				)
+			).toBe(`
+					<aui:script>if(something()){proceed()}</aui:script>
+			`);
+		});
 	});
 });


### PR DESCRIPTION
Just testing the [claim made in this Slack thread](https://liferay.slack.com/archives/C04D8HMEF/p1606323974062700?thread_ts=1606233408.059000&cid=C04D8HMEF) that the reason why my earlier attempts to minify-in-place inside "build/" may have seemed to not be working due to Gradle caching.

While the cache may cause problems, I am skeptical that this will work because in my testing I found that `processResources` happens too late (after `npm-scripts` runs), but in the interests of thoroughness I am going to try this out and test it in a full `ant all` run anyway.

---

Final summary: we tested this out and the minify-in-`build/` trick does work, but even with minification turned way down to avoid reordering issues, testing in DXP shows that it is too risky to turn on by default (for example, we see other parts of the toolchain choking as a result of tags + lines following each other on the same line — probably something we could work around with some careful semicolon insertion, but it would be very fiddly...). So last commit in this PR gates the functionality behind an environment variable which will be empty by default.