### PR TITLE
chore(monorepo): freshen lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9815,7 +9815,7 @@ liferay-npm-bundler@2.19.4:
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-liferay-theme-tasks@10.0.2, liferay-theme-tasks@^10.0.0:
+liferay-theme-tasks@10.0.2:
   version "10.0.2"
   resolved "https://registry.yarnpkg.com/liferay-theme-tasks/-/liferay-theme-tasks-10.0.2.tgz#6efcbbd3f402c626ef5b77de8fcd0575c79fdd0d"
   integrity sha512-ES7Oe3sBpRBMTkX4rqfgvl1tsJvERfTd2b/UyT/x8LERuQeXu0v9fbuc3vbNpDTbXxnSJglTDt0GxbCCjpTImw==


### PR DESCRIPTION
Just this noisy little change that came up during the releases:

- https://github.com/liferay/liferay-frontend-projects/releases/tag/generator-liferay-theme%2Fv10.0.2
- https://github.com/liferay/liferay-frontend-projects/releases/tag/liferay-theme-tasks%2Fv10.0.3

CI will complain until this goes in. Example complaint:

https://github.com/liferay/liferay-frontend-projects/actions/runs/421524069