### PR TITLE
feat(js-themes-toolkit): expose r2 API

### DIFF
--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/__tests__/index.test.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/__tests__/index.test.js
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const {r2} = require('liferay-theme-tasks');
+
+describe('index.js', () => {
+	it('exposes the r2 API from the "main" package resource', () => {
+		expect(require('liferay-theme-tasks')).toBe(require('..'));
+
+		expect(Object.keys(r2).sort()).toEqual(['exec', 'swap', 'valueMap']);
+	});
+
+	describe('r2.swap()', () => {
+		const {swap} = r2;
+
+		it('swap text alignment', () => {
+			expect(swap('p{text-align:right;}')).toEqual(
+				'p{text-align:left;}',
+				'text-align: left => text-align: right'
+			);
+			expect(swap('p{text-align:left;}')).toEqual(
+				'p{text-align:right;}',
+				'text-align: right => text-align: left'
+			);
+		});
+	});
+});

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/index.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/index.js
@@ -9,6 +9,7 @@ const _ = require('lodash');
 
 const checkNodeVersion = require('../lib/checkNodeVersion');
 const project = require('../lib/project');
+const r2 = require('../lib/r2/liferay-r2');
 const {getArgv} = require('../lib/util');
 const plugin = require('../plugin');
 const registerTaskBuild = require('./tasks/build');
@@ -80,5 +81,6 @@ function register() {
 }
 
 module.exports = {
+	r2,
 	registerTasks,
 };


### PR DESCRIPTION
As discussed in [the issue](https://github.com/liferay/liferay-frontend-projects/issues/249), we already have a copy of the liferay-r2 code originally hosted at [liferay-labs/R2](https://github.com/liferay-labs/R2), which got inlined into the themes toolkit in [this commit](https://github.com/liferay/liferay-js-themes-toolkit/commit/a843516ffb18bbeb9b3c3b1c7de8a2622d233b12#diff-a016e05e9164926c610083bf8d96c2a4d473221ecda45c00522bdef0c5d97585).

So, given that we needed access to r2's functionality in [this PR](https://github.com/liferay/liferay-frontend-projects/pull/282), we can just leverage the existing copy of the code that we have in the
theme tasks (npm-scripts already depends on the theme tasks).

Note that I added a couple of simple tests to show that you can actually grab and use the r2 API from the public interface of the package.

Closes: https://github.com/liferay/liferay-frontend-projects/issues/249