### PR TITLE
chore: set up autolabeling of "docs" and "guidelines" changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -31,9 +31,17 @@ changelog-generator:
     - projects/npm-tools/packages/changelog-generator/*
     - projects/npm-tools/packages/changelog-generator/**/*
 
+docs:
+    - '*.md'
+    - '**/*.md'
+
 eslint-config:
     - projects/eslint-config/*
     - projects/eslint-config/**/*
+
+guidelines:
+    - guidelines/*
+    - guidelines/**/*
 
 jest-junit-reporter:
     - projects/npm-tools/packages/jest-junit-reporter/*


### PR DESCRIPTION
Any change to an "*.md" file is labeled as "docs". Additionally, changes under "guidelines/" are special-cased to reflect that they are meta-documentation about how we do development.