### PR TITLE
feat: provide a mechanism to extend the `remotes` and `shared` fields of webpack config

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/package.json
+++ b/projects/npm-tools/packages/npm-scripts/package.json
@@ -51,6 +51,7 @@
 		"metal-tools-soy": "4.3.2",
 		"mini-css-extract-plugin": "0.11.2",
 		"minimist": "^1.2.0",
+		"path-browserify": "^1.0.1",
 		"prettier": "^2.1.2",
 		"react": "*",
 		"react-dom": "*",

--- a/projects/npm-tools/packages/npm-scripts/src/transform/js/relocateImports.js
+++ b/projects/npm-tools/packages/npm-scripts/src/transform/js/relocateImports.js
@@ -50,6 +50,7 @@ module.exports = function (previousDirRelPath) {
 
 				if (
 					NODE_TYPES.has(node.type) &&
+					source &&
 					source.value.startsWith('./')
 				) {
 					source.value = source.value.replace(/^\./, dotReplacement);

--- a/projects/npm-tools/packages/npm-scripts/src/utils/createFederationConfig.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/createFederationConfig.js
@@ -127,5 +127,10 @@ module.exports = async function () {
 					}, {}),
 			}),
 		],
+		resolve: {
+			fallback: {
+				path: require.resolve('path-browserify'),
+			},
+		},
 	};
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11804,6 +11804,11 @@ passwd-user@^3.0.0:
   dependencies:
     execa "^1.0.0"
 
+path-browserify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
+
 path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"


### PR DESCRIPTION
See [IFI-2310](https://issues.liferay.com/browse/IFI-2310).

The changes here are needed to build and deploy [this branch](https://github.com/izaera/liferay-portal/tree/LPS-125746).

I will release a new version of `npm-scripts` after this is merged which, BTW, should be the last that we need unless we add new features or fix bugs, because I have added all information contained in the old default preset (see [this commit](https://github.com/liferay/liferay-frontend-projects/commit/c380ba0e1fb1e4f8c3b9e168a7d3b1b667eb75cd)) given that it doesn't fail the build. In addition, it has been made extensible, so..., that should be enough.

As always this has been tested locally with the linked private branch of `liferay-portal`.

I will send the portal's PR as soon as we release a new version of npm-scripts.