### PR TITLE
fix(js-toolkit): let compression level be configured

### DIFF
--- a/maintenance/projects/js-toolkit/docs/.npmbundlerrc-file-reference.md
+++ b/maintenance/projects/js-toolkit/docs/.npmbundlerrc-file-reference.md
@@ -176,6 +176,22 @@ $ liferay-npm-bundler
 -   **Category**: `.npmbundlerrc`
     > ⚠ This option is deprecated. Use [`create-jar.features.js-extender`](#create-jarfeaturesjs-extender) instead.
 
+## create-jar.compression-level
+
+-   **Description**: Defines the compression level to use when creating the JAR file. It must be a number between `0` (no compression) and `9` (maximum compression).
+-   **Category**: `.npmbundlerrc`
+-   **Type**: `number`
+-   **Default**: `6`
+-   **Example**:
+
+```json
+{
+	"create-jar": {
+		"compression-level": 9
+	}
+}
+```
+
 ## create-jar.customManifestHeaders
 
 -   **Description**: Defines custom headers to be written to the MANIFEST.MF file contained in the output JAR. Note that this is the same as [create-jar.features.manifest](#create-jarfeaturesmanifest) but with lower precedence, i.e., values are combined but the the ones from the other section take precedence over the ones in this.

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/jar.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/jar.ts
@@ -19,6 +19,25 @@ export default class Jar {
 	}
 
 	/**
+	 * Get compression level to apply when making the JAR file.
+	 * @return a number between 0 (no compression) and 9 (maximum compression)
+	 */
+	get compressionLevel(): number {
+		const {_project} = this;
+		const {npmbundlerrc} = _project;
+
+		if (this._compressionLevel === undefined) {
+			this._compressionLevel = prop.get(
+				npmbundlerrc,
+				'create-jar.compression-level',
+				6
+			);
+		}
+
+		return this._compressionLevel;
+	}
+
+	/**
 	 * Get configuration description file path.
 	 * @return path of the file or undefined if not configured
 	 */
@@ -171,6 +190,7 @@ export default class Jar {
 		return this._webContextPath;
 	}
 
+	private _compressionLevel: number;
 	private _customManifestHeaders: object;
 	private _outputDir: FilePath;
 	private _outputFilename: string;

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/index.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/index.js
@@ -29,14 +29,22 @@ export default function createJar() {
 	addSystemConfigurationFiles(zip);
 	addPortletInstanceConfigurationFile(zip);
 
-	return zip.generateAsync({type: 'nodebuffer'}).then((buffer) => {
-		fs.mkdirpSync(project.jar.outputDir.asNative);
+	const {compression, compressionOptions} = getCompressionConfiguration();
 
-		fs.writeFileSync(
-			project.jar.outputDir.join(project.jar.outputFilename).asNative,
-			buffer
-		);
-	});
+	return zip
+		.generateAsync({
+			compression,
+			compressionOptions,
+			type: 'nodebuffer',
+		})
+		.then((buffer) => {
+			fs.mkdirpSync(project.jar.outputDir.asNative);
+
+			fs.writeFileSync(
+				project.jar.outputDir.join(project.jar.outputFilename).asNative,
+				buffer
+			);
+		});
 }
 
 /**
@@ -223,6 +231,23 @@ function addPortletInstanceConfigurationFile(zip) {
 		'portlet_preferences.json',
 		JSON.stringify(ddmJson, null, 2)
 	);
+}
+
+/**
+ * Get compression and compressionOptions configuration based on project's
+ * configuration.
+ * @return {object} an object with compression and compressionOptions fields
+ */
+function getCompressionConfiguration() {
+	if (project.jar.compressionLevel === 0) {
+		return {compression: 'STORE'};
+	}
+	else {
+		return {
+			compression: 'DEFLATE',
+			compressionOptions: {level: project.jar.compressionLevel},
+		};
+	}
 }
 
 /**

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/index.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/index.js
@@ -29,12 +29,9 @@ export default function createJar() {
 	addSystemConfigurationFiles(zip);
 	addPortletInstanceConfigurationFile(zip);
 
-	const {compression, compressionOptions} = getCompressionConfiguration();
-
 	return zip
 		.generateAsync({
-			compression,
-			compressionOptions,
+			...getCompressionConfiguration(),
 			type: 'nodebuffer',
 		})
 		.then((buffer) => {


### PR DESCRIPTION
( See issue #256 )

We should allow user define the compression level to use when creating the JAR file. By default we are using STORE compression, which doesn't compress anything but this leads to huge JARs and some customers have problems with cloud deployments (see [LPP-39585](https://issues.liferay.com/browse/LPP-39585)).

We should probably use compression level 6 (a compromise between compression speed and artifact size) by default and let the value be configurable in case someone wants to tweak it further.