### PR TITLE
chore(js-themes-toolkit): make final tweaks for monorepo releases

### DIFF
--- a/maintenance/projects/js-themes-toolkit-v8-x/.yarnrc
+++ b/maintenance/projects/js-themes-toolkit-v8-x/.yarnrc
@@ -1,1 +1,9 @@
 --publish.tag maintenance
+
+# We don't actually use `yarn version` to publish this project, but we still
+# specify the desired tag format here so that `@liferay/changelog-generator` can
+# pick it up.
+#
+# Note that prefix is based on the directory name so that
+# `@liferay/changelog-generator` distinguish it from the v9-x series.
+version-tag-prefix "js-themes-toolkit-v8-x/v"

--- a/maintenance/projects/js-themes-toolkit-v8-x/CONTRIBUTING.md
+++ b/maintenance/projects/js-themes-toolkit-v8-x/CONTRIBUTING.md
@@ -75,8 +75,8 @@ yarn ci
 
 # Prepare and push final commit:
 git add -A
-git commit -m "chore: prepare $VERSION release"
-git tag liferay-js-themes-toolkit/v$VERSION -m liferay-js-themes-toolkit/v$VERSION
+git commit -m "chore(js-themes-toolkit): prepare $VERSION release"
+git tag js-themes-toolkit-v8-x/v$VERSION -m liferay-js-themes-toolkit/v$VERSION
 git push upstream master --follow-tags
 ```
 

--- a/maintenance/projects/js-themes-toolkit-v8-x/package.json
+++ b/maintenance/projects/js-themes-toolkit-v8-x/package.json
@@ -28,8 +28,8 @@
 		"ansi-colors": "3.2.4"
 	},
 	"scripts": {
-		"changelog": "npx liferay-changelog-generator",
-		"changelog:regenerate": "npx liferay-changelog-generator --regenerate",
+		"changelog": "node ../../../projects/npm-tools/packages/changelog-generator/bin/liferay-changelog-generator.js",
+		"changelog:regenerate": "node ../../../projects/npm-tools/packages/changelog-generator/bin/liferay-changelog-generator.js --regenerate",
 		"ci": "yarn format:check && yarn lint && yarn test",
 		"format": "cd ../../.. && yarn format",
 		"format:check": "cd ../../.. && yarn format:check",

--- a/maintenance/projects/js-themes-toolkit-v9-x/.yarnrc
+++ b/maintenance/projects/js-themes-toolkit-v9-x/.yarnrc
@@ -1,1 +1,9 @@
 --publish.tag maintenance
+
+# We don't actually use `yarn version` to publish this project, but we still
+# specify the desired tag format here so that `@liferay/changelog-generator` can
+# pick it up.
+#
+# Note that prefix is based on the directory name so that
+# `@liferay/changelog-generator` distinguish it from the v8-x series.
+version-tag-prefix "js-themes-toolkit-v9-x/v"

--- a/maintenance/projects/js-themes-toolkit-v9-x/CONTRIBUTING.md
+++ b/maintenance/projects/js-themes-toolkit-v9-x/CONTRIBUTING.md
@@ -63,8 +63,8 @@ yarn ci
 
 # Prepare and push final commit:
 git add -A
-git commit -m "chore: prepare $VERSION release"
-git tag liferay-js-themes-toolkit/v$VERSION -m liferay-js-themes-toolkit/v$VERSION
+git commit -m "chore(js-themes-toolkit): prepare $VERSION release"
+git tag js-themes-toolkit-v9-x/v$VERSION -m liferay-js-themes-toolkit/v$VERSION
 git push upstream master --follow-tags
 ```
 

--- a/maintenance/projects/js-themes-toolkit-v9-x/package.json
+++ b/maintenance/projects/js-themes-toolkit-v9-x/package.json
@@ -40,8 +40,8 @@
 		"ansi-colors": "3.2.4"
 	},
 	"scripts": {
-		"changelog": "npx liferay-changelog-generator",
-		"changelog:regenerate": "npx liferay-changelog-generator --regenerate",
+		"changelog": "node ../../../projects/npm-tools/packages/changelog-generator/bin/liferay-changelog-generator.js",
+		"changelog:regenerate": "node ../../../projects/npm-tools/packages/changelog-generator/bin/liferay-changelog-generator.js --regenerate",
 		"ci": "yarn format:check && yarn lint && yarn test",
 		"format": "cd ../../.. && yarn format",
 		"format:check": "cd ../../.. && yarn format:check",


### PR DESCRIPTION
I'm just running through the CONTRIBUTING.md docs to prove that we can actually do releases from the monorepo, and this commit makes the changes I've identified as being necessary:

- Namely, we need to add a `version-tag-prefix` in the `.yarnrc` files for use by the changelog-generator.
- We need to switch to the latest not-yet-published version of the generator, because the last-published version doesn't want to run from subdirectories like these maintenance projects use (it expects to run from the repo root, or from a packages/ subdirectory).
- In order to distinguish between the two series, we need them to use distinct tag prefixes. We could teach the changelog-generator a new switch to deal with this, but I'd rather not add the complexity there for what is a decidedly odd use case (multiple projects on same branch happening to share the same prefix), so let's just use these somewhat ugly prefixes instead.

Test plan: Go through the prep to make a new 8.x release and produce [a diff like this](https://gist.github.com/wincent/d5890667390caf595d558aab4a809470). Could also do it for 9.x but I'm going to do that shortly anyway, and it should be just the same.