### PR TITLE
chore(js-themes-toolkit): restore missing license information

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -19,8 +19,8 @@
 #
 
 /copyright.js
-/maintenance/projects/*/copyright.js
-/projects/*/copyright.js
+/maintenance/projects/**/copyright.js
+/projects/**/copyright.js
 
 #
 # Third-party code

--- a/.prettierignore
+++ b/.prettierignore
@@ -22,5 +22,5 @@
 #
 
 /copyright.js
-/maintenance/projects/*/copyright.js
-/projects/*/copyright.js
+/maintenance/projects/**/copyright.js
+/projects/**/copyright.js

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/.eslintrc.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/.eslintrc.js
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const path = require('path');
+
+module.exports = {
+	overrides: [
+		{
+
+			// These files originally from: https://github.com/ded/R2
+			// Via fork: https://github.com/liferay-labs/R2
+
+			files: ['index.js', '__tests__/index.test.js'],
+			rules: {
+				'notice/notice': [
+					'error',
+					{
+						templateFile: path.join(__dirname, 'copyright.js'),
+					},
+				],
+			},
+		},
+	],
+};

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/__tests__/index.test.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/__tests__/index.test.js
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-FileCopyrightText: © 2012 Dustin Diaz
  * SPDX-License-Identifier: MIT
  */
 

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/copyright.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/copyright.js
@@ -1,0 +1,5 @@
+/**
+ * SPDX-FileCopyrightText: © 2012 Dustin Diaz
+ * SPDX-License-Identifier: MIT
+ */
+

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/index.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/index.js
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-FileCopyrightText: © 2012 Dustin Diaz
  * SPDX-License-Identifier: MIT
  */
 

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/.eslintrc.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/.eslintrc.js
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const path = require('path');
+
+module.exports = {
+	overrides: [
+		{
+
+			// These files originally from: https://github.com/ded/R2
+			// Via fork: https://github.com/liferay-labs/R2
+
+			files: ['index.js', '__tests__/index.test.js'],
+			rules: {
+				'notice/notice': [
+					'error',
+					{
+						templateFile: path.join(__dirname, 'copyright.js'),
+					},
+				],
+			},
+		},
+	],
+};

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/__tests__/index.test.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/__tests__/index.test.js
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-FileCopyrightText: © 2012 Dustin Diaz
  * SPDX-License-Identifier: MIT
  */
 

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/copyright.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/copyright.js
@@ -1,0 +1,5 @@
+/**
+ * SPDX-FileCopyrightText: © 2012 Dustin Diaz
+ * SPDX-License-Identifier: MIT
+ */
+

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/index.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/index.js
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-FileCopyrightText: © 2012 Dustin Diaz
  * SPDX-License-Identifier: MIT
  */
 


### PR DESCRIPTION
As noted here:

- https://github.com/liferay/liferay-frontend-projects/issues/249#issuecomment-733010877
- https://github.com/liferay/liferay-js-themes-toolkit/pull/424#discussion_r368860354

We dropped some licensing information when we forked this package from [ded/R2](https://github.com/ded/R2) into [liferay-labs/R2](https://github.com/liferay-labs/R2). We later [inlined the code into the themes toolkit](https://github.com/liferay/liferay-js-themes-toolkit/commit/a843516ffb18bbeb9b3c3b1c7de8a2622d233b12), and did not restore the original copyright.

Seeing as we were looking at this code for [issue #249](https://github.com/liferay/liferay-frontend-projects/issues/249), we may as well put things right now.

Basically, there are only two files of interest in the original implementation (the index and the tests), so we put the correct copyright information in those via an override and leave everything else; you can see that the other files were added by us with original authorship by looking at [the commit listing in the liferay-labs repo](https://github.com/liferay-labs/R2/commits/master).

We make the change on v10 and v9 of the toolkit (v8 doesn't have an inlined copy of the module).