### PR TITLE
chore(monorepo): use "dependencies" label instead of "dev-dependency"

### DIFF
--- a/.github/ISSUE_TEMPLATE/devDependency.md
+++ b/.github/ISSUE_TEMPLATE/devDependency.md
@@ -1,7 +1,7 @@
 ---
 name: 📦 devDependency
 about: Issues about adding new devDependencies
-labels: dev-dependency
+labels: dependencies
 ---
 
 <!--

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ These are the documents that used to live in the [liferay-frontend-guidelines](h
 -   [`guidelines/dxp/`](guidelines/dxp): Guidance specific to working on Liferay DXP.
 -   [`guidelines/css/`](guidelines/css): Guidance about CSS.
 
-| Issues                                                                                                                               | Actions                                                                                                                      |
-| ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| [label: `dependencies`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Adependencies)     | [New issue](https://github.com/liferay/liferay-frontend-projects/issues/new?labels=dependencies&template=devDependency.md)   |
-| [label: `proposal`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Arfc)                  | [New issue](https://github.com/liferay/liferay-frontend-projects/issues/new?labels=rfc&template=Proposal.md)                 |
-| [label: `question`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Aquestion)             | [New issue](https://github.com/liferay/liferay-frontend-projects/issues/new?labels=question&template=Question.md)            |
+| Issues                                                                                                                           | Actions                                                                                                                    |
+| -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| [label: `dependencies`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Adependencies) | [New issue](https://github.com/liferay/liferay-frontend-projects/issues/new?labels=dependencies&template=devDependency.md) |
+| [label: `proposal`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Arfc)              | [New issue](https://github.com/liferay/liferay-frontend-projects/issues/new?labels=rfc&template=Proposal.md)               |
+| [label: `question`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Aquestion)         | [New issue](https://github.com/liferay/liferay-frontend-projects/issues/new?labels=question&template=Question.md)          |
 
 ## Projects
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ These are the documents that used to live in the [liferay-frontend-guidelines](h
 
 | Issues                                                                                                                               | Actions                                                                                                                      |
 | ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| [label: `dev-dependency`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Adev-dependency) | [New issue](https://github.com/liferay/liferay-frontend-projects/issues/new?labels=dev-dependency&template=devDependency.md) |
+| [label: `dependencies`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Adependencies)     | [New issue](https://github.com/liferay/liferay-frontend-projects/issues/new?labels=dependencies&template=devDependency.md)   |
 | [label: `proposal`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Arfc)                  | [New issue](https://github.com/liferay/liferay-frontend-projects/issues/new?labels=rfc&template=Proposal.md)                 |
 | [label: `question`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Aquestion)             | [New issue](https://github.com/liferay/liferay-frontend-projects/issues/new?labels=question&template=Question.md)            |
 


### PR DESCRIPTION
We were using "dev-dependency" over in [the old repo](https://github.com/liferay/liferay-frontend-guidelines) but every time dependabot opens a PR with us it's going to spammily recreate a "dependencies" label, so we may as well just use that one.