### PR TITLE
feat(eslint-config): add Cavanaugh 7.4.x to list of possible deprecations

### DIFF
--- a/projects/eslint-config/plugins/portal/docs/rules/deprecation.md
+++ b/projects/eslint-config/plugins/portal/docs/rules/deprecation.md
@@ -39,6 +39,7 @@ In short, all notices should contain one of the following version descriptors:
 -   Judson (7.1.x)
 -   Mueller (7.2.x)
 -   Athanasius (7.3.x)
+-   Cavanaugh (7.4.x)
 
 And replacement information of the form:
 

--- a/projects/eslint-config/plugins/portal/lib/rules/deprecation.js
+++ b/projects/eslint-config/plugins/portal/lib/rules/deprecation.js
@@ -25,6 +25,7 @@ const VERSIONS = new Map([
 	['7.1', 'Judson (7.1.x)'],
 	['7.2', 'Mueller (7.2.x)'],
 	['7.3', 'Athanasius (7.3.x)'],
+	['7.4', 'Cavanaugh (7.4.x)'],
 ]);
 
 /**

--- a/projects/eslint-config/plugins/portal/tests/lib/rules/deprecation.js
+++ b/projects/eslint-config/plugins/portal/tests/lib/rules/deprecation.js
@@ -480,6 +480,27 @@ ruleTester.run('deprecation', rule, {
 		{
 			code: `
 				/**
+				 * @deprecated As of Cavanaugh (7.4.x)
+				 */
+			`,
+		},
+		{
+			code: `
+				/**
+				 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+				 */
+			`,
+		},
+		{
+			code: `
+				/**
+				 * @deprecated As of Cavanaugh (7.4.x), replaced by Liferay.Qux
+				 */
+			`,
+		},
+		{
+			code: `
+				/**
 				 * Note: It doesn't make any sense to have more than one
 				 * deprecation notice in a single comment, but this example is
 				 * just to show that we process these annotations line-by-line


### PR DESCRIPTION
Fixes #388 

It adds `Cavanaugh (7.4.x)` to the list of possible deprecation versions, adds it to the docs, and adds it to the test.
I ran `yarn ci` and it was green, as all CI's should be.

I didn't mess around with the versioning thing, as I saw some other changes were in the list, if I needed to do that LMK so I can do it.