### PR TITLE
feat(eslint-config)!: teach sort-imports, group-imports to separate type-only inputs

### DIFF
--- a/projects/eslint-config/jest.config.js
+++ b/projects/eslint-config/jest.config.js
@@ -5,5 +5,8 @@
 
 module.exports = {
 	setupFilesAfterEnv: ['<rootDir>/scripts/setupJest.js'],
-	testMatch: ['<rootDir>/plugins/*/tests/lib/rules/*.js'],
+	testMatch: [
+		'<rootDir>/plugins/*/tests/lib/rules/*.js',
+		'<rootDir>/test/**/*.js',
+	],
 };

--- a/projects/eslint-config/plugins/liferay/docs/rules/group-imports.md
+++ b/projects/eslint-config/plugins/liferay/docs/rules/group-imports.md
@@ -4,11 +4,12 @@ This rule enforces (and autofixes) that `import` statements and `require` calls 
 
 ## Rule Details
 
-Imports appear in the following groups, separated by a blank line:
+Imports appear in groups of the following type, separated by a blank line:
 
 1. "External" imports (ie. NodeJS built-in modules and dependencies specified in "package.json"; these do not start with "." or "..").
-2. "Internal" imports (ie. local to the projects, starting with "." or "..");
+2. "Internal" imports (ie. local to the projects, starting with "." or "..").
 3. "Side-effect-only" imports.
+4. "Type-only" imports (ie. `import type {T} from 'thing';`), either from external modules or internal ones.
 
 Additionally, any import that is preceded by a comment must be prefaced by a blank line for readability.
 

--- a/projects/eslint-config/plugins/liferay/docs/rules/sort-imports.md
+++ b/projects/eslint-config/plugins/liferay/docs/rules/sort-imports.md
@@ -8,6 +8,7 @@ Imports appear in the following order:
 
 1. "External" imports (ie. NodeJS built-in modules and dependencies specified in "package.json"; these do not start with "." or "..").
 2. "Internal" imports (ie. local to the projects, starting with "." or "..");
+3. "Type-only" imports (ie. `import type {A} from 'thing';`).
 
 Within each group, we sort lexicographically (and case-sensitively) by the module source (ie. the thing on the right-hand side).
 
@@ -29,7 +30,7 @@ imports 'thing';
 require('other');
 ```
 
-Any time this rule encounters such an import, it considers it a boundary and will not reorder any imports across that boundary.
+Any time this rule encounters such an import, it considers it a boundary and, generally, will not reorder any imports across that boundary. (Type-only imports are a special case, because they are independent of evaluation order and can always be safely moved to the end.)
 
 ## Examples
 

--- a/projects/eslint-config/plugins/liferay/docs/rules/sort-imports.md
+++ b/projects/eslint-config/plugins/liferay/docs/rules/sort-imports.md
@@ -8,7 +8,7 @@ Imports appear in the following order:
 
 1. "External" imports (ie. NodeJS built-in modules and dependencies specified in "package.json"; these do not start with "." or "..").
 2. "Internal" imports (ie. local to the projects, starting with "." or "..");
-3. "Type-only" imports (ie. `import type {A} from 'thing';`).
+3. "Type-only" imports (ie. `import type {A} from 'thing';`), first external ones and then internal ones.
 
 Within each group, we sort lexicographically (and case-sensitively) by the module source (ie. the thing on the right-hand side).
 

--- a/projects/eslint-config/plugins/liferay/lib/common/imports.js
+++ b/projects/eslint-config/plugins/liferay/lib/common/imports.js
@@ -203,6 +203,14 @@ function isRequireStatement(node) {
 	);
 }
 
+/**
+ * Returns true if `node` corresponds to a type-only import (ie. `import type
+ * {x} from 'source'`).
+ */
+function isTypeImport(node) {
+	return node.type === 'ImportDeclaration' && node.importKind === 'type';
+}
+
 function withScope() {
 	const scope = [];
 
@@ -241,5 +249,6 @@ module.exports = {
 	isLocal,
 	isRelative,
 	isRequireStatement,
+	isTypeImport,
 	withScope,
 };

--- a/projects/eslint-config/plugins/liferay/lib/rules/group-imports.js
+++ b/projects/eslint-config/plugins/liferay/lib/rules/group-imports.js
@@ -9,6 +9,7 @@ const {
 	getSource,
 	hasSideEffects,
 	isLocal,
+	isTypeImport,
 	withScope,
 } = require('../common/imports');
 
@@ -167,7 +168,8 @@ module.exports = {
 					const previousSource = getSource(previous);
 
 					const changed =
-						isLocal(currentSource) ^ isLocal(previousSource);
+						isLocal(currentSource) ^ isLocal(previousSource) ||
+						isTypeImport(current) ^ isTypeImport(previous);
 
 					if (changed) {
 						expectBlankLines(current);

--- a/projects/eslint-config/plugins/liferay/lib/rules/no-duplicate-imports.js
+++ b/projects/eslint-config/plugins/liferay/lib/rules/no-duplicate-imports.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {getSource} = require('../common/imports');
+const {getSource, isTypeImport} = require('../common/imports');
 
 const DESCRIPTION = 'modules must be imported only once';
 
@@ -14,7 +14,7 @@ module.exports = {
 
 		return {
 			ImportDeclaration(node) {
-				const isType = node.importKind === 'type';
+				const isType = isTypeImport(node);
 
 				const source = getSource(node);
 

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/group-imports.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/group-imports.js
@@ -92,6 +92,7 @@ ruleTester.run('group-imports', rule, {
 				import stuff from 'stuff';
 				import 'side-effect';
 				import type {T} from 'one';
+				import type {V} from './local';
 				import x from './x';
 			`,
 			errors: [
@@ -146,6 +147,12 @@ ruleTester.run('group-imports', rule, {
 				{
 					message:
 						'imports must be grouped ' +
+						'(expected blank line before: "./local")',
+					type: 'ImportDeclaration',
+				},
+				{
+					message:
+						'imports must be grouped ' +
 						'(expected blank line before: "./x")',
 					type: 'ImportDeclaration',
 				},
@@ -167,6 +174,8 @@ ruleTester.run('group-imports', rule, {
 				import 'side-effect';
 
 				import type {T} from 'one';
+
+				import type {V} from './local';
 
 				import x from './x';
 			`,

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/group-imports.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/group-imports.js
@@ -77,6 +77,104 @@ ruleTester.run('group-imports', rule, {
 				import x from './x';
 			`,
 		},
+		{
+			code: `
+				import abc from 'abc';
+				import type {U} from 'other';
+				import {g, z} from 'one'; // Correct.
+
+				import {a} from 'other'; // 1 excess blank line before.
+
+
+				import w from 'w'; // 2 excess blank lines before.
+				import type {X, Z} from 'zzz';
+				// Comment describing the next import.
+				import stuff from 'stuff';
+				import 'side-effect';
+				import type {T} from 'one';
+				import x from './x';
+			`,
+			errors: [
+				{
+					message:
+						'imports must be grouped ' +
+						'(expected blank line before: "other")',
+					type: 'ImportDeclaration',
+				},
+				{
+					message:
+						'imports must be grouped ' +
+						'(expected blank line before: "one")',
+					type: 'ImportDeclaration',
+				},
+				{
+					message:
+						'imports must be grouped ' +
+						'(unexpected blank line before: "other")',
+					type: 'ImportDeclaration',
+				},
+				{
+					message:
+						'imports must be grouped ' +
+						'(unexpected blank line before: "w")',
+					type: 'ImportDeclaration',
+				},
+				{
+					message:
+						'imports must be grouped ' +
+						'(expected blank line before: "zzz")',
+					type: 'ImportDeclaration',
+				},
+				{
+					message:
+						'imports must be grouped ' +
+						'(expected blank line before: "stuff")',
+					type: 'ImportDeclaration',
+				},
+				{
+					message:
+						'imports must be grouped ' +
+						'(expected blank line before: "side-effect")',
+					type: 'ImportDeclaration',
+				},
+				{
+					message:
+						'imports must be grouped ' +
+						'(expected blank line before: "one")',
+					type: 'ImportDeclaration',
+				},
+				{
+					message:
+						'imports must be grouped ' +
+						'(expected blank line before: "./x")',
+					type: 'ImportDeclaration',
+				},
+			],
+			output: `
+				import abc from 'abc';
+
+				import type {U} from 'other';
+
+				import {g, z} from 'one'; // Correct.
+				import {a} from 'other'; // 1 excess blank line before.
+				import w from 'w'; // 2 excess blank lines before.
+
+				import type {X, Z} from 'zzz';
+
+				// Comment describing the next import.
+				import stuff from 'stuff';
+
+				import 'side-effect';
+
+				import type {T} from 'one';
+
+				import x from './x';
+			`,
+
+			// espree doesn't know how to parse TypeScript imports.
+
+			skip: ['espree'],
+		},
 	],
 
 	valid: [
@@ -92,6 +190,31 @@ ruleTester.run('group-imports', rule, {
 
 				import x from './x';
 			`,
+
+			// espree doesn't know how to parse TypeScript imports.
+
+			skip: ['espree'],
+		},
+		{
+			code: `
+				import {g, z} from 'one';
+				import {a} from 'other';
+
+				// Comment describing the next import.
+				import stuff from 'stuff';
+
+				import 'side-effect';
+
+				import x from './x';
+
+				import type {T} from 'one';
+				import type {U} from 'other';
+				import type {X, Z} from 'zzz';
+			`,
+
+			// espree doesn't know how to parse TypeScript imports.
+
+			skip: ['espree'],
 		},
 		{
 

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/sort-imports.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/sort-imports.js
@@ -140,13 +140,7 @@ ruleTester.run('sort-imports', rule, {
 				{
 					message:
 						'imports must be sorted by module name ' +
-						'(expected: "other" << "./x")',
-					type: 'ImportDeclaration',
-				},
-				{
-					message:
-						'imports must be sorted by module name ' +
-						'(expected: "one" << "../s")',
+						'(expected: "other" << "./x" << "a-side-effectful-import" << "one" << "../s")',
 					type: 'ImportDeclaration',
 				},
 			],
@@ -189,17 +183,25 @@ ruleTester.run('sort-imports', rule, {
 
 			code: `
 				import type {U} from './Records';
+				import ReactDOM from 'react-dom';
 				import type {T} from './Frisbee';
+				import React from 'react';
+				import Record from './Records';
+				import 'side-effects';
 			`,
 			errors: [
 				{
 					message:
 						'imports must be sorted by module name ' +
-						'(expected: "./Frisbee" << "./Records")',
+						'(expected: "react" << "react-dom" << "./Records" << "side-effects" << (type) "./Frisbee" << (type) "./Records")',
 					type: 'ImportDeclaration',
 				},
 			],
 			output: `
+				import React from 'react';
+				import ReactDOM from 'react-dom';
+				import Record from './Records';
+				import 'side-effects';
 				import type {T} from './Frisbee';
 				import type {U} from './Records';
 			`,

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/sort-imports.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/sort-imports.js
@@ -183,6 +183,7 @@ ruleTester.run('sort-imports', rule, {
 
 			code: `
 				import type {U} from './Records';
+				import type {V} from 'very-external';
 				import ReactDOM from 'react-dom';
 				import type {T} from './Frisbee';
 				import React from 'react';
@@ -193,7 +194,7 @@ ruleTester.run('sort-imports', rule, {
 				{
 					message:
 						'imports must be sorted by module name ' +
-						'(expected: "react" << "react-dom" << "./Records" << "side-effects" << (type) "./Frisbee" << (type) "./Records")',
+						'(expected: "react" << "react-dom" << "./Records" << "side-effects" << (type) "very-external" << (type) "./Frisbee" << (type) "./Records")',
 					type: 'ImportDeclaration',
 				},
 			],
@@ -202,6 +203,7 @@ ruleTester.run('sort-imports', rule, {
 				import ReactDOM from 'react-dom';
 				import Record from './Records';
 				import 'side-effects';
+				import type {V} from 'very-external';
 				import type {T} from './Frisbee';
 				import type {U} from './Records';
 			`,

--- a/projects/eslint-config/test/integration.js
+++ b/projects/eslint-config/test/integration.js
@@ -1,0 +1,209 @@
+/**
+ * SPDX-FileCopyrightText: © 2021 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const parser = require('@typescript-eslint/parser');
+const {Linter} = require('eslint');
+const {default: diff} = require('jest-diff');
+
+/**
+ * Integration tests that show how rules interact when applied together by
+ * activating all the rules in a plugin at once.
+ */
+describe('@liferay/eslint-config/liferay', () => {
+	const plugin = '@liferay/eslint-config/liferay';
+
+	it('formats imports', () => {
+
+		// This shows how these rules work together to format imports:
+		//
+		// - group-imports (keeps imports in groups)
+		// - import-extensions (strips unnecessary extensions)
+		// - sort-imports (sorts imports by module name)
+		// - sort-import-destructures (sorts destructured items in import
+		//   specifiers)
+
+		expect(plugin).toAutofix({
+			code: `
+				import b from 'b';
+				import type {B} from 'b';
+				import type {D, C} from 'x';
+				import a from 'a';
+				import {d, c} from 'c';
+				import thing from './thing.js';
+				import another from './another';
+				import 'for-side-effects';
+				import type {A} from 'a';
+			`,
+			output: `
+				import a from 'a';
+				import b from 'b';
+				import {c, d} from 'c';
+
+				import another from './another';
+				import thing from './thing';
+
+				import 'for-side-effects';
+
+				import type {A} from 'a';
+				import type {B} from 'b';
+				import type {C, D} from 'x';
+			`,
+		});
+	});
+
+	it('formats require statements', () => {
+
+		// This shows how these rules work together to format require
+		// statements:
+		//
+		// - group-imports (keeps require statements in groups)
+		// - import-extensions (strips unnecessary extensions)
+		// - sort-imports (sorts require statements by module name)
+		//
+		// Not in effect here:
+		//
+		// - sort-import-destructures (sorts destructured items in import
+		//   specifiers)
+		//
+		// because sorting destructured items in require statements is actually
+		// handled by the third-party rule:
+		//
+		// - sort-destructure-keys/sort-destructure-keys
+
+		expect(plugin).toAutofix({
+			code: `
+				const b = require('b');
+				const a = require('a');
+				const {d, c} = require('c');
+				const thing = require('./thing.js');
+				const another = require('./another');
+				require('for-side-effects');
+				const property = require('./other').property;
+			`,
+			output: `
+				const a = require('a');
+				const b = require('b');
+				const {d, c} = require('c');
+
+				const another = require('./another');
+				const thing = require('./thing');
+
+				require('for-side-effects');
+
+				const {property} = require('./other');
+			`,
+		});
+	});
+
+	it('formats class names in JSX', () => {
+
+		// This shows how these rules work together to format class names in
+		// JSX:
+		//
+		// - no-duplicate-class-names
+		// - sort-class-names
+		// - trim-class-names (trims whitespace)
+
+		expect(plugin).toAutofix({
+			code: `<div className="   one two one three  "></div>`,
+			output: `<div className="one three two"></div>`,
+		});
+	});
+});
+
+describe('@liferay/eslint-config/portal', () => {
+	const plugin = '@liferay/eslint-config/portal';
+
+	// Not much to test here (yet), because most of the rules currently
+	// in this plugin don't have autofixes. This test is included as a
+	// placeholder reserved for future expansion.
+
+	it('formats deprecation notices', () => {
+		expect(plugin).toAutofix({
+			code: `
+				/**
+				 * @deprecated As of Mueller (7.2) replaced by Foo
+				 */
+			`,
+			output: `
+				/**
+				 * @deprecated As of Mueller (7.2.x), replaced by Foo
+				 */
+			`,
+		});
+	});
+});
+
+// Memoize linters so that we don't have to recreate them for each `it()` block.
+
+const linters = {};
+
+expect.extend({
+	toAutofix(plugin, {code, output}) {
+		const linter =
+			linters[plugin] ||
+			(function () {
+				let rules;
+
+				if (plugin === '@liferay/eslint-config/liferay') {
+					({rules} = require('../plugins/liferay'));
+				}
+				else if (plugin === '@liferay/eslint-config/portal') {
+					({rules} = require('../plugins/portal'));
+				}
+				else {
+					throw new Error(`Unknown plugin: ${plugin}`);
+				}
+
+				const linter = new Linter();
+
+				linter.defineParser('@typescript-eslint/parser', parser);
+
+				const config = {
+					parser: '@typescript-eslint/parser',
+					parserOptions: {
+						ecmaFeatures: {
+							jsx: true,
+						},
+					},
+					rules: {},
+				};
+
+				Object.entries(rules).forEach(([name, rule]) => {
+					linter.defineRule(name, rule);
+					config.rules[name] = 'error';
+				});
+
+				linters[plugin] = {
+					verifyAndFix(code) {
+						return linter.verifyAndFix(code, config);
+					},
+				};
+
+				return linters[plugin];
+			})();
+
+		const {output: actual} = linter.verifyAndFix(code);
+
+		return {
+			actual,
+			message: () => {
+				const diffString = diff(output, actual, {
+					expand: this.expand,
+				});
+
+				return (
+					this.utils.matcherHint('toAutofix') +
+					'\n\n' +
+					(diffString && diffString.includes('- Expect')
+						? `Difference:\n\n${diffString}`
+						: `Expected: ${this.utils.printExpected(output)}\n` +
+						  `Received: ${this.utils.printReceived(actual)}`)
+				);
+			},
+			pass: output === actual,
+		};
+	},
+});

--- a/projects/eslint-config/test/integration.js
+++ b/projects/eslint-config/test/integration.js
@@ -28,11 +28,13 @@ describe('@liferay/eslint-config/liferay', () => {
 			code: `
 				import b from 'b';
 				import type {B} from 'b';
+				import type {T} from './local';
 				import type {D, C} from 'x';
 				import a from 'a';
 				import {d, c} from 'c';
 				import thing from './thing.js';
 				import another from './another';
+				import type {U} from './first';
 				import 'for-side-effects';
 				import type {A} from 'a';
 			`,
@@ -49,6 +51,9 @@ describe('@liferay/eslint-config/liferay', () => {
 				import type {A} from 'a';
 				import type {B} from 'b';
 				import type {C, D} from 'x';
+
+				import type {U} from './first';
+				import type {T} from './local';
 			`,
 		});
 	});


### PR DESCRIPTION
Via [Slack thread](https://liferay.slack.com/archives/C3JBR21HA/p1615278868119400).

We discussed two possible end states:

1.  Mix type-only imports among other imports:

        import X from './X';
        import type {T} from './X';
        import Z from './Z';

2.  Put type-only imports at the end, in a section of their own:

        import X from './X';
        import Z from './Z';

        import type {T} from './X';

We agreed that, while "1" is easier to implement, we like the conceptual separation of "2". Type-only inputs really are totally different beasts (for example, they get elided during compilation, for example).

Changing the group-imports rule alone doesn't produce the desired effect; it merely makes sure that type-only imports start a new group. eg.

```ts
import a from 'a';
import b from 'b';
import type {T} from 'a';
import type {U} from 'b';
import c from 'c';
import d from 'd';
```

will get autofixed to:

```ts
import a from 'a';
import b from 'b';

import type {T} from 'a';
import type {U} from 'b';

import c from 'c';
import d from 'd';
```

but when combined with the effect of the `sort-imports` rule, we move all the type-only imports together to the end and the final result is:

```ts
import a from 'a';
import b from 'b';
import c from 'c';
import d from 'd';

import type {T} from 'a';
import type {U} from 'b';
```

It turns out that this requires a pretty invasive change to the sort-imports rule. Previously, we only sorted within groups, but now that we want to move type-only imports into a separate group at the end, we need to combine the two strategies (sorting within groups and sorting type-only imports to the end).

Note that the error output is a bit "meh" here. In most cases it looks simple:

    imports must be sorted by module name (expected: "./a" << "./b")

But given that you can have a type-only and a value-only import from the same module, you could wind up with confusing output like:

    imports must be sorted by module name (expected: "./a" << "./a")

So, we distinguish that by adding a "(type)" annotation:

    imports must be sorted by module name (expected: "./a" << (type) "./a")

It's a bit "meh" because the text doesn't really tell the whole story, but we need our lint output to be relatively terse (that's the way ESLint rules are; mostly intended to fit on one line so they be displayed inline in IDEs etc), so spelling it all out literally isn't really an option:

    imports must be sorted by module name, with type imports coming last
    (expected: import a from "./a" << import type {A} from "./a")

As such, we settle for the "(type)" disambiguator as a reasonable but not perfect compromise solution. Note that in the case of duplicate imports we already don't have very good output, because we rely on the `no-duplicate-imports` rule to deal with those problems for us; eg:

```ts
import a from './a';
import {b} from './a';
```

would already print a confusing error like:

    imports must be sorted by module name (expected: "./a" << "./a")

I'm not going to stress to much about this, because we have no-duplicate-imports doing its thing and handling type-only imports appropriately since https://github.com/liferay/liferay-frontend-projects/pull/431 and we also haven an autofix for sort-imports, so it's probably all going to be fine despite the suboptimal error messages.

Note how this requires us to re-jig the error reporting in one additional sense. Previously, if we had two "groups":

```
a
c
b

l
m
n

z
y
x
```

We would report minimal differences within each group (ie. we'd say that the order needs to be `"b << c"` + `"z << y << z"`).

Now that we are potentially moving items across groups, we report the misordered items globally (eg. `"b << c << l << m << n << x << y << z"`). This is the price of progress, I guess.

To see how this interacts with the group-imports rule to give us the desired effect, I added some integration tests that run all the rules in the plug-in at once (all of our existing tests run only one rule at a time).

The idea here is to focus on rules that act together to produce a combined effect (all of our rules already have separate tests that verify their behavior when operating individually).

Bonus refactoring included: extracted common `isTypeImport()` helper function that can be used in a few places.