### PR TITLE
feat(npm-scripts): bump liferay-theme-tasks dependency to 10.3.0

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/package.json
+++ b/projects/npm-tools/packages/npm-scripts/package.json
@@ -47,7 +47,7 @@
 		"liferay-lang-key-dev-loader": "^1.0.3",
 		"liferay-npm-bridge-generator": "2.23.0",
 		"liferay-npm-bundler": "2.23.0",
-		"liferay-theme-tasks": "10.2.0",
+		"liferay-theme-tasks": "10.3.0",
 		"metal-tools-soy": "4.3.2",
 		"mini-css-extract-plugin": "0.11.2",
 		"minimist": "^1.2.0",


### PR DESCRIPTION
Now that we have 10.3.0, we need to update that here.

Once this is merged and a new version is released, we should be able to use the `dartSass` option for building themes