### PR TITLE
chore(jquery-form): post-release cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+/third-party/projects/jquery-form/jquery.form.min.js
+/third-party/projects/jquery-form/yarn.lock
 node_modules
 yarn-error.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ These apply to any work at Liferay, including in this monorepo:
 ## Project-specific contribution guidelines
 
 -   [`eslint-config`](projects/eslint-config/CONTRIBUTING.md)
+-   [`jquery-form`](third-party/projects/jquery-form/CONTRIBUTING.md)
 -   [`js-themes-toolkit` v10](projects/js-themes-toolkit/CONTRIBUTING.md)
 -   [`js-themes-toolkit` v9](maintenance/projects/js-themes-toolkit-v9-x/CONTRIBUTING.md)
 -   [`js-themes-toolkit` v8](maintenance/projects/js-themes-toolkit-v8-x/CONTRIBUTING.md)

--- a/third-party/README.md
+++ b/third-party/README.md
@@ -4,5 +4,6 @@
 
 -   Upstream project: https://github.com/jquery-form/form
 -   Base version used by Liferay: [jquery-form/v3.51](https://github.com/liferay/liferay-frontend-projects/tree/jquery-form/v3.51)
+-   Changelog showing Liferay changes: [`CHANGELOG.md`](./projects/jquery-form/CHANGELOG.md).
 -   Our package name: `@liferay/jquery-form`
 -   Usage site in Liferay DXP: [`frontend-js-jquery-web`](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-jquery-web)

--- a/third-party/projects/jquery-form/CONTRIBUTING.md
+++ b/third-party/projects/jquery-form/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Releasing
+
+1.   Run the changelog generator with `--prepatch` or similar:
+
+     ```
+     ../../../projects/npm-tools/packages/changelog-generator/bin/liferay-changelog-generator.js --prepatch
+     ```
+
+2.   Publish using `yarn publish --prepatch` (or similar).
+
+3.   Push to monorepo:
+
+     ```
+     git push upstream --follow-tags --dry-run
+     git push upstream --follow-tags
+     ```
+
+4.   Copy release notes from CHANGELOG.md to [the releases page](https://github.com/liferay/liferay-frontend-projects/releases).

--- a/third-party/projects/jquery-form/jquery.form.js
+++ b/third-party/projects/jquery-form/jquery.form.js
@@ -188,9 +188,7 @@ $.fn.ajaxSubmit = function(options) {
             // `data` is passed to `html()`, as suggested in
             // https://github.com/jquery-form/form/issues/464
 
-            data = options.replaceTarget
-                ? data
-                : $.parseHTML($('<div>').text(data).html());
+            data = options.replaceTarget ? data : $.parseHTML($('<div>').text(data).html());
 
             $(options.target)[fn](data).each(oldSuccess, arguments);
         });


### PR DESCRIPTION
Just some minor follow-ups in light of the first release:

- Fixed a complaint that jshint had.
- Ignore build cruft.
- Add notes on steps taken to release.