### PR TITLE
feat(npm-scripts): add `@function` and `@return` to list of stylelint at-rules

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/config/stylelint.json
+++ b/projects/npm-tools/packages/npm-scripts/src/config/stylelint.json
@@ -10,12 +10,15 @@
 					"else",
 					"extend",
 					"for",
+					"forward",
 					"function",
 					"if",
 					"include",
 					"mixin",
 					"return",
-					"warn"
+					"use",
+					"warn",
+					"while"
 				]
 			}
 		],

--- a/projects/npm-tools/packages/npm-scripts/src/config/stylelint.json
+++ b/projects/npm-tools/packages/npm-scripts/src/config/stylelint.json
@@ -10,9 +10,11 @@
 					"else",
 					"extend",
 					"for",
+					"function",
 					"if",
 					"include",
 					"mixin",
+					"return",
 					"warn"
 				]
 			}


### PR DESCRIPTION
Came up in [this Slack thread](https://liferay.slack.com/archives/CNBG06JS3/p1606416319333100).

We decided to add the `at-rule-no-unknown` rule [here](https://github.com/liferay/liferay-npm-tools/issues/344#issuecomment-576756682) and customized the whitelist of allowed rules [here](https://github.com/liferay/liferay-npm-tools/pull/347/commits/be48c275d5377a1b1f1a0cb34a37a1c807c1846c) based on the built-in rules that come with Sass and that were currently in use in DXP at the time.

@eduardoallegrini [says](https://liferay.slack.com/archives/CNBG06JS3/p1606466305337500?thread_ts=1606416319.333100&cid=CNBG06JS3) that `@function` is kosher to add to the list, although the truth is we may not need it in many places. Right now `master` has exactly one usage and one corresponding lint suppression.

#### Test plan

Add a `@function` containing a `@return` to an .scss file in DXP and run linter (`yarn run checkFormat`):

    Example.scss
      7:1  error  Unexpected unknown at-rule "@function" (at-rule-no-unknown)  at-rule-no-unknown
      9:3  error  Unexpected unknown at-rule "@return" (at-rule-no-unknown)  at-rule-no-unknown

Then apply the change in this commit and re-run; see no errors.

Closes: https://github.com/liferay/liferay-frontend-projects/issues/253