### PR TITLE
fix(js-toolkit): unable to deploy to 7.1 due to InvalidSyntaxException

### DIFF
--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/__tests__/manifest.test.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/__tests__/manifest.test.js
@@ -123,7 +123,7 @@ it('includes Require-Capability when provided', () => {
 	expect(manifest.content).toEqual(
 		`Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Require-Capability: my-capability;filter:=capability-value
+Require-Capability: my-capability;filter:="capability-value"
 Tool: liferay-npm-bundler-${version}
 `
 	);

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/manifest.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/manifest.ts
@@ -64,7 +64,7 @@ export default class Manifest {
 			throw new Error(`RequireCapability[${key}] can only be set once`);
 		}
 
-		this._requireCapabilities[key] = `filter:=${filter}`;
+		this._requireCapabilities[key] = `filter:="${filter}"`;
 	}
 
 	addCustomHeader(key: string, value: string): void {


### PR DESCRIPTION
See [LPP-39704](https://issues.liferay.com/browse/LPP-39704)
