### PR TITLE
feat(guidelines): mitigate problems with link checker rate limiting

### DIFF
--- a/guidelines/support/checkLinks.js
+++ b/guidelines/support/checkLinks.js
@@ -177,6 +177,13 @@ function checkRemote(link, files) {
 				if (statusCode >= 200 && statusCode < 400) {
 					resolve();
 				}
+				else if (statusCode === 429) {
+					warn(
+						files,
+						`Cannot verify ${link} due to rate-limiting (HTTP 429 Too Many Requests)`
+					);
+					resolve();
+				}
 				else {
 					bail(`Status code ${statusCode} for remote link: ${link}`);
 				}
@@ -333,6 +340,9 @@ async function run(pending) {
 	}
 }
 
+/**
+ * Report a bad file (or files) and increment the total error count.
+ */
 function report(bad, message) {
 	const files = typeof bad === 'string' ? [bad] : [...bad];
 
@@ -363,6 +373,17 @@ async function* walk(directory) {
 			yield entry;
 		}
 	}
+}
+
+/**
+ * Warn about problems in `files`; this does not increment the total error count
+ * and does not affect the exit status of the process.
+ */
+function warn(files, message) {
+	files.forEach((file) => {
+		// eslint-disable-next-line no-console
+		console.log(`${file}: ${message}`);
+	});
 }
 
 main()


### PR DESCRIPTION
This mitigates but does not fix [#360](https://github.com/liferay/liferay-frontend-projects/issues/360).

At this point we see a reliable pattern of npmjs servers rate-limiting us with [HTTP 429 "Too Many Requests" status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429).

Seeing as these links are not definitely broken (ie. they're just not provably correct) we should treat them as soft warnings (even if no one reads them) instead of hard errors.

We can still look at doing something fancy in the future to properly deal with #360, but the present change is cheap and stops the bleeding.