### PR TITLE
refactor: remove explicit dependency on clayui/css

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
 	"description": "Liferay's Frontend Infrastructure Team monorepo",
 	"devDependencies": {
 		"@babel/preset-env": "^7.4.2",
-		"@clayui/css": "^3.x",
 		"@cnakazawa/watch": "^1.0.4",
 		"@types/ejs": "3.0.4",
 		"@types/escodegen": "0.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -974,7 +974,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@clayui/css@3.23.0", "@clayui/css@^3.x":
+"@clayui/css@3.23.0":
   version "3.23.0"
   resolved "https://registry.yarnpkg.com/@clayui/css/-/css-3.23.0.tgz#174c01a76ccd354a0c667a531feac2e47e5a3432"
   integrity sha512-gkLrgBTFfcjn7LyYDZyPHncdxLHRwG/hYqE5if+KtJskaQaGj+5DmyDXiwCEeY7ispDeS6Vceoaum8rIACVrxA==


### PR DESCRIPTION
This came in via 18e9c76f12 but I don't think we actually need this as a top-level `devDependency`. It will come in anyway transitively with liferay-frontend-theme-styled and liferay-frontend-theme-unstyled, which were added in f5da76606f.

Originally looked at this because of [this dependabot PR](https://github.com/liferay/liferay-frontend-projects/pull/414).

I don't think this will stop the bot from reminding us to update our own internal dependencies (that we aren't even directly using here anyway), so I might also tell the bot to ignore this dependency.