### PR TITLE
feat: extend webpack federation support

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
@@ -17,7 +17,7 @@ const spawnSync = require('../utils/spawnSync');
 const validateConfig = require('../utils/validateConfig');
 const webpack = require('./webpack');
 
-const {build: BUILD_CONFIG, federation: FEDERATION_ENABLED} = getMergedConfig(
+const {build: BUILD_CONFIG, federation: FEDERATION_CONFIG} = getMergedConfig(
 	'npmscripts'
 );
 const CWD = process.cwd();
@@ -73,7 +73,7 @@ function runBridge() {
 /**
  * Main script that runs all all specified build tasks synchronously.
  *
- * Babel and liferay-npm-bundler are always run,
+ * Babel and liferay-npm-bundler are run unless the disable flag is set,
  * liferay-npm-bridge-generator and webpack are run if the corresponding
  * ".npmbridgerc" and "webpack.config.js" files, respectively, are
  * present, and soy is run when soy files are detected.
@@ -94,18 +94,31 @@ module.exports = async function (...args) {
 		buildSoy();
 	}
 
-	runBabel(
-		BUILD_CONFIG.input,
-		'--out-dir',
-		BUILD_CONFIG.output,
-		'--source-maps'
-	);
+	const disableOldBuild =
+		FEDERATION_CONFIG && FEDERATION_CONFIG.disableOldBuild;
 
-	if (fs.existsSync('webpack.config.js') || !!FEDERATION_ENABLED) {
+	if (!disableOldBuild) {
+		runBabel(
+			BUILD_CONFIG.input,
+			'--out-dir',
+			BUILD_CONFIG.output,
+			'--source-maps'
+		);
+	}
+
+	if (fs.existsSync('webpack.config.js') || !!FEDERATION_CONFIG) {
 		webpack(...args);
 	}
 
-	runBundler();
+	if (!disableOldBuild) {
+		runBundler();
+	}
+	else {
+		const {output} = BUILD_CONFIG;
+
+		fs.copyFileSync('package.json', path.join(output, 'package.json'));
+		fs.writeFileSync(path.join(output, 'manifest.json'), '{}');
+	}
 
 	translateSoy(BUILD_CONFIG.output);
 

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
@@ -106,7 +106,7 @@ module.exports = async function (...args) {
 		);
 	}
 
-	if (fs.existsSync('webpack.config.js') || !!FEDERATION_CONFIG) {
+	if (fs.existsSync('webpack.config.js') || FEDERATION_CONFIG) {
 		webpack(...args);
 	}
 

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/webpack.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/webpack.js
@@ -58,13 +58,7 @@ function withWebpackConfig(filename, callback) {
 			federation = '{}';
 		}
 		else if (typeof FEDERATION_CONFIG === 'object') {
-			federation = '{\n';
-
-			if (FEDERATION_CONFIG.main) {
-				federation += `main: '${FEDERATION_CONFIG.main}'\n`;
-			}
-
-			federation += '}\n';
+			federation = JSON.stringify(FEDERATION_CONFIG);
 		}
 	}
 

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/webpack.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/webpack.js
@@ -10,7 +10,7 @@ const getMergedConfig = require('../utils/getMergedConfig');
 const spawnSync = require('../utils/spawnSync');
 const withTempFile = require('../utils/withTempFile');
 
-const FEDERATION = getMergedConfig('npmscripts', 'federation');
+const FEDERATION_CONFIG = getMergedConfig('npmscripts', 'federation');
 const TWEAK_WEBPACK_CONFIG_PATH = require.resolve(
 	'../utils/tweakWebpackConfig'
 );
@@ -51,6 +51,24 @@ function escapeLiteralString(str) {
 function withWebpackConfig(filename, callback) {
 	const webpackConfigPath = path.resolve(filename);
 
+	let federation;
+
+	if (FEDERATION_CONFIG) {
+		if (typeof FEDERATION_CONFIG === 'boolean') {
+			federation = '{}';
+		}
+		else if (typeof FEDERATION_CONFIG === 'object') {
+			federation = '{\n';
+
+			if (FEDERATION_CONFIG.main) {
+				federation += `main: '${FEDERATION_CONFIG.main}'\n`;
+
+			}
+
+			federation += '}\n';
+		}
+	}
+
 	const webpackConfig = `
 		const fs = require('fs');
 		const tweakWebpackConfig = require('${escapeLiteralString(
@@ -68,10 +86,7 @@ function withWebpackConfig(filename, callback) {
 		module.exports = tweakWebpackConfig(
 			webpackConfig,
 			{
-				federation:
-					${typeof FEDERATION == 'string'
-						? `'${FEDERATION}'`
-						: FEDERATION}
+				federation: ${federation}
 			}
 		);
 	`;

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/webpack.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/webpack.js
@@ -10,7 +10,7 @@ const getMergedConfig = require('../utils/getMergedConfig');
 const spawnSync = require('../utils/spawnSync');
 const withTempFile = require('../utils/withTempFile');
 
-const FEDERATION_ENABLED = getMergedConfig('npmscripts', 'federation');
+const FEDERATION = getMergedConfig('npmscripts', 'federation');
 const TWEAK_WEBPACK_CONFIG_PATH = require.resolve(
 	'../utils/tweakWebpackConfig'
 );
@@ -68,7 +68,10 @@ function withWebpackConfig(filename, callback) {
 		module.exports = tweakWebpackConfig(
 			webpackConfig,
 			{
-				federation: ${FEDERATION_ENABLED}
+				federation:
+					${typeof FEDERATION == 'string'
+						? `'${FEDERATION}'`
+						: FEDERATION}
 			}
 		);
 	`;

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/webpack.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/webpack.js
@@ -62,7 +62,6 @@ function withWebpackConfig(filename, callback) {
 
 			if (FEDERATION_CONFIG.main) {
 				federation += `main: '${FEDERATION_CONFIG.main}'\n`;
-
 			}
 
 			federation += '}\n';

--- a/projects/npm-tools/packages/npm-scripts/src/utils/tweakWebpackConfig.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/tweakWebpackConfig.js
@@ -33,7 +33,10 @@ const BABEL_CONFIG = getMergedConfig('babel');
  * Modify an existing webpack config to conform to Liferay standards.
  *
  * @param {object|Array|undefined} webpackConfig
- * @param {boolean} federation set to true to inject federation support
+ * @param {object} federation
+ * Federation configuration, which can contain:
+ *   - main: entry point for federation support (by default the value inside the
+ *         `main` field of the `package.json` file is used).
  *
  * @return {object|Array} the tweaked webpack config
  */
@@ -51,9 +54,7 @@ function tweakWebpackConfig(webpackConfig, {federation} = {}) {
 	}
 
 	if (federation) {
-		arrayConfig.push(
-			createFederationConfig(
-				typeof federation === 'string' ? federation : undefined));
+		arrayConfig.push(createFederationConfig(federation));
 	}
 
 	arrayConfig = arrayConfig.map((webpackConfig) =>
@@ -69,9 +70,10 @@ function tweakWebpackConfig(webpackConfig, {federation} = {}) {
  * Note that the default federation configuration exports the "main" entry point
  * as a federation module and makes it available through Liferay DXP.
  *
- * @param {string|undefined} federation
- * If given it points to the explicit federation entry point. Otherwise the
- * value inside the `main` field of the `package.json` file is used.
+ * @param {object} federation
+ * Federation configuration, which can contain:
+ *   - main: entry point for federation support (by default the value inside the
+ *         `main` field of the `package.json` file is used).
  *
  * @return {object} a webpack configuration
  */
@@ -81,7 +83,7 @@ function createFederationConfig(federation) {
 	const bnd = parseBnd();
 
 	const name = packageJson.name;
-	const main = federation || packageJson.main || 'index.js';
+	const main = federation.main || packageJson.main || 'index.js';
 	const webContextPath = bnd['Web-ContextPath'] || name;
 
 	const {filePath: nullJsFilePath} = createTempFile('null.js', '');

--- a/projects/npm-tools/packages/npm-scripts/src/utils/tweakWebpackConfig.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/tweakWebpackConfig.js
@@ -12,10 +12,7 @@ const createTempFile = require('./createTempFile');
 const getMergedConfig = require('./getMergedConfig');
 const parseBnd = require('./parseBnd');
 
-const CORE_REMOTES = [
-	'frontend-js-react-web',
-	'frontend-taglib-clay'
-];
+const CORE_REMOTES = ['frontend-js-react-web', 'frontend-taglib-clay'];
 const CORE_SHARES = [
 	'@clayui/icon',
 	'classnames',
@@ -24,7 +21,7 @@ const CORE_SHARES = [
 	'react',
 	'react-dnd',
 	'react-dnd-html5-backend',
-	'react-dom'
+	'react-dom',
 ];
 
 const BABEL_CONFIG = getMergedConfig('babel');

--- a/projects/npm-tools/packages/npm-scripts/src/utils/tweakWebpackConfig.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/tweakWebpackConfig.js
@@ -126,7 +126,7 @@ function createFederationConfig(federation) {
 				},
 				filename: 'container.js',
 				library: {
-					name: `Liferay.Webpack.Container["${name}"]`,
+					name: `window[Symbol.for("__LIFERAY_WEBPACK_CONTAINERS__")]["${name}"]`,
 					type: 'assign',
 				},
 				name,
@@ -134,7 +134,7 @@ function createFederationConfig(federation) {
 				remotes: CORE_REMOTES.reduce((remotes, name) => {
 					remotes[
 						name
-					] = `Liferay.Webpack.Container["${name}"]@/o/${name}/__generated__/container.js`;
+					] = `window[Symbol.for("__LIFERAY_WEBPACK_CONTAINERS__")]["${name}"]@/o/${name}/__generated__/container.js`;
 
 					return remotes;
 				}, {}),

--- a/projects/npm-tools/packages/npm-scripts/src/utils/tweakWebpackConfig.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/tweakWebpackConfig.js
@@ -12,8 +12,20 @@ const createTempFile = require('./createTempFile');
 const getMergedConfig = require('./getMergedConfig');
 const parseBnd = require('./parseBnd');
 
-const CORE_REMOTES = ['frontend-js-react-web'];
-const CORE_SHARES = ['react'];
+const CORE_REMOTES = [
+	'frontend-js-react-web',
+	'frontend-taglib-clay'
+];
+const CORE_SHARES = [
+	'@clayui/icon',
+	'classnames',
+	'formik',
+	'prop-types',
+	'react',
+	'react-dnd',
+	'react-dnd-html5-backend',
+	'react-dom'
+];
 
 const BABEL_CONFIG = getMergedConfig('babel');
 
@@ -39,7 +51,9 @@ function tweakWebpackConfig(webpackConfig, {federation} = {}) {
 	}
 
 	if (federation) {
-		arrayConfig.push(createFederationConfig());
+		arrayConfig.push(
+			createFederationConfig(
+				typeof federation === 'string' ? federation : undefined));
 	}
 
 	arrayConfig = arrayConfig.map((webpackConfig) =>
@@ -55,15 +69,19 @@ function tweakWebpackConfig(webpackConfig, {federation} = {}) {
  * Note that the default federation configuration exports the "main" entry point
  * as a federation module and makes it available through Liferay DXP.
  *
+ * @param {string|undefined} federation
+ * If given it points to the explicit federation entry point. Otherwise the
+ * value inside the `main` field of the `package.json` file is used.
+ *
  * @return {object} a webpack configuration
  */
-function createFederationConfig() {
+function createFederationConfig(federation) {
 	// eslint-disable-next-line @liferay/liferay/no-dynamic-require
 	const packageJson = require(path.join(process.cwd(), 'package.json'));
 	const bnd = parseBnd();
 
 	const name = packageJson.name;
-	const main = packageJson.main || 'index.js';
+	const main = federation || packageJson.main || 'index.js';
 	const webContextPath = bnd['Web-ContextPath'] || name;
 
 	const {filePath: nullJsFilePath} = createTempFile('null.js', '');


### PR DESCRIPTION
This PR adds newer features to `npm-scripts` which are needed to implement [LPS-124287](https://issues.liferay.com/browse/LPS-124287).

I have tested it locally with the LPS-124287 PR for portal and everything work, but we need to merge this and release a new version for the other PR to work.