### PR TITLE
feat(npm-scripts)!: prefer arrow callbacks in JSP too

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/jsp/lintJSP.js
+++ b/projects/npm-tools/packages/npm-scripts/src/jsp/lintJSP.js
@@ -12,16 +12,18 @@ const linter = new Linter();
 
 const {major, minor} = getDXPVersion() || {};
 
-const ecmaVersion =
-	major === undefined || major > 7 || (major === 7 && minor > 3) ? 6 : 5;
+const modern = major === undefined || major > 7 || (major === 7 && minor > 3);
 
 const config = {
 	parserOptions: {
-		ecmaVersion,
+		ecmaVersion: modern ? 6 : 5,
 	},
 	rules: {
 		'no-debugger': 'error',
 		'no-extra-boolean-cast': 'error',
+		'prefer-arrow-callback': modern
+			? ['error', {allowNamedFunctions: true}]
+			: 'off',
 	},
 };
 


### PR DESCRIPTION
On `master` we don't need to support IE any more, which means that we can use arrow functions in JSP now (we could previously use them in JS because we transpile pretty much all JS).

Once [this PR](https://github.com/liferay-frontend/liferay-portal/pull/793) goes in, our Java-powered SF tooling won't complain about arrow functions any more. So, we can go one step further (this commit) and actually enforce the preference for arrow functions in callback positions in JSP. We already do this for JS files.

This is a "breaking" change because it will trigger [over a 1,000 lint errors in `master`](https://gist.github.com/wincent/7f385dfb04e4d97cd5246fcf9eb71414).

The good news is there is an autofix that produces [this pretty sane-looking 11.7k-line diff](https://gist.github.com/wincent/ca11e30db9f010b4633bbd8c9b15275a)/

That's a lot of churn, but I think it's worth it in the name of consistency.

In service of [LPS-122094](https://issues.liferay.com/browse/LPS-122094).