### PR TITLE
style(js-toolkit): fix formatting

### DIFF
--- a/maintenance/projects/js-toolkit/lerna.json
+++ b/maintenance/projects/js-toolkit/lerna.json
@@ -9,9 +9,7 @@
 		}
 	},
 	"npmClient": "yarn",
-	"packages": [
-		"packages/*"
-	],
+	"packages": ["packages/*"],
 	"tagVersionPrefix": "liferay-js-toolkit/v",
 	"useWorkspaces": true,
 	"version": "2.21.0"


### PR DESCRIPTION
Because [Lerna mangles it](https://github.com/liferay/liferay-frontend-projects/runs/1523806083?check_suite_focus=true) whenever we release.

We're going to have to figure out a way to stop it from doing that... or we might simply hope to stop using Lerna or releasing "legacy" projects which use it... (We could ignore the file, but that defeats the purpose of having Prettier *in charge* of formatting everything in the repo.)