### PR TITLE
docs: link to general guidelines and list recommended scopes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,23 @@ These apply to any work at Liferay, including in this monorepo:
 -   [Creating a project](CONTRIBUTING/creating-a-project.md)
 -   [Importing a project](CONTRIBUTING/importing-a-project.md)
 -   [Migrating an npm package to the `@liferay` named scope](CONTRIBUTING/migrating-an-npm-package-to-the-liferay-named-scope.md)
+
+## Conventional commit scopes
+
+It is helpful to include [an optional scope in your commit messages](guidelines/general/commit_messages.md) so that people can see, at a glance, which commits affect which projects. Valid scopes correspond to project names such as:
+
+-   `eslint-config`
+-   `js-themes-toolkit`
+-   `js-toolkit`
+-   `npm-tools`
+
+And package names such as:
+
+-   `changelog-generator`
+-   `js-publish`
+-   `npm-scripts`
+-   `workspace-scripts`
+
+As well as the scope of `monorepo` to label cross-cutting changes that affect multiple projects and packages in the monorepo.
+
+**NOTE:** The preceding lists are non-exhaustive and for illustration purposes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contributing
 
+## General guidelines
+
+These apply to any work at Liferay, including in this monorepo:
+
+-   [Guidelines](guidelines) (in particular, see the [`guidelines/general`](guidelines/general) directory).
+
 ## Project-specific contribution guidelines
 
 -   [`eslint-config`](projects/eslint-config/CONTRIBUTING.md)

--- a/guidelines/README.md
+++ b/guidelines/README.md
@@ -2,7 +2,7 @@
 
 ![guidelines](https://github.com/liferay/liferay-frontend-projects/workflows/guidelines/badge.svg)
 
-This is a live (changing) repository containing [general](/general) and [Liferay DXP-specific](/dxp) guidelines for doing Frontend Development at Liferay Inc.
+This is a live (changing) repository containing [general](general) and [Liferay DXP-specific](dxp) guidelines for doing Frontend Development at Liferay Inc.
 
 ## Guideline development
 


### PR DESCRIPTION
Based on [conversation here](https://github.com/liferay/liferay-frontend-projects/pull/389#issuecomment-770646774) which was about not finding contributing guidelines for how to format commit messages.

We could still use some more specific docs about what scopes we'd like to see when working in the monorepo (eg. using scopes to indicate project), so I added that in the second commit.