### PR TITLE
chore(jquery-form): prepare to release jquery-form under named scope

### DIFF
--- a/third-party/projects/jquery-form/package.json
+++ b/third-party/projects/jquery-form/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jquery-form",
+  "name": "@liferay/jquery-form",
   "title": "jQuery Form Plugin",
   "description": "A simple way to AJAX-ify any form on your page; with file upload and progress support.",
   "keywords": [

--- a/third-party/projects/jquery-form/package.json
+++ b/third-party/projects/jquery-form/package.json
@@ -41,5 +41,10 @@
     "gulp-uglify": "~0.2.1",
     "gulp-concat": "~2.1.7",
     "gulp-jshint": "~1.4.2"
+  },
+  "repository": {
+    "directory": "third-party/projects/jquery-form",
+    "type": "git",
+    "url": "https://github.com/liferay/liferay-frontend-projects.git"
   }
 }


### PR DESCRIPTION
Our first release is going to be `@liferay/jquery-form` v3.51.0-liferay.1, and is going to correspond to the same code as upstream, but with the patch originally proposed in https://github.com/liferay-frontend/liferay-portal/pull/699 applied to it. I'll send a separate PR for that in a minute. Subsequent releases, if any, will be `@liferay/jquery-form` v3.51.0-liferay.2, v3.51.0-liferay.3 etc. ie. the same versioning scheme we employ in [liferay-ckeditor](https://github.com/liferay/liferay-ckeditor) — the idea is that you can see at a glance what upstream version we're using as a base, and on top of that you can tell how many patches/tweaks we've applied on top.