### PR TITLE
feat: support generation of bridges from AMD to webpack

### DIFF
--- a/maintenance/projects/js-toolkit/lerna.json
+++ b/maintenance/projects/js-toolkit/lerna.json
@@ -9,9 +9,7 @@
 		}
 	},
 	"npmClient": "yarn",
-	"packages": [
-		"packages/*"
-	],
+	"packages": ["packages/*"],
 	"tagVersionPrefix": "liferay-js-toolkit/v",
 	"useWorkspaces": true,
 	"version": "2.22.0"

--- a/projects/js-toolkit/packages/js-toolkit-core/src/transform/js/index.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/transform/js/index.ts
@@ -121,8 +121,10 @@ async function mergeMaps(
 
 	const mergedMapGenerator = new SourceMapGenerator();
 
+	/* eslint-disable @typescript-eslint/await-thenable */
 	const oldMapConsumer = await new SourceMapConsumer(oldMap);
 	const newMapConsumer = await new SourceMapConsumer(newMap);
+	/* eslint-enable @typescript-eslint/await-thenable */
 
 	newMapConsumer.eachMapping((mapping) => {
 

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
@@ -15,6 +15,7 @@ const setEnv = require('../utils/setEnv');
 const {buildSoy, cleanSoy, soyExists, translateSoy} = require('../utils/soy');
 const spawnSync = require('../utils/spawnSync');
 const validateConfig = require('../utils/validateConfig');
+const createBridges = require('./createBridges');
 const webpack = require('./webpack');
 
 const {build: BUILD_CONFIG, federation: FEDERATION_CONFIG} = getMergedConfig(
@@ -118,6 +119,12 @@ module.exports = async function (...args) {
 
 		fs.copyFileSync('package.json', path.join(output, 'package.json'));
 		fs.writeFileSync(path.join(output, 'manifest.json'), '{}');
+	}
+
+	const {bridges} = FEDERATION_CONFIG;
+
+	if (bridges) {
+		createBridges(bridges, BUILD_CONFIG.output);
 	}
 
 	translateSoy(BUILD_CONFIG.output);

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/createBridges.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/createBridges.js
@@ -9,14 +9,14 @@ const path = require('path');
 
 module.exports = function (bridges, dir) {
 	const projectPackageJson = JSON.parse(
-		fs.readFileSync('package.json', 'utf-8')
+		fs.readFileSync('package.json', 'utf8')
 	);
 
-	Object.entries(bridges).forEach(([packageName, exportName]) => {
+	for (const [packageName, exportName] of Object.entries(bridges)) {
 		const packageJson = JSON.parse(
 			fs.readFileSync(
 				require.resolve(`${packageName}/package.json`),
-				'utf-8'
+				'utf8'
 			)
 		);
 
@@ -69,7 +69,7 @@ module.exports = function (bridges, dir) {
 	getModule('${projectPackageJson.name}').then(
 		function({${exportName}}) {
 			Liferay.Loader.define(
-				"${namespacedVersionedPackageName}/${moduleName}", ['module'],
+				'${namespacedVersionedPackageName}/${moduleName}', ['module'],
 				function (module) {
 					module.exports = ${exportName};
 				}
@@ -79,5 +79,5 @@ module.exports = function (bridges, dir) {
 })();
 `
 		);
-	});
+	}
 };

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/createBridges.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/createBridges.js
@@ -1,0 +1,83 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const {addNamespace} = require('@liferay/js-toolkit-core');
+const fs = require('fs');
+const path = require('path');
+
+module.exports = function (bridges, dir) {
+	const projectPackageJson = JSON.parse(
+		fs.readFileSync('package.json', 'utf-8')
+	);
+
+	Object.entries(bridges).forEach(([packageName, exportName]) => {
+		const packageJson = JSON.parse(
+			fs.readFileSync(
+				require.resolve(`${packageName}/package.json`),
+				'utf-8'
+			)
+		);
+
+		const namespacedVersionedPackageName = addNamespace(
+			`${packageJson.name}@${packageJson.version}`,
+			projectPackageJson
+		);
+
+		const packageDir = path.join(
+			dir,
+			'node_modules',
+			namespacedVersionedPackageName
+		);
+
+		fs.mkdirSync(packageDir, {recursive: true});
+
+		fs.writeFileSync(
+			path.join(packageDir, 'package.json'),
+			JSON.stringify(
+				{
+					...packageJson,
+					name: addNamespace(packageJson.name, projectPackageJson),
+				},
+				null,
+				'\t'
+			)
+		);
+
+		let {main: moduleFileName} = packageJson;
+
+		moduleFileName = moduleFileName || 'index.js';
+		moduleFileName = moduleFileName.replace(/^\.\//, '');
+
+		if (!moduleFileName.toLowerCase().endsWith('.js')) {
+			moduleFileName += '.js';
+		}
+
+		fs.mkdirSync(path.join(packageDir, path.dirname(moduleFileName)), {
+			recursive: true,
+		});
+
+		const moduleName = moduleFileName.replace(/\.js$/i, '');
+
+		fs.writeFileSync(
+			path.join(packageDir, moduleFileName),
+			`
+(function() {
+	const getModule = window[Symbol.for('__LIFERAY_WEBPACK_GET_MODULE__')];
+
+	getModule('${projectPackageJson.name}').then(
+		function({${exportName}}) {
+			Liferay.Loader.define(
+				"${namespacedVersionedPackageName}/${moduleName}", ['module'],
+				function (module) {
+					module.exports = ${exportName};
+				}
+			);
+		}
+	);
+})();
+`
+		);
+	});
+};


### PR DESCRIPTION
This is implementation of #290 . Needed for [this portal PR](https://github.com/liferay-frontend/liferay-portal/pull/606).

I have tested it locally and it's not horrible.

--- 

What this basically does is adding a new section inside `federation` of `npmscripts.config.js` containing the packages to bridge. So, for example, if we had this in `frontend-js-react-web`'s `npmscripts.config.js`:

```javascript
module.exports = {
	federation: {
		bridges: {
			'classnames': '__classnames',
			'formik': '__formik',
			'prop-types': '__propTypes',
			'react': '__react',
			'react-dnd': '__reactDnd',
			'react-dnd-html5-backend': '__reactDndHtml5Backend',
			'react-dom': '__reactDom'
		},
		main: 'js/index.federation.js',
	}
};
```

It would create bridges from `classnames` in the AMD loader to `classnames` in the webpack realm. The `__classnames` part is the name of the member as it is exported in the webpack's main entry point of `frontend-js-react-web`. So, that file would be `js/index.federation.js` and would contain something like:

```javascript
export * as __classnames from 'classnames';
export * as __formik from 'formik';
export {default as __propTypes} from 'prop-types';
export {default as __react} from 'react';
export * as __reactDnd from 'react-dnd';
export * as __reactDndHtml5Backend from 'react-dnd-html5-backend';
export {default as __reactDom} from 'react-dom';
```

I know we could do the variable name by convention, but:

1) It requires more code
2) (Especially important, at least for me) There are so many things by convention now, that it is easy to get lost and remember where things come from and where should they be defined, so having it explicitly configured helps a lot with this (because it reminds you what to grep for).

Also, given that this is temporary and will be removed when the epic is finished, I think this is fair enough: it covers what we need now (for example: it doesn't allow bridging explicit modules, just package default entry points, which is the only thing we need now) with minimal configuration.

For completeness, the generated bridges look like this:

```javascript
(function() {
	const getModule = window[Symbol.for('__LIFERAY_WEBPACK_GET_MODULE__')];

	getModule('frontend-js-react-web').then(
		function({__classnames}) {
			Liferay.Loader.define(
				"frontend-js-react-web$classnames@2.2.6/index", ['module'],
				function (module) {
					module.exports = __classnames;
				}
			);
		}
	);
})();
```