### PR TITLE
fix(js-themes-toolkit): silence noisy yarn warning

### DIFF
--- a/projects/js-themes-toolkit/package.json
+++ b/projects/js-themes-toolkit/package.json
@@ -8,6 +8,7 @@
 	"keywords": [
 		"yeoman-generator"
 	],
+	"name": "liferay-js-themes-toolkit",
 	"private": true,
 	"scripts": {
 		"build": true,


### PR DESCRIPTION
Silences:

    warning Missing name in workspace at "projects/js-themes-toolkit", ignoring.