### PR TITLE
fix(npm-scripts): support scoped packages correctly

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/scripts/createBridges.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/createBridges.js
@@ -28,7 +28,7 @@ module.exports = function (bridges, dir) {
 		const packageDir = path.join(
 			dir,
 			'node_modules',
-			namespacedVersionedPackageName
+			namespacedVersionedPackageName.replace('/', '%2F')
 		);
 
 		fs.mkdirSync(packageDir, {recursive: true});


### PR DESCRIPTION
I thought using liferay-js-toolkit-core for namespacing would have done this, but it turns out that [it is done at the bundler level](https://github.com/liferay/liferay-frontend-projects/blob/2da0f09cc0c885db457f4237bd1ac0b432c92bf4/projects/js-toolkit/packages/npm-bundler/src/adapt/bundler-project/write-export-modules.ts#L44), so we have to mimic it here.

I'm not releasing yet, because I have spotted a new error in the [portal's PR](https://github.com/liferay-frontend/liferay-portal/pull/606) :-(