### PR TITLE
feat(js-themes-toolkit): adds js minification step (Fixes #364)

### DIFF
--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/project/options.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/project/options.js
@@ -74,6 +74,10 @@ class Options {
 		return this._options['sassOptions'];
 	}
 
+	get terser() {
+		return this._options['terser'];
+	}
+
 	_normalizeFilePath(optionName) {
 		const {_options} = this;
 
@@ -87,7 +91,7 @@ class Options {
 				Option ${optionName} contains '\\' characters.
 
 				This can be due to using Windows paths in a config file, which is not
-				supported, or because its use is legitimate in POSIX paths. 
+				supported, or because its use is legitimate in POSIX paths.
 
 				In the first case, you should edit your 'gulpfile.js' and change any
 				paths to be in POSIX format.

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/package.json
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/package.json
@@ -19,6 +19,7 @@
 		"gulp-replace-task": "^0.11.0",
 		"gulp-sass": "^3.2.0",
 		"gulp-sourcemaps": "1.6.0",
+		"gulp-terser": "^2.0.0",
 		"gulp-util": "^3.0.8",
 		"gulp-watch": "^5.0.1",
 		"gulp-zip": "^3.2.0",

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/tasks/build/index.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/tasks/build/index.js
@@ -7,8 +7,11 @@
 
 const chalk = require('chalk');
 const fs = require('fs-extra');
+const gulpIf = require('gulp-if');
 const rename = require('gulp-rename');
 const replace = require('gulp-replace-task');
+const sourcemaps = require('gulp-sourcemaps');
+const terser = require('gulp-terser');
 const _ = require('lodash');
 const path = require('path');
 const PluginError = require('plugin-error');
@@ -91,6 +94,7 @@ module.exports = function () {
 			'build:fix-at-directives',
 			'build:r2',
 			'build:copy:fontAwesome',
+			'build:minify:js',
 			'build:war',
 			cb
 		);
@@ -311,6 +315,17 @@ module.exports = function () {
 			pathBuild.join('font').asNative,
 			done
 		);
+	});
+
+	gulp.task('build:minify:js', () => {
+		const production = process.env.NODE_ENV === 'production';
+
+		return gulp
+			.src(pathBuild.join('**', '*.js').asPosix)
+			.pipe(gulpIf(production, sourcemaps.init()))
+			.pipe(gulpIf(production, terser(options.terser || {})))
+			.pipe(gulpIf(production, sourcemaps.write('.')))
+			.pipe(gulp.dest(pathBuild));
 	});
 
 	gulp.task('build:war', (done) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7076,6 +7076,16 @@ gulp-sourcemaps@1.6.0:
     through2 "^2.0.0"
     vinyl "^1.0.0"
 
+gulp-terser@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-terser/-/gulp-terser-2.0.0.tgz#07f95ef9121fe9d4970c3c4ee775c9cd658d0474"
+  integrity sha512-8KxzgUpNeLsSujUCrNKUiSI1ioO5TfW4ODhbM+wzNTWgYp7yCIl1c/5EeOI+SOXaNLi+BzzMqrbb0eYMIThFCQ==
+  dependencies:
+    plugin-error "^1.0.1"
+    terser "5.4.0"
+    through2 "^4.0.2"
+    vinyl-sourcemaps-apply "^0.2.1"
+
 gulp-util@^3.0, gulp-util@^3.0.0, gulp-util@^3.0.4, gulp-util@^3.0.7, gulp-util@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
@@ -12552,7 +12562,7 @@ read-pkg@^5.0.0, read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-"readable-stream@2 || 3", readable-stream@^3.0.6, readable-stream@^3.1.1:
+"readable-stream@2 || 3", readable-stream@3, readable-stream@^3.0.6, readable-stream@^3.1.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -14504,6 +14514,15 @@ terser@5.3.8, terser@^5.3.8:
     source-map "~0.7.2"
     source-map-support "~0.5.19"
 
+terser@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.4.0.tgz#9815c0839072d5c894e22c6fc508fbe9f5e7d7e8"
+  integrity sha512-3dZunFLbCJis9TAF2VnX+VrQLctRUmt1p3W2kCsJuZE4ZgWqh//+1MZ62EanewrqKoUf4zIaDGZAvml4UDc0OQ==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.7.2"
+    source-map-support "~0.5.19"
+
 terser@^4.6.3:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
@@ -14589,6 +14608,13 @@ through2@^3.0.0, through2@^3.0.1:
   dependencies:
     inherits "^2.0.4"
     readable-stream "2 || 3"
+
+through2@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-4.0.2.tgz#a7ce3ac2a7a8b0b966c80e7c49f0484c3b239764"
+  integrity sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==
+  dependencies:
+    readable-stream "3"
 
 through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.4:
   version "2.3.8"


### PR DESCRIPTION
Hey @bryceosterhaus, @wincent, my gulp fu is pretty rusty (or my fu in general), but I think this should do it as far as minifying JS in themes goes.

> In production mode, `terser` will be invoked to minify `js` resources in a theme after every other processing has taken place.
>
> Terser options can be overriden by declaring a `terser` object in the `package.json` file of your theme. By default, it is invoked with defaults configuration.
>
> Sourcemaps are enabled by default and handled outside of terser if the minification takes place.

Everytime I get back to this I get an intense urge of rewriting the whole thing, but instead, I end up adding yet another thing. One day, though...

![promise](https://user-images.githubusercontent.com/905006/102882900-060fd600-4447-11eb-801f-3e8a7d8297cc.gif)
