### PR TITLE
fix: stabilize liferay-portal build until a new webpack release arrives

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/utils/createBridges.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/createBridges.js
@@ -24,12 +24,15 @@ const writeBridge = require('./writeBridge');
  * @return {void}
  */
 module.exports = function (bridges, dir) {
+
 	// If bridges is undefined or false, do nothing
+
 	if (!bridges) {
 		return;
 	}
 
 	// If bridges is true, generate the `main` entry bridge only
+
 	if (bridges === true) {
 		bridges = [];
 	}

--- a/projects/npm-tools/packages/npm-scripts/src/utils/createBridges.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/createBridges.js
@@ -24,6 +24,16 @@ const writeBridge = require('./writeBridge');
  * @return {void}
  */
 module.exports = function (bridges, dir) {
+	// If bridges is undefined or false, do nothing
+	if (!bridges) {
+		return;
+	}
+
+	// If bridges is true, generate the `main` entry bridge only
+	if (bridges === true) {
+		bridges = [];
+	}
+
 	/* eslint-disable-next-line @liferay/liferay/no-dynamic-require */
 	const projectPackageJson = require(path.resolve('package.json'));
 
@@ -35,9 +45,7 @@ module.exports = function (bridges, dir) {
 		writeBridge(dir, projectPackageJson);
 	}
 
-	// Write bridges for exported dependencies (if configured)
-
-	bridges = bridges || [];
+	// Write bridges for exported dependencies
 
 	for (const packageName of bridges) {
 		const packageJson = JSON.parse(


### PR DESCRIPTION
This is like reverting to version 36.2.0 but without removing the code, so that we leave `liferay-portal` build in a stable situation for further development.

The code being removed was necessary for [LPS-124287](https://issues.liferay.com/browse/LPS-124287) but given that it won't make it into portal until a new webpack release is made, we are removing this code until then.

The serve side counterpart of this PR is [here](https://github.com/liferay-frontend/liferay-portal/pull/660)
    
