### PR TITLE
docs(js-themes-toolkit): update links to point at new repo

### DIFF
--- a/maintenance/projects/js-themes-toolkit-v8-x/CONTRIBUTING.md
+++ b/maintenance/projects/js-themes-toolkit-v8-x/CONTRIBUTING.md
@@ -1,34 +1,10 @@
 # Contributing Guidelines
 
-If you wish to contribute to Liferay Themes Toolkit these guidelines will be
-important for you. They cover instructions for setup, information on how the
-repository is organized, as well as contribution requirements.
-
-## Setup
-
-TBD
-
-## Repo organization
-
-TBD
-
-## Pull requests & Github issues
-
--   All pull requests should be sent to the `develop` branch, as the `master`
-    branch should always reflect the most recent release.
--   Any merged changes will remain in the `develop` branch until the next
-    scheduled release.
--   The only exception to this rule is for emergency hot fixes, in which case the
-    pull request can be sent to the `master` branch.
--   A Github issue should also be created for any bug fix or feature, this helps
-    when generating the CHANGELOG.md file.
--   All commits in a given pull request should start with the `Fixes #xxx -`
-    message for traceability purposes.
+If you wish to contribute to Liferay Themes Toolkit these guidelines will be important for you. They cover instructions for setup, information on how the repository is organized, as well as contribution requirements.
 
 ## Tests
 
-Any change (be it an improvement, a new feature or a bug fix) needs to include
-a test, and all tests from the repo need to be passing. To run the tests:
+Any change (be it an improvement, a new feature or a bug fix) needs to include a test, and all tests from the repo need to be passing. To run the tests:
 
 ```
 yarn test
@@ -38,31 +14,23 @@ This will run the complete test suite using Jest.
 
 ## Formatting
 
-All changes need to follow the general formatting guidelines that are enforced
-in the CI. To format your code:
+All changes need to follow the general formatting guidelines that are enforced in the CI. To format your code:
 
 ```
 yarn format
 ```
 
-## JS Docs
-
-All methods should be documented, following [google's format](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler).
-
 # Releasing
 
 Collaborators with publish permissions should follow these steps.
 
-There are two different workflows for publishing this project, one for scheduled
-releases, and one for emergency hot fixes.
-
 ## Scheduled release
 
-### 1. Update the `8.x` branch
+### 1. Update the local branch
 
 ```sh
-git checkout 8.x
-git pull upstream 8.x
+git checkout master
+git pull upstream master
 ```
 
 ### 2. Update dependency versions
@@ -108,26 +76,13 @@ yarn ci
 # Prepare and push final commit:
 git add -A
 git commit -m "chore: prepare $VERSION release"
-git push upstream 8.x
-```
-
-You can now create a draft PR (proposing a merge of 8.x into 8.x-stable); **we won't actually merge this PR; we just want to see the CI pass**.
-
-### 5. Perform the merge to 8.x-stable
-
-Once we've seen the CI pass above, we can **close the PR without merging it** (it was already pushed to the 8.x branch) and publish our tags.
-
-```sh
-git checkout 8.x-stable
-git pull upstream 8.x-stable
-git merge --ff-only 8.x
 git tag liferay-js-themes-toolkit/v$VERSION -m liferay-js-themes-toolkit/v$VERSION
-git push upstream 8.x-stable --follow-tags
+git push upstream master --follow-tags
 ```
 
 ### 6. Update the release notes
 
-Go to [liferay-js-themes-toolkit/release](https://github.com/liferay/liferay-js-themes-toolkit/releases) and add a copy of the relevant section from the CHANGELOG.md.
+Go to [the releases page](https://github.com/liferay/liferay-frontend-projects/releases) and add a copy of the relevant section from the CHANGELOG.md.
 
 ### 7. Do the NPM publish
 

--- a/maintenance/projects/js-themes-toolkit-v8-x/README.md
+++ b/maintenance/projects/js-themes-toolkit-v8-x/README.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-This repo contains the source for a [set of NPM packages](https://github.com/liferay/liferay-js-themes-toolkit/tree/master/packages) designed to help create, update, and maintain Liferay Themes. The packages that you are most likely to interact with directly are:
+This repo contains the source for a [set of NPM packages](packages) designed to help create, update, and maintain Liferay Themes. The packages that you are most likely to interact with directly are:
 
--   [generator-liferay-theme](https://github.com/liferay/liferay-js-themes-toolkit/tree/master/packages/generator-liferay-theme): A [Yeoman](https://yeoman.io/) generator for creating new themes, themelets, and layout templates.
--   [liferay-theme-tasks](https://github.com/liferay/liferay-js-themes-toolkit/tree/master/packages/liferay-theme-tasks): A set of [Gulp](https://gulpjs.com/) tasks for building and deploying themes.
+-   [generator-liferay-theme](packages/generator-liferay-theme): A [Yeoman](https://yeoman.io/) generator for creating new themes, themelets, and layout templates.
+-   [liferay-theme-tasks](packages/liferay-theme-tasks): A set of [Gulp](https://gulpjs.com/) tasks for building and deploying themes.
 
 ## Compatibility
 
@@ -27,14 +27,19 @@ Starting with version 9 of the toolkit, in order to keep the toolkit simple, eac
 
 Other differences between the major versions:
 
-| Toolkit version | Branch   | Status             |
-| --------------- | -------- | ------------------ |
-| 7.x             | -        | deprecated         |
-| 8.x             | `8.x`    | maintenance        |
-| 9.x             | `9.x`    | maintenance        |
-| 10.x            | `master` | active development |
+| Toolkit version | Status             |
+| --------------- | ------------------ |
+| [v7.x]          | deprecated         |
+| [v8.x]          | maintenance        |
+| [v9.x]          | maintenance        |
+| [v10.x]         | active development |
 
 Notes:
 
 -   The 7.x series of the toolkit is unlikely to receive any further development, so is effectively deprecated.
--   Most active development is taking place on the `master` branch, corresponding to the 10.x series of releases, but the 8.x and 9.x series are still valid for existing themes. You may wish to continue using v8 (because you need to target DXP 7.0 or 7.1) or v9 (because you want to avoid the breaking changes involved in updating to v10; specifically, moving from Gulp v3 to Gulp v4, which may require custom theme tasks to be updated).
+-   Most active development is taking place on in the 10.x series of releases, but the 8.x and 9.x series are still valid for existing themes. You may wish to continue using v8 (because you need to target DXP 7.0 or 7.1) or v9 (because you want to avoid the breaking changes involved in updating to v10; specifically, moving from Gulp v3 to Gulp v4, which may require custom theme tasks to be updated).
+
+[v7.x]: https://github.com/liferay/liferay-js-themes-toolkit/tree/archive/7.0.x
+[v8.x]: https://github.com/liferay/liferay-frontend-projects/maintenance/projects/js-themes-toolkit-v8-x
+[v9.x]: https://github.com/liferay/liferay-frontend-projects/maintenance/projects/js-themes-toolkit-v9-x
+[v10.x]: https://github.com/liferay/liferay-frontend-projects/projects/js-themes-toolkit

--- a/maintenance/projects/js-themes-toolkit-v9-x/CONTRIBUTING.md
+++ b/maintenance/projects/js-themes-toolkit-v9-x/CONTRIBUTING.md
@@ -2,18 +2,9 @@
 
 If you wish to contribute to Liferay Themes Toolkit these guidelines will be important for you. They cover instructions for setup, information on how the repository is organized, as well as contribution requirements.
 
-## Setup
-
-TBD
-
-## Repo organization
-
-TBD
-
 ## Pull requests & Github issues
 
--   All pull requests should be sent to the `9.x` branch, as the `master` branch should always reflect the most recent release.
--   Aim to create one Pull Request per bug fix or feature, if possible, as this helps to generate a high-quality CHANGELOG.md file. We use [liferay-changelog-generator](https://github.com/liferay/liferay-npm-tools/tree/master/packages/liferay-changelog-generator) to produce changelogs automatically; it will base the changelog on the titles of the PRs merged for each release, so bear that in mind when writing PR titles.
+-   Aim to create one Pull Request per bug fix or feature, if possible, as this helps to generate a high-quality CHANGELOG.md file. We use [@liferay/changelog-generator](https://github.com/liferay/liferay-frontend-projects/tree/master/projects/npm-tools/packages/changelog-generator) to produce changelogs automatically; it will base the changelog on the titles of the PRs merged for each release, so bear that in mind when writing PR titles.
 
 ## Tests
 
@@ -33,23 +24,17 @@ All changes need to follow the general formatting guidelines that are enforced i
 yarn format
 ```
 
-## JS Docs
-
-All methods should be documented, following [google's format](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler).
-
 # Releasing
 
 Collaborators with publish permissions should follow these steps.
 
-There are two different workflows for publishing this project, one for scheduled releases, and one for emergency hot fixes.
-
 ## Scheduled release
 
-### 1. Update the `9.x` branch
+### 1. Update the local branch
 
 ```sh
-git checkout 9.x
-git pull upstream 9.x
+git checkout master
+git pull upstream master
 ```
 
 ### 2. Update dependency versions
@@ -80,12 +65,12 @@ yarn ci
 git add -A
 git commit -m "chore: prepare $VERSION release"
 git tag liferay-js-themes-toolkit/v$VERSION -m liferay-js-themes-toolkit/v$VERSION
-git push upstream 9.x --follow-tags
+git push upstream master --follow-tags
 ```
 
 ### 5. Update the release notes
 
-Go to [liferay-js-themes-toolkit/release](https://github.com/liferay/liferay-js-themes-toolkit/releases) and add a copy of the relevant section from the CHANGELOG.md.
+Go to [the releases page](https://github.com/liferay/liferay-frontend-projects/releases) and add a copy of the relevant section from the CHANGELOG.md.
 
 ### 6. Do the NPM publish
 
@@ -94,7 +79,7 @@ We used to use Lerna to manage this repo, but as the number of packages has redu
 -   First "liferay-theme-tasks".
 -   Then "generator-liferay-theme".
 
-When publishing a normal release, the `maintenance` _dist-tag_ is automatically used (as configured in the root [.yarnrc](https://github.com/liferay/liferay-js-themes-toolkit/blob/9.x/.yarnrc) file):
+When publishing a normal release, the `maintenance` _dist-tag_ is automatically used (as configured in the [.yarnrc](.yarnrc) file):
 
 ```sh
 cd packages

--- a/maintenance/projects/js-themes-toolkit-v9-x/README.md
+++ b/maintenance/projects/js-themes-toolkit-v9-x/README.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-This repo contains the source for a [set of NPM packages](https://github.com/liferay/liferay-js-themes-toolkit/tree/master/packages) designed to help create, update, and maintain Liferay Themes. The packages that you are most likely to interact with directly are:
+This repo contains the source for a [set of NPM packages](packages) designed to help create, update, and maintain Liferay Themes. The packages that you are most likely to interact with directly are:
 
--   [generator-liferay-theme](https://github.com/liferay/liferay-js-themes-toolkit/tree/master/packages/generator-liferay-theme): A [Yeoman](https://yeoman.io/) generator for creating new themes, themelets, and layout templates.
--   [liferay-theme-tasks](https://github.com/liferay/liferay-js-themes-toolkit/tree/master/packages/liferay-theme-tasks): A set of [Gulp](https://gulpjs.com/) tasks for building and deploying themes.
+-   [generator-liferay-theme](packages/generator-liferay-theme): A [Yeoman](https://yeoman.io/) generator for creating new themes, themelets, and layout templates.
+-   [liferay-theme-tasks](packages/liferay-theme-tasks): A set of [Gulp](https://gulpjs.com/) tasks for building and deploying themes.
 
 ## Compatibility
 
@@ -27,14 +27,19 @@ Starting with version 9 of the toolkit, in order to keep the toolkit simple, eac
 
 Other differences between the major versions:
 
-| Toolkit version | Branch   | Status             |
-| --------------- | -------- | ------------------ |
-| 7.x             | -        | deprecated         |
-| 8.x             | `8.x`    | maintenance        |
-| 9.x             | `9.x`    | maintenance        |
-| 10.x            | `master` | active development |
+| Toolkit version | Status             |
+| --------------- | ------------------ |
+| [v7.x]          | deprecated         |
+| [v8.x]          | maintenance        |
+| [v9.x]          | maintenance        |
+| [v10.x]         | active development |
 
 Notes:
 
 -   The 7.x series of the toolkit is unlikely to receive any further development, so is effectively deprecated.
--   Most active development is taking place on the `master` branch, corresponding to the 10.x series of releases, but the 8.x and 9.x series are still valid for existing themes. You may wish to continue using v8 (because you need to target DXP 7.0 or 7.1) or v9 (because you want to avoid the breaking changes involved in updating to v10; specifically, moving from Gulp v3 to Gulp v4, which may require custom theme tasks to be updated).
+-   Most active development is taking place on in the 10.x series of releases, but the 8.x and 9.x series are still valid for existing themes. You may wish to continue using v8 (because you need to target DXP 7.0 or 7.1) or v9 (because you want to avoid the breaking changes involved in updating to v10; specifically, moving from Gulp v3 to Gulp v4, which may require custom theme tasks to be updated).
+
+[v7.x]: https://github.com/liferay/liferay-js-themes-toolkit/tree/archive/7.0.x
+[v8.x]: https://github.com/liferay/liferay-frontend-projects/maintenance/projects/js-themes-toolkit-v8-x
+[v9.x]: https://github.com/liferay/liferay-frontend-projects/maintenance/projects/js-themes-toolkit-v9-x
+[v10.x]: https://github.com/liferay/liferay-frontend-projects/projects/js-themes-toolkit

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/generator-liferay-theme/lib/util.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/generator-liferay-theme/lib/util.js
@@ -152,8 +152,9 @@ function sayHello(generator) {
 
 		We recommend using version 10.x instead of 9.x whenever possible.
 
-		See https://github.com/liferay/liferay-js-themes-toolkit#compatibility
-		for more information.
+		For more information, see:
+
+		https://github.com/liferay/liferay-frontend-projects/tree/master/projects/js-themes-toolkit#compatibility
 
 		`
 	);

--- a/projects/js-themes-toolkit/CONTRIBUTING.md
+++ b/projects/js-themes-toolkit/CONTRIBUTING.md
@@ -14,7 +14,7 @@ TBD
 
 -   All pull requests should be sent to the `master` branch.
 -   The `stable` branch always reflects the most recent release.
--   Aim to create one Pull Request per bug fix or feature, if possible, as this helps to generate a high-quality CHANGELOG.md file. We use [liferay-changelog-generator](https://github.com/liferay/liferay-npm-tools/tree/master/packages/liferay-changelog-generator) to produce changelogs automatically; it will base the changelog on the titles of the PRs merged for each release, so bear that in mind when writing PR titles.
+-   Aim to create one Pull Request per bug fix or feature, if possible, as this helps to generate a high-quality CHANGELOG.md file. We use [@liferay/changelog-generator](https://github.com/liferay/liferay-frontend-projects/tree/master/projects/npm-tools/packages/changelog-generator) to produce changelogs automatically; it will base the changelog on the titles of the PRs merged for each release, so bear that in mind when writing PR titles.
 
 ## Tests
 
@@ -33,10 +33,6 @@ All changes need to follow the general formatting guidelines that are enforced i
 ```
 yarn format
 ```
-
-## JS Docs
-
-All methods should be documented, following [Google's format](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler).
 
 # Releasing
 
@@ -91,7 +87,7 @@ There's no need to commit it because the next step will do it.
 
 ### 5. Do the publish
 
-We are using [liferay-js-publish](https://github.com/liferay/liferay-npm-tools/tree/master/packages/liferay-js-publish) to perform the publication to npm and manage git tags.
+We are using [@liferay/js-publish](https://github.com/liferay/liferay-frontend-projects/tree/master/projects/npm-tools/packages/liferay-js-publish) to perform the publication to npm and manage Git tags.
 
 To perform the release, run (in the released project's folder):
 
@@ -115,7 +111,7 @@ As long as there is a hyphen in the version number, `liferay-js-publish` will ta
 
 ### 6. Update the release notes
 
-Go to [liferay-js-themes-toolkit/release](https://github.com/liferay/liferay-js-themes-toolkit/releases) and add a copy of the relevant section from the CHANGELOG.md.
+Go to [the release pages](https://github.com/liferay/liferay-frontend-projects/releases) and add a copy of the relevant section from the CHANGELOG.md.
 
 ### 7. Sanity check the package pages on the NPM website:
 

--- a/projects/js-themes-toolkit/README.md
+++ b/projects/js-themes-toolkit/README.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-This repo contains the source for a [set of NPM packages](https://github.com/liferay/liferay-js-themes-toolkit/tree/master/packages) designed to help create, update, and maintain Liferay Themes. The packages that you are most likely to interact with directly are:
+This repo contains the source for a [set of NPM packages](packages) designed to help create, update, and maintain Liferay Themes. The packages that you are most likely to interact with directly are:
 
--   [generator-liferay-theme](https://github.com/liferay/liferay-js-themes-toolkit/tree/master/packages/generator-liferay-theme): A [Yeoman](https://yeoman.io/) generator for creating new themes, themelets, and layout templates.
--   [liferay-theme-tasks](https://github.com/liferay/liferay-js-themes-toolkit/tree/master/packages/liferay-theme-tasks): A set of [Gulp](https://gulpjs.com/) tasks for building and deploying themes.
+-   [generator-liferay-theme](packages/generator-liferay-theme): A [Yeoman](https://yeoman.io/) generator for creating new themes, themelets, and layout templates.
+-   [liferay-theme-tasks](packages/liferay-theme-tasks): A set of [Gulp](https://gulpjs.com/) tasks for building and deploying themes.
 
 ## Compatibility
 
@@ -27,14 +27,19 @@ Starting with version 9 of the toolkit, in order to keep the toolkit simple, eac
 
 Other differences between the major versions:
 
-| Toolkit version | Branch   | Status             |
-| --------------- | -------- | ------------------ |
-| 7.x             | -        | deprecated         |
-| 8.x             | `8.x`    | maintenance        |
-| 9.x             | `9.x`    | maintenance        |
-| 10.x            | `master` | active development |
+| Toolkit version | Status             |
+| --------------- | ------------------ |
+| [v7.x]          | deprecated         |
+| [v8.x]          | maintenance        |
+| [v9.x]          | maintenance        |
+| [v10.x]         | active development |
 
 Notes:
 
 -   The 7.x series of the toolkit is unlikely to receive any further development, so is effectively deprecated.
--   Most active development is taking place on the `master` branch, corresponding to the 10.x series of releases, but the 8.x and 9.x series are still valid for existing themes. You may wish to continue using v8 (because you need to target DXP 7.0 or 7.1) or v9 (because you want to avoid the breaking changes involved in updating to v10; specifically, moving from Gulp v3 to Gulp v4, which may require custom theme tasks to be updated).
+-   Most active development is taking place on in the 10.x series of releases, but the 8.x and 9.x series are still valid for existing themes. You may wish to continue using v8 (because you need to target DXP 7.0 or 7.1) or v9 (because you want to avoid the breaking changes involved in updating to v10; specifically, moving from Gulp v3 to Gulp v4, which may require custom theme tasks to be updated).
+
+[v7.x]: https://github.com/liferay/liferay-js-themes-toolkit/tree/archive/7.0.x
+[v8.x]: https://github.com/liferay/liferay-frontend-projects/maintenance/projects/js-themes-toolkit-v8-x
+[v9.x]: https://github.com/liferay/liferay-frontend-projects/maintenance/projects/js-themes-toolkit-v9-x
+[v10.x]: https://github.com/liferay/liferay-frontend-projects/projects/js-themes-toolkit


### PR DESCRIPTION
Labeling this as "docs" although there is one code change in there. This commit updates all references that were pointing at the old (archived, read-only) repo to point at the monorepo instead.

Bonus: soft-wrapped the v8 CONTRIBUTING.md because that's what we're doing in all the other Markdown files.