### PR TITLE
feat(eslint-config): teach no-duplicate-imports rule about type imports

### DIFF
--- a/projects/eslint-config/plugins/liferay/docs/rules/no-duplicate-imports.md
+++ b/projects/eslint-config/plugins/liferay/docs/rules/no-duplicate-imports.md
@@ -18,3 +18,10 @@ Examples of **correct** code for this rule:
 import {a, g, z} from 'one';
 import x from './x';
 ```
+
+Note the one exception to this rule, that in TypeScript files it is permitted (and sometimes necessary) to have two imports from a module, one that imports _values_ and another that imports _types_:
+
+```ts
+import foo from 'foo';
+import type {bar} from 'foo';
+```

--- a/projects/eslint-config/plugins/liferay/lib/rules/no-duplicate-imports.js
+++ b/projects/eslint-config/plugins/liferay/lib/rules/no-duplicate-imports.js
@@ -10,12 +10,18 @@ const DESCRIPTION = 'modules must be imported only once';
 module.exports = {
 	create(context) {
 		const imports = new Set();
+		const typeImports = new Set();
 
 		return {
 			ImportDeclaration(node) {
+				const isType = node.importKind === 'type';
+
 				const source = getSource(node);
 
-				if (imports.has(source)) {
+				if (
+					(typeImports.has(source) && isType) ||
+					(imports.has(source) && !isType)
+				) {
 					context.report({
 						message: `${DESCRIPTION} (duplicate import: ${JSON.stringify(
 							source
@@ -24,7 +30,12 @@ module.exports = {
 					});
 				}
 				else {
-					imports.add(source);
+					if (isType) {
+						typeImports.add(source);
+					}
+					else {
+						imports.add(source);
+					}
 				}
 			},
 		};

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/no-duplicate-imports.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/no-duplicate-imports.js
@@ -32,6 +32,25 @@ ruleTester.run('no-duplicate-imports', rule, {
 				},
 			],
 		},
+		{
+			code: `
+				import type {g, z} from 'two';
+				import x from './x';
+				import type {a} from 'two';
+			`,
+			errors: [
+				{
+					message:
+						'modules must be imported only once ' +
+						'(duplicate import: "two")',
+					type: 'ImportDeclaration',
+				},
+			],
+
+			// espree doesn't know how to parse TypeScript imports.
+
+			skip: ['espree'],
+		},
 	],
 
 	valid: [
@@ -40,6 +59,17 @@ ruleTester.run('no-duplicate-imports', rule, {
 				import {a, g, z} from 'one';
 				import x from './x';
 			`,
+		},
+		{
+			code: `
+				// A non-type + a type import aren't considered duplicates.
+				import thing from 'thing';
+				import type {Example} from 'thing';
+			`,
+
+			// espree doesn't know how to parse TypeScript imports.
+
+			skip: ['espree'],
 		},
 	],
 });


### PR DESCRIPTION
It's legit to import from the same module twice, as long as exactly one of the imports is a type-only import:

```ts
import Thing from './Thing';
import type {ThingT} from './Thing';
```

In the old days, Flow had this syntax and TypeScript didn't. You would instead have to import the type as though it were a value like this, and trust the TypeScript compiler to figure out that you only wanted it for the type definition:

```ts
import Thing, {ThingT} from './Thing';
```

This made it tricky to do things like circular type-only imports (ie. modules A and B wanting to share type definitions with each other). But TypeScript has support for this now and [the way we're currently using this it in liferay-portal](https://github.com/liferay-frontend/liferay-portal/pull/874), we don't even have a choice really, because we're using Babel to strip out type information (Babel knows nothing about the types unless they are flagged syntactically, so if it sees a mixed type/non-type import it doesn't know that it has to strip out part of it).

Presently a draft because tomorrow I need to check or update our other rules to make sure they behave properly with type-only imports (eg. `group-imports`, sort-imports` etc... we have about 7 rules that look at imports in some way, so I want to check them all; I suspect that most of them will be just fine, but one or two may need tweaking).