### PR TITLE
feat(eslint-config)!: turn off no-for-of-loops rule by default

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,6 @@ module.exports = {
 		},
 	],
 	rules: {
-		'no-for-of-loops/no-for-of-loops': 'off',
 		'notice/notice': [
 			'error',
 			{

--- a/maintenance/projects/js-toolkit/.eslintrc.js
+++ b/maintenance/projects/js-toolkit/.eslintrc.js
@@ -13,7 +13,6 @@ module.exports = {
 	rules: {
 		'@liferay/liferay/no-dynamic-require': 'off',
 		'no-console': 'off',
-		'no-for-of-loops/no-for-of-loops': 'off',
 		'no-return-assign': ['error', 'except-parens'],
 		'notice/notice': [
 			'error',

--- a/projects/eslint-config/index.js
+++ b/projects/eslint-config/index.js
@@ -89,7 +89,7 @@ const config = {
 		'no-console': ['error', {allow: ['warn', 'error']}],
 		'no-constant-condition': ['error', {checkLoops: false}],
 		'no-control-regex': 'off',
-		'no-for-of-loops/no-for-of-loops': 'error',
+		'no-for-of-loops/no-for-of-loops': 'off',
 		'no-only-tests/no-only-tests': 'error',
 		'no-return-assign': ['error', 'always'],
 		'no-unused-expressions': 'error',

--- a/projects/eslint-config/plugins/liferay/lib/rules/padded-test-blocks.js
+++ b/projects/eslint-config/plugins/liferay/lib/rules/padded-test-blocks.js
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* eslint-disable no-for-of-loops/no-for-of-loops */
-
 const DESCRIPTION =
 	'consecutive test blocks should be separated by a blank line';
 

--- a/projects/eslint-config/plugins/portal/lib/rules/no-react-dom-render.js
+++ b/projects/eslint-config/plugins/portal/lib/rules/no-react-dom-render.js
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* eslint-disable no-for-of-loops/no-for-of-loops */
-
 const DESCRIPTION =
 	'Direct use of ReactDOM.render is discouraged; instead, use ' +
 	'the <react:component /> JSP taglib, or do: ' +

--- a/projects/js-toolkit/.eslintrc.js
+++ b/projects/js-toolkit/.eslintrc.js
@@ -97,7 +97,6 @@ module.exports = {
 		},
 	],
 	rules: {
-		'no-for-of-loops/no-for-of-loops': 'off',
 		'no-return-assign': ['error', 'except-parens'],
 		'notice/notice': [
 			'error',


### PR DESCRIPTION
Now that we no longer support IE on the DXP master branch, we can turn this rule off by default, and then opt explicitly back into it on the maintenance branches (eg. 7.3.x and older), or in products which go to the maintenance branches (eg. alloy-editor etc).

The truth is that even in places where we need to support IE, this rule was always very conservative; we polyfill/transpile in IE, and [the only reason that that couldn't be relied upon to work swimmingly](https://github.com/liferay/liferay-frontend-projects/issues/354) is that Babel used `Symbol.iterator` in its output and we weren't 100% confident in our polyfill coverage.

In any case, I'll be following up with some pulls to other projects/branches to make turn the rule back on where it is still needed.

One final note: I am turning the rule `'off'` rather than just removing it so as to reflect that we still do use this rule in some places, it's just that we don't have it on by default.

Closes: https://github.com/liferay/liferay-frontend-projects/issues/405
