### PR TITLE
feat(eslint-config)!: disallow unnecessary string interpolation in JSX

### DIFF
--- a/projects/eslint-config/react.js
+++ b/projects/eslint-config/react.js
@@ -22,6 +22,10 @@ const config = {
 		 * @see https://github.com/yannickcr/eslint-plugin-react
 		 */
 		'react/forbid-foreign-prop-types': 'error',
+		'react/jsx-curly-brace-presence': [
+			'error',
+			{children: 'never', props: 'never'},
+		],
 		'react/jsx-fragments': 'error',
 		'react/jsx-key': 'error',
 		'react/jsx-no-comment-textnodes': 'error',


### PR DESCRIPTION
By way of: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md

Will fix:

```jsx
<div className={'yo'}>{'hi'}</div>
```

to:

```jsx
<div className="yo">hi</div>
```

Closes: https://github.com/liferay/liferay-frontend-projects/issues/421