### PR TITLE
test(eslint-config): show that various rules already support TS

### DIFF
--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/imports-first.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/imports-first.js
@@ -48,6 +48,24 @@ ruleTester.run('imports-first', rule, {
 			],
 		},
 		{
+			code: `
+				const NAME: Thing = {};
+
+				import type {Thing} from './Thing';
+			`,
+			errors: [
+				{
+					message:
+						'import of "./Thing" must come before other statements',
+					type: 'ImportDeclaration',
+				},
+			],
+
+			// espree doesn't know how to parse TypeScript imports.
+
+			skip: ['espree'],
+		},
+		{
 
 			// Regression test: the second require here wasn't being flagged
 			// because we were choking (silently) on the directive:
@@ -104,6 +122,17 @@ ruleTester.run('imports-first', rule, {
 					require('other')();
 				}
 			`,
+		},
+		{
+			code: `
+				import type {Thing} from './Thing';
+
+				const NAME: Thing = {};
+			`,
+
+			// espree doesn't know how to parse TypeScript imports.
+
+			skip: ['espree'],
 		},
 		{
 

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/no-absolute-import.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/no-absolute-import.js
@@ -38,6 +38,19 @@ ruleTester.run('no-absolute-import', rule, {
 				},
 			],
 		},
+		{
+			code: `import type {MapT} from '/usr/share/types/Map';`,
+			errors: [
+				{
+					message: 'import sources should not use absolute paths',
+					type: 'Literal',
+				},
+			],
+
+			// espree doesn't know how to parse TypeScript imports.
+
+			skip: ['espree'],
+		},
 	],
 
 	valid: [
@@ -47,6 +60,13 @@ ruleTester.run('no-absolute-import', rule, {
 				const other = require('other');
 				import {x} from 'x';
 			`,
+		},
+		{
+			code: `import type {MapT} from './Map';`,
+
+			// espree doesn't know how to parse TypeScript imports.
+
+			skip: ['espree'],
 		},
 	],
 });

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/sort-import-destructures.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/sort-import-destructures.js
@@ -92,6 +92,19 @@ ruleTester.run('sort-import-destructures', rule, {
 				} from 'file';
 			`,
 		},
+		{
+
+			// Works with type-only imports too.
+
+			code: `import type {C, B, A} from 'thing';`,
+			errors: [
+				{
+					message: 'destructured names in imports must be sorted',
+				},
+			],
+			output: `import type {A, B, C} from 'thing';`,
+			skip: ['espree'],
+		},
 	],
 
 	valid: [

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/sort-imports.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/sort-imports.js
@@ -185,6 +185,31 @@ ruleTester.run('sort-imports', rule, {
 		},
 		{
 
+			// Example with type-only imports.
+
+			code: `
+				import type {U} from './Records';
+				import type {T} from './Frisbee';
+			`,
+			errors: [
+				{
+					message:
+						'imports must be sorted by module name ' +
+						'(expected: "./Frisbee" << "./Records")',
+					type: 'ImportDeclaration',
+				},
+			],
+			output: `
+				import type {T} from './Frisbee';
+				import type {U} from './Records';
+			`,
+
+			// espree doesn't know how to parse TypeScript imports.
+
+			skip: ['espree'],
+		},
+		{
+
 			// Regression test: two imports from the same module were causing
 			// duplication.
 


### PR DESCRIPTION
These are just additions to the test suite to show that these import-related rules already support TypeScript without breaking.

Other pulls pushed so far are:

- https://github.com/liferay/liferay-frontend-projects/pull/431 ("teach no-duplicate-imports rule about type imports")
- https://github.com/liferay/liferay-frontend-projects/pull/433 ("teach import-extensions rule about .ts, .tsx")

Both of those required actual changes to the code, unlike this one.

Only remaining one after this will be the `group-imports` rule, but that one is complex enough to warrant its own changelog entry and therefore go in via a separate PR.