### PR TITLE
refactor(monorepo): split GitHub workflows by Yarn workspaces

### DIFF
--- a/.github/workflows/global.yml
+++ b/.github/workflows/global.yml
@@ -1,6 +1,6 @@
 # Based on: https://github.com/actions/starter-workflows/blob/master/ci/node.js.yml
 
-name: ci
+name: global
 
 on:
     push:
@@ -98,79 +98,6 @@ jobs:
             - run: yarn --cache-folder=${{ env.yarn-cache-path }} --frozen-lockfile
             - run: yarn --cache-folder=${{ env.yarn-cache-path }} build
             - run: yarn --cache-folder=${{ env.yarn-cache-path }} test
-
-    test-js-themes-toolkit-v8:
-        runs-on: ubuntu-latest
-
-        strategy:
-            matrix:
-                node-version: [10.x]
-
-        steps:
-            - uses: actions/checkout@v2
-            - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v1
-              with:
-                  node-version: ${{ matrix.node-version }}
-            - name: Use or update Yarn cache
-              uses: actions/cache@v2
-              with:
-                  path: ${{ env.yarn-cache-path }}
-                  key: ${{ runner.os }}-${{ env.yarn-cache-name }}-${{ hashFiles('**/yarn.lock') }}-js-themes-toolkit-v8
-            - run: yarn --cache-folder=../../../${{ env.yarn-cache-path }} --frozen-lockfile
-              working-directory: maintenance/projects/js-themes-toolkit-v8-x
-            - run: yarn --cache-folder=../../../${{ env.yarn-cache-path }} test
-              working-directory: maintenance/projects/js-themes-toolkit-v8-x
-
-    test-js-themes-toolkit-v9:
-        runs-on: ubuntu-latest
-
-        strategy:
-            matrix:
-                node-version: [10.x]
-
-        steps:
-            - uses: actions/checkout@v2
-            - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v1
-              with:
-                  node-version: ${{ matrix.node-version }}
-            - name: Use or update Yarn cache
-              uses: actions/cache@v2
-              with:
-                  path: ${{ env.yarn-cache-path }}
-                  key: ${{ runner.os }}-${{ env.yarn-cache-name }}-${{ hashFiles('**/yarn.lock') }}-js-themes-toolkit-v9
-            - run: yarn --cache-folder=../../../${{ env.yarn-cache-path }} --frozen-lockfile
-              working-directory: maintenance/projects/js-themes-toolkit-v9-x
-            - run: yarn --cache-folder=../../../${{ env.yarn-cache-path }} test
-              working-directory: maintenance/projects/js-themes-toolkit-v9-x
-
-    test-js-toolkit-v2:
-        runs-on: ubuntu-latest
-
-        strategy:
-            matrix:
-                node-version: [12.x]
-
-        steps:
-            - uses: actions/checkout@v2
-            - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v1
-              with:
-                  node-version: ${{ matrix.node-version }}
-            - name: Use or update Yarn cache
-              uses: actions/cache@v2
-              with:
-                  path: ${{ env.yarn-cache-path }}
-                  key: ${{ runner.os }}-${{ env.yarn-cache-name }}-${{ hashFiles('**/yarn.lock') }}-js-toolkit
-            - run: yarn --cache-folder=../../../${{ env.yarn-cache-path }} --frozen-lockfile
-              working-directory: maintenance/projects/js-toolkit
-            - run: yarn --cache-folder=../../../${{ env.yarn-cache-path }} check-deps
-              working-directory: maintenance/projects/js-toolkit
-            - run: yarn --cache-folder=../../../${{ env.yarn-cache-path }} build
-              working-directory: maintenance/projects/js-toolkit
-            - run: yarn --cache-folder=../../../${{ env.yarn-cache-path }} test
-              working-directory: maintenance/projects/js-toolkit
 
     test-windows:
         runs-on: windows-latest

--- a/.github/workflows/guidelines.yml
+++ b/.github/workflows/guidelines.yml
@@ -1,6 +1,6 @@
 # Based on: https://github.com/actions/starter-workflows/blob/master/ci/node.js.yml
 
-name: Guidelines
+name: guidelines
 
 on:
     push:

--- a/.github/workflows/js-themes-toolkit-v8-x.yml
+++ b/.github/workflows/js-themes-toolkit-v8-x.yml
@@ -1,0 +1,65 @@
+# Based on: https://github.com/actions/starter-workflows/blob/master/ci/node.js.yml
+
+name: js-themes-toolkit-v8-x
+
+on:
+    push:
+        branches: [master]
+        paths:
+            - 'maintenance/projects/js-themes-toolkit-v8-x/**'
+    pull_request:
+        branches: [master]
+        paths:
+            - 'maintenance/projects/js-themes-toolkit-v8-x/**'
+
+env:
+    CI: true
+    yarn-cache-name: yarn-cache-2
+    yarn-cache-path: .yarn
+
+jobs:
+    check-lockfile:
+        runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                node-version: [12.x]
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v1
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - name: Use or update Yarn cache
+              uses: actions/cache@v2
+              with:
+                  path: ${{ env.yarn-cache-path }}
+                  key: ${{ runner.os }}-${{ env.yarn-cache-name }}-${{ hashFiles('**/yarn.lock') }}
+            - run: yarn --cache-folder=${{ env.yarn-cache-path }}
+              working-directory: maintenance/projects/js-themes-toolkit-v8-x
+            - run: git diff --quiet -- yarn.lock
+              working-directory: maintenance/projects/js-themes-toolkit-v8-x
+
+    test:
+        runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                node-version: [10.x]
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v1
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - name: Use or update Yarn cache
+              uses: actions/cache@v2
+              with:
+                  path: ${{ env.yarn-cache-path }}
+                  key: ${{ runner.os }}-${{ env.yarn-cache-name }}-${{ hashFiles('**/yarn.lock') }}-js-themes-toolkit-v8
+            - run: yarn --cache-folder=../../../${{ env.yarn-cache-path }} --frozen-lockfile
+              working-directory: maintenance/projects/js-themes-toolkit-v8-x
+            - run: yarn --cache-folder=../../../${{ env.yarn-cache-path }} test
+              working-directory: maintenance/projects/js-themes-toolkit-v8-x

--- a/.github/workflows/js-themes-toolkit-v9-x.yml
+++ b/.github/workflows/js-themes-toolkit-v9-x.yml
@@ -1,0 +1,65 @@
+# Based on: https://github.com/actions/starter-workflows/blob/master/ci/node.js.yml
+
+name: js-themes-toolkit-v9-x
+
+on:
+    push:
+        branches: [master]
+        paths:
+            - 'maintenance/projects/js-themes-toolkit-v9-x/**'
+    pull_request:
+        branches: [master]
+        paths:
+            - 'maintenance/projects/js-themes-toolkit-v9-x/**'
+
+env:
+    CI: true
+    yarn-cache-name: yarn-cache-2
+    yarn-cache-path: .yarn
+
+jobs:
+    check-lockfile:
+        runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                node-version: [12.x]
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v1
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - name: Use or update Yarn cache
+              uses: actions/cache@v2
+              with:
+                  path: ${{ env.yarn-cache-path }}
+                  key: ${{ runner.os }}-${{ env.yarn-cache-name }}-${{ hashFiles('**/yarn.lock') }}
+            - run: yarn --cache-folder=${{ env.yarn-cache-path }}
+              working-directory: maintenance/projects/js-themes-toolkit-v9-x
+            - run: git diff --quiet -- yarn.lock
+              working-directory: maintenance/projects/js-themes-toolkit-v9-x
+
+    test:
+        runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                node-version: [10.x]
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v1
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - name: Use or update Yarn cache
+              uses: actions/cache@v2
+              with:
+                  path: ${{ env.yarn-cache-path }}
+                  key: ${{ runner.os }}-${{ env.yarn-cache-name }}-${{ hashFiles('**/yarn.lock') }}-js-themes-toolkit-v9
+            - run: yarn --cache-folder=../../../${{ env.yarn-cache-path }} --frozen-lockfile
+              working-directory: maintenance/projects/js-themes-toolkit-v9-x
+            - run: yarn --cache-folder=../../../${{ env.yarn-cache-path }} test
+              working-directory: maintenance/projects/js-themes-toolkit-v9-x

--- a/.github/workflows/js-toolkit-v2.yml
+++ b/.github/workflows/js-toolkit-v2.yml
@@ -1,0 +1,69 @@
+# Based on: https://github.com/actions/starter-workflows/blob/master/ci/node.js.yml
+
+name: js-toolkit-v2
+
+on:
+    push:
+        branches: [master]
+        paths:
+            - 'maintenance/projects/js-toolkit/**'
+    pull_request:
+        branches: [master]
+        paths:
+            - 'maintenance/projects/js-toolkit/**'
+
+env:
+    CI: true
+    yarn-cache-name: yarn-cache-2
+    yarn-cache-path: .yarn
+
+jobs:
+    check-lockfile:
+        runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                node-version: [12.x]
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v1
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - name: Use or update Yarn cache
+              uses: actions/cache@v2
+              with:
+                  path: ${{ env.yarn-cache-path }}
+                  key: ${{ runner.os }}-${{ env.yarn-cache-name }}-${{ hashFiles('**/yarn.lock') }}
+            - run: yarn --cache-folder=${{ env.yarn-cache-path }}
+              working-directory: maintenance/projects/js-toolkit
+            - run: git diff --quiet -- yarn.lock
+              working-directory: maintenance/projects/js-toolkit
+
+    test:
+        runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                node-version: [12.x]
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v1
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - name: Use or update Yarn cache
+              uses: actions/cache@v2
+              with:
+                  path: ${{ env.yarn-cache-path }}
+                  key: ${{ runner.os }}-${{ env.yarn-cache-name }}-${{ hashFiles('**/yarn.lock') }}-js-toolkit
+            - run: yarn --cache-folder=../../../${{ env.yarn-cache-path }} --frozen-lockfile
+              working-directory: maintenance/projects/js-toolkit
+            - run: yarn --cache-folder=../../../${{ env.yarn-cache-path }} check-deps
+              working-directory: maintenance/projects/js-toolkit
+            - run: yarn --cache-folder=../../../${{ env.yarn-cache-path }} build
+              working-directory: maintenance/projects/js-toolkit
+            - run: yarn --cache-folder=../../../${{ env.yarn-cache-path }} test
+              working-directory: maintenance/projects/js-toolkit


### PR DESCRIPTION
Before:

-   `ci.yml`:
    -   Runs repo-wide lint and formatting checks.
    -   Runs tests for all four groups of yarn workspaces, corresponding to:
        -   `yarn.lock` (ie. everything under `projects/` on Linux and Windows).
        -   `maintenance/projects/js-themes-toolkit-v8-x/yarn.lock`
        -   `maintenance/projects/js-themes-toolkit-v9-x/yarn.lock`
        -   `maintenance/projects/js-toolkit/yarn.lock`
    -   Checks top-level `yarn.lock` only for unwanted changes during installation.
-   `guidelines.yml`: runs checks specific to "guidelines/" directory (specifically, broken-link checks).
-   `labeler.yml`: applies labels automatically based on paths touched by a PR.

After:

-   `guidelines.yml` and `labeler.yml`: same as before.
-   Split `ci.yml` into four files, one corresponding to each group of yarn workspaces:
    -   `js-themes-toolkit-v8-x.yml`: runs tests for the corresponding directory under "maintenance/"; also checks the lockfile.
    -   `js-themes-toolkit-v9-x`: runs tests for the corresponding directory under "maintenance/"; also checks the lockfile.
    -   `js-toolkit-v2.yml`: runs tests for the corresponding directory under "maintenance/"; also checks the lockfile.
    -   `global.yml`: effectively the remnant of "ci.yml"; now responsible for "everything else" (ie. global lints, format checks, tests under the "projects/" directory, and also checks the top-level lockfile).

So the net effect here should be that we:

-   Always run the "global" tests, lints, and format checks.
-   Always catch staleness of the top-level lockfile.
-   Run tests for projects under "maintenance/" only when touching files under those project folders; and when we do that, we check their lockfiles too.

I guess we'll see if this works... 🤷‍♂️ 