### PR TITLE
feat: allow extension of webpack `exposes`

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/utils/createFederationConfig.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/createFederationConfig.js
@@ -263,13 +263,19 @@ module.exports = async function () {
 	};
 };
 
-function transformExposes(exposes, inputDirectory) {
+function transformExposes(exposes, inputDir) {
 	return exposes.reduce((exposes, filePath) => {
-		const exposeName = path.posix
-			.relative('.', filePath)
-			.replace(/\.js$/i, '');
+		if (!filePath.startsWith('<inputDir>/')) {
+			throw new Error(
+				"Only paths relative to '<inputDir>/' are accepted as 'exposes'"
+			);
+		}
 
-		exposes[exposeName] = `./${inputDirectory}/${filePath}`;
+		filePath = filePath.replace(/^<inputDir>\//, '');
+
+		const exposeName = filePath.replace(/\.js$/i, '');
+
+		exposes[exposeName] = `./${inputDir}/${filePath}`;
 
 		return exposes;
 	}, {});

--- a/projects/npm-tools/packages/npm-scripts/src/utils/createFederationConfig.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/createFederationConfig.js
@@ -225,7 +225,7 @@ module.exports = async function () {
 		plugins: [
 			new ModuleFederationPlugin({
 				exposes: {
-					...prefixExposesPaths(exposes, `./${build.input}/`),
+					...transformExposes(exposes, build.input),
 					'.': mainFilePath,
 				},
 				filename: 'container.js',
@@ -263,13 +263,13 @@ module.exports = async function () {
 	};
 };
 
-function prefixExposesPaths(exposes, prefix) {
+function transformExposes(exposes, inputDirectory) {
 	return exposes.reduce((exposes, filePath) => {
 		const exposeName = path.posix
 			.relative('.', filePath)
 			.replace(/\.js$/i, '');
 
-		exposes[exposeName] = `${prefix}${filePath}`;
+		exposes[exposeName] = `./${inputDirectory}/${filePath}`;
 
 		return exposes;
 	}, {});


### PR DESCRIPTION
This is needed for LPS-126503 because we need to export JS endpoint to be consumed from `<react:component>`.

I've tested this locally.