### PR TITLE
feat(npm-scripts): add some basic support for building with TypeScript

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/package.json
+++ b/projects/npm-tools/packages/npm-scripts/package.json
@@ -23,6 +23,7 @@
 		"@testing-library/react-hooks": "^3.4.2",
 		"@testing-library/user-event": "^4.2.4",
 		"@types/jest": "^26.0.14",
+		"@types/vfile-message": "2.0.0",
 		"babel-eslint": "^10.0.3",
 		"babel-jest": "^25.1.0",
 		"babel-loader": "^8.1.0",

--- a/projects/npm-tools/packages/npm-scripts/src/config/babel.json
+++ b/projects/npm-tools/packages/npm-scripts/src/config/babel.json
@@ -11,7 +11,8 @@
 				"targets": "Chrome 65, Firefox ESR, Safari >= 12, last 1 Chrome version, last 1 ChromeAndroid version, last 1 Edge version, last 1 Firefox version, last 1 iOS version"
 			}
 		],
-		"@babel/preset-react"
+		"@babel/preset-react",
+		"@babel/preset-typescript"
 	],
 	"plugins": [
 		"@babel/proposal-class-properties",

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
@@ -17,6 +17,7 @@ let runBridge = require('../utils/runBridge');
 let runBundler = require('../utils/runBundler');
 const setEnv = require('../utils/setEnv');
 let {buildSoy, cleanSoy, soyExists, translateSoy} = require('../utils/soy');
+const spawnSync = require('../utils/spawnSync');
 const validateConfig = require('../utils/validateConfig');
 let webpack = require('./webpack');
 
@@ -89,6 +90,10 @@ module.exports = async function (...args) {
 	const runLegacyBuild = !federation || federation.mode !== 'default';
 
 	if (inputPathExists && runLegacyBuild) {
+		if (fs.existsSync('tsconfig.json')) {
+			spawnSync('tsc', ['--noEmit']);
+		}
+
 		runBabel(
 			BUILD_CONFIG.input,
 			'--out-dir',

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
@@ -93,7 +93,9 @@ module.exports = async function (...args) {
 			BUILD_CONFIG.input,
 			'--out-dir',
 			BUILD_CONFIG.output,
-			'--source-maps'
+			'--source-maps',
+			'--extensions',
+			'.cjs,.es,.es6,.js,.jsx,.mjs,.ts,.tsx'
 		);
 	}
 

--- a/projects/npm-tools/packages/npm-scripts/test/utils/getMergedConfig.js
+++ b/projects/npm-tools/packages/npm-scripts/test/utils/getMergedConfig.js
@@ -91,6 +91,7 @@ describe('getMergedConfig()', () => {
 							targets: expect.stringContaining('Chrome version'),
 						},
 					],
+					'@babel/preset-typescript',
 				]);
 
 				expect(config.overrides[0].presets).toMatchObject([

--- a/yarn.lock
+++ b/yarn.lock
@@ -1885,6 +1885,13 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/vfile-message@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/vfile-message/-/vfile-message-2.0.0.tgz#690e46af0fdfc1f9faae00cd049cc888957927d5"
+  integrity sha512-GpTIuDpb9u4zIO165fUy9+fXcULdD8HFRNli04GehoMVbeNq7D6OBnqSmg3lxZnC+UvgUhEWKxdKiwYUkGltIw==
+  dependencies:
+    vfile-message "*"
+
 "@types/vinyl@*":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/vinyl/-/vinyl-2.0.4.tgz#9a7a8071c8d14d3a95d41ebe7135babe4ad5995a"
@@ -15428,7 +15435,7 @@ vfile-location@^3.0.0:
   resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-3.1.0.tgz#81cd8a04b0ac935185f4fce16f270503fc2f692f"
   integrity sha512-FCZ4AN9xMcjFIG1oGmZKo61PjwJHRVA+0/tPUP2ul4uIwjGGndIxavEMRpWn5p4xwm/ZsdXp9YNygf1ZyE4x8g==
 
-vfile-message@^2.0.0:
+vfile-message@*, vfile-message@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-2.0.4.tgz#5b43b88171d409eae58477d13f23dd41d52c371a"
   integrity sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==


### PR DESCRIPTION
So I need to add some code to liferay-portal in service of [LPS-127081](https://issues.liferay.com/browse/LPS-127081) ("Implement and integrate Global JS Store mechanism in DXP") and I think it would be very useful to "future proof" it by making sure it is TypeScript-ready. We probably don't want to have our store just be un untyped "bag of data", especially if we are going to have to live with and support this API for many years and it is going to become a central channel for cross-app communication with DXP. Example libraries which share this point of view are [Undux](https://github.com/bcherny/undux) and [Recoil](https://recoiljs.org), but they are both React-specific and we want something generic.

So, we can either:

1. Build and ship the API in TypeScript in a way that lends itself to strongly typing the data; or:
2. At least _prototype_ the API in TypeScript to show that it supports strongly-typed usage, even if we end up stripping the type annotations and shipping the thing in JS at the end (ie. leave the door open to an eventual conversion to TypeScript).

There are some obstacles to doing either though, because "turning on TypeScript" in DXP is not going to be as simple as flipping a switch. The only module where we're using TypeScript currently is doing it in a sneaky way, [via webpack and the ts-loader](https://github.com/liferay/liferay-portal/blob/9837c4d81f2de200ad2bcd7acc83578fb25e975c/modules/apps/remote-app/remote-app-client-js/webpack.config.js#L28).
    
To make it possible to _actually_ use TypeScript in a well-integrated fashion in DXP we're going to have to do a bit more work (that means making sure all the linting, formatting, testing pathways works, that our build process doesn't regress in terms of performance, that cross-module type definitions are easily consumed and available, and so on...).

This PR is a draft showing what the minimum first steps would be to get us going and be able to do one of "1" or "2" mentioned above.

There are three main ways to process TypeScript at this time:

1. `webpack` + `ts-loader`: this handles both building and type-checking.
2. Babel's `@babel/preset-typescript`, which handles _only_ stripping out of TypeScript syntax (eg. annotations); it does not do any actual type-checking, so is of limited value.
3. Using the TypeScript compiler itself (`tsc`), which can both type-check and emit code.

So given that "2" on its own is not valuable (no type-checking) and going all-in on "3" is a huge/risky change (ie. from Babel to `tsc`, especially fraught as we're in the middle of moving towards a "federated" build style that is much more webpack-centric than Babel-centric), I'm going to go with a mixture: we'll run `tsc --noEmit` to do type-checking only, and then Babel with the preset to do the build while stripping out TS type annotations.

Further details explained in the commit messages, but the executive summary is that we need to:

1. Add some type definitions to duct tape over an old transitive dependency that we have and allow us to run `tsc --noEmit` during the build.
2. Actually run `tsc --noEmit` during the build.
3. Configure Babel (awkwardly) to not ignore ".ts" files.