### PR TITLE
fix(npm-scripts): avoid unhandled promise rejection

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/index.js
+++ b/projects/npm-tools/packages/npm-scripts/src/index.js
@@ -14,7 +14,7 @@ module.exports = async function () {
 
 	const PUBLIC_COMMANDS = {
 		async build() {
-			require('./scripts/build')(...ARGS_ARRAY.slice(1));
+			await require('./scripts/build')(...ARGS_ARRAY.slice(1));
 		},
 
 		async check() {


### PR DESCRIPTION
This was causing an unhandled rejection when the build process failed, which led to gradle not noticing any problem and continuing as if nothing had happened.