### PR TITLE
refactor(guidelines): use a better name for CI job

### DIFF
--- a/.github/workflows/guidelines.yml
+++ b/.github/workflows/guidelines.yml
@@ -16,7 +16,7 @@ env:
     yarn-cache-path: .yarn
 
 jobs:
-    build:
+    check-links:
         runs-on: ubuntu-latest
 
         strategy:


### PR DESCRIPTION
So it will show up as "guidelines/check-links" instead of "guidelines/build" (which is a bit misleading. All the other jobs have more accurate/descriptive names, like "check-lockfile", "format-check" and so on, so this just brings this workflow into line with the others.