### PR TITLE
chore(npm-scripts): update to latest @liferay/eslint-config

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/package.json
+++ b/projects/npm-tools/packages/npm-scripts/package.json
@@ -14,7 +14,7 @@
 		"@babel/preset-env": "^7.4.2",
 		"@babel/preset-react": "^7.8.3",
 		"@babel/preset-typescript": "^7.10.4",
-		"@liferay/eslint-config": "21.2.1",
+		"@liferay/eslint-config": "21.3.0",
 		"@liferay/jest-junit-reporter": "1.2.0",
 		"@liferay/js-toolkit-core": "3.0.1-pre.1",
 		"@liferay/npm-bundler-preset-liferay-dev": "4.6.5",


### PR DESCRIPTION
Bumps us from 21.2.1 to 21.3.0. [Release notes](https://github.com/liferay/liferay-frontend-projects/releases/tag/eslint-config%2Fv21.3.0).

Main things of interest in there are:

-   Adding Cavannaugh to the list of possible deprecations: [#389](https://github.com/liferay/liferay-frontend-projects/pull/389)
-   Bug fix to handle the edge case of "strange" imports of the form `import '.'`: [#137](https://github.com/liferay/liferay-frontend-projects/pull/137)

Seeing as I am about to cut a release of `@liferay/npm-scripts`, may as well flush these pending changes out.