### PR TITLE
feat(js-toolkit): RequireCapability: convert package.json version classfier to OSGi version classifer

### DIFF
--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/index.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/index.js
@@ -12,6 +12,7 @@ import path from 'path';
 
 import * as ddm from './ddm';
 import Manifest from './manifest';
+import * as osgi from './osgi';
 import * as xml from './xml';
 
 const pkgJson = project.pkgJson;
@@ -100,7 +101,7 @@ function addLocalizationFiles(zip) {
  * @param {JSZip} zip the ZIP file
  */
 function addManifest(zip) {
-	const bundleVersion = getBundleVersionAndClassifier(pkgJson.version);
+	const bundleVersion = osgi.getBundleVersionAndClassifier(pkgJson.version);
 
 	const manifest = new Manifest();
 
@@ -301,19 +302,4 @@ function getSystemConfigurationJson() {
 	}
 
 	return configurationJson.system;
-}
-
-/**
- * Get the OSGi bundle version from the package.json version. Respects
- * the different types of version classifiers.
- * @return {object}
- */
-function getBundleVersionAndClassifier(pkgJsonVersion) {
-	const parts = pkgJsonVersion.split('-');
-	if (parts.length > 1) {
-		return parts[0] + '.' + parts.slice(1).join('-');
-	}
-	else {
-		return pkgJsonVersion;
-	}
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/index.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/index.js
@@ -100,10 +100,12 @@ function addLocalizationFiles(zip) {
  * @param {JSZip} zip the ZIP file
  */
 function addManifest(zip) {
+	const bundleVersion = getBundleVersionAndClassifier(pkgJson.version);
+
 	const manifest = new Manifest();
 
 	manifest.bundleSymbolicName = pkgJson.name;
-	manifest.bundleVersion = pkgJson.version;
+	manifest.bundleVersion = bundleVersion;
 	if (pkgJson.description) {
 		manifest.bundleName = pkgJson.description;
 	}
@@ -112,7 +114,7 @@ function addManifest(zip) {
 
 	manifest.addProvideCapability(
 		'osgi.webresource',
-		`osgi.webresource=${pkgJson.name};version:Version="${pkgJson.version}"`
+		`osgi.webresource=${pkgJson.name};version:Version="${bundleVersion}"`
 	);
 
 	if (project.l10n.supported) {
@@ -299,4 +301,19 @@ function getSystemConfigurationJson() {
 	}
 
 	return configurationJson.system;
+}
+
+/**
+ * Get the OSGi bundle version from the package.json version. Respects
+ * the different types of version classifiers.
+ * @return {object}
+ */
+function getBundleVersionAndClassifier(pkgJsonVersion) {
+	const parts = pkgJsonVersion.split('-');
+	if (parts.length > 1) {
+		return parts[0] + '.' + parts.slice(1).join('-');
+	}
+	else {
+		return pkgJsonVersion;
+	}
 }

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/manifest.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/manifest.ts
@@ -5,6 +5,8 @@
 
 import project from 'liferay-npm-build-tools-common/lib/project';
 
+import * as osgi from './osgi';
+
 const FORBIDDEN_CUSTOM_HEADERS = new Set([
 	'Bundle-ManifestVersion',
 	'Bundle-Name',
@@ -30,13 +32,7 @@ export default class Manifest {
 		if (this._bundleVersion) {
 			throw new Error('BundleVersion can only be set once');
 		}
-		const parts = bundleVersion.split('-');
-		if (parts.length > 1) {
-			this._bundleVersion = parts[0] + '.' + parts.slice(1).join('-');
-		}
-		else {
-			this._bundleVersion = bundleVersion;
-		}
+		this._bundleVersion = osgi.getBundleVersionAndClassifier(bundleVersion);
 	}
 
 	set bundleName(bundleName: string) {

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/osgi.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/osgi.js
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Get the OSGi bundle version from the package.json version. Respects
+ * the different types of version classifiers.
+ * @return {object}
+ */
+export function getBundleVersionAndClassifier(pkgJsonVersion) {
+	const parts = pkgJsonVersion.split('-');
+	if (parts.length > 1) {
+		return parts[0] + '.' + parts.slice(1).join('-');
+	}
+	else {
+		return pkgJsonVersion;
+	}
+}


### PR DESCRIPTION
Follow-up to PR #219

This PR also converts the version in the manifest header `RequireCapability`.
