### PR TITLE
feat(eslint-config)!: teach import-extensions rule about .ts, .tsx

### DIFF
--- a/projects/eslint-config/plugins/liferay/lib/rules/import-extensions.js
+++ b/projects/eslint-config/plugins/liferay/lib/rules/import-extensions.js
@@ -7,7 +7,7 @@ const path = require('path');
 
 const {isLocal} = require('../common/imports');
 
-const BAD_EXTENSIONS = new Set(['.js']);
+const BAD_EXTENSIONS = new Set(['.js', '.ts', '.tsx']);
 
 function stripExtension(value) {
 	if (isLocal(value)) {

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/import-extensions.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/import-extensions.js
@@ -48,12 +48,41 @@ ruleTester.run('import-extensions', rule, {
 			output: `import * as Billboard from './billboard';`,
 		},
 		{
+			code: `
+				import type {T} from './Helpers.ts';
+				import List from './List.tsx';
+				import type {ListItemT} from './ListItem.tsx';
+				import other from './other.ts';
+			`,
+			errors: [badImport, badImport, badImport, badImport],
+			output: `
+				import type {T} from './Helpers';
+				import List from './List';
+				import type {ListItemT} from './ListItem';
+				import other from './other';
+			`,
+
+			// espree doesn't know how to parse TypeScript imports.
+
+			skip: ['espree'],
+		},
+		{
 			code: `export * from './Other.es.js';`,
 			errors: [badExport],
 			output: `export * from './Other.es';`,
 		},
 		{
 			code: `export * from './Other.js';`,
+			errors: [badExport],
+			output: `export * from './Other';`,
+		},
+		{
+			code: `export * from './Other.ts';`,
+			errors: [badExport],
+			output: `export * from './Other';`,
+		},
+		{
+			code: `export * from './Other.tsx';`,
 			errors: [badExport],
 			output: `export * from './Other';`,
 		},


### PR DESCRIPTION
This is a companion to [#431](https://github.com/liferay/liferay-frontend-projects/pull/431) (which teaches the no-duplicate-imports rule about type-only imports). I'm going through all the other import-related rules and making sure they do the right thing with TypeScript.

So, in this commit, we add tests to show that both type-only and value-only imports/exports from ".ts" and ".tsx" files work with this rule, which requires us to add those extensions to the list of "banned" extensions.

Technically, a "breaking" change because we'll be potentially catching more lint error than we were before.