### PR TITLE
feat(eslint-config)!: teach class-names rules about "customClassName" attributes

### DIFF
--- a/projects/eslint-config/plugins/liferay/docs/rules/no-duplicate-class-names.md
+++ b/projects/eslint-config/plugins/liferay/docs/rules/no-duplicate-class-names.md
@@ -1,6 +1,6 @@
 # Class names inside the "className" JSX attribute must be unique (no-duplicate-class-names)
 
-This rule enforces (and autofixes) that the class names inside the "className" attribute of a JSX element are unique.
+This rule enforces (and autofixes) that the class names inside the "className" attribute of a JSX element are unique. This rule also works with any attribute that looks "className-ish" (that is, attributes of the form "someClassName" containing string values).
 
 ## Rule Details
 
@@ -8,12 +8,14 @@ Examples of **incorrect** code for this rule:
 
 ```js
 <div className="one one two"></div>
+<CustomPopover triggerClassName="a a b" />
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
 <div className="one two"></div>
+<CustomPopover triggerClassName="a b" />
 ```
 
 ### Limitations

--- a/projects/eslint-config/plugins/liferay/docs/rules/sort-class-names.md
+++ b/projects/eslint-config/plugins/liferay/docs/rules/sort-class-names.md
@@ -1,6 +1,6 @@
 # Sort class names inside the "className" JSX attribute (sort-class-names)
 
-This rule enforces (and autofixes) that the class names inside the "className" attribute of a JSX element are sorted.
+This rule enforces (and autofixes) that the class names inside the "className" attribute of a JSX element are sorted. This rule also works with any attribute that looks "className-ish" (that is, attributes of the form "someClassName" containing string values).
 
 ## Rule Details
 
@@ -9,6 +9,7 @@ Examples of **incorrect** code for this rule:
 ```js
 <div className="a c b d"></div>
 <div className={'bar foo'}></div>
+<CustomPopover triggerClassName="z y x" />
 ```
 
 Examples of **correct** code for this rule:
@@ -17,6 +18,7 @@ Examples of **correct** code for this rule:
 <div className="a b c d"></div>
 <div className="a b"></div>
 <div className={'foo bar'}></div>
+<CustomPopover triggerClassName="x y z" />
 ```
 
 ### Limitations

--- a/projects/eslint-config/plugins/liferay/docs/rules/trim-class-names.md
+++ b/projects/eslint-config/plugins/liferay/docs/rules/trim-class-names.md
@@ -1,6 +1,6 @@
 # Trim whitespace inside the "className" JSX attribute (trim-class-names)
 
-This rule enforces (and autofixes) that the class names inside the "className" attribute of a JSX element are not preceded or followed by whitespace.
+This rule enforces (and autofixes) that the class names inside the "className" attribute of a JSX element are not preceded or followed by whitespace. This rule also works with any attribute that looks "className-ish" (that is, attributes of the form "someClassName" containing string values).
 
 ## Rule Details
 
@@ -10,6 +10,7 @@ Examples of **incorrect** code for this rule:
 <div className="   foo bar"></div>
 <div className="foo bar"></div>
 <div className={'    foo bar    '}></div>
+<CustomPopover triggerClassName="   foo bar  " />
 ```
 
 Examples of **correct** code for this rule:
@@ -18,6 +19,7 @@ Examples of **correct** code for this rule:
 <div className="foo bar"></div>
 <div className="foo bar"></div>
 <div className={'foo bar'}></div>
+<CustomPopover triggerClassName="foo bar" />
 ```
 
 ### Limitations

--- a/projects/eslint-config/plugins/liferay/lib/common/className.js
+++ b/projects/eslint-config/plugins/liferay/lib/common/className.js
@@ -3,13 +3,15 @@
  * SPDX-License-Identifier: MIT
  */
 
+const CLASS_NAME_REGEX = /(?:\bc|[a-z]C)lassName$/;
+
 /**
  * A visitor function that calls `callback` for any "className" `JSXAttribute`.
  */
 function checkJSXAttribute(node, callback, context = null, options = {}) {
 	const {allowTemplateLiteralExpressions} = options;
 
-	if (node.name.name !== 'className' || !node.value) {
+	if (!CLASS_NAME_REGEX.test(node.name.name) || !node.value) {
 		return;
 	}
 

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/no-duplicate-class-names.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/no-duplicate-class-names.js
@@ -42,6 +42,16 @@ ruleTester.run('no-duplicate-class-names', rule, {
 			],
 			output: '<div className="one two"></div>',
 		},
+		{
+			code: '<CustomPopover triggerClassName="a b b" />',
+			errors: [
+				{
+					message,
+					type: 'Literal',
+				},
+			],
+			output: '<CustomPopover triggerClassName="a b" />',
+		},
 	],
 
 	valid: [
@@ -50,5 +60,10 @@ ruleTester.run('no-duplicate-class-names', rule, {
 		// Note that we don't check template literals containing expressions.
 
 		{code: '<div className={`one one ${two}`}></div>'},
+
+		// And we don't check "classname-ish" attributes that don't contain
+		// strings.
+
+		{code: '<CustomPopover triggerClassName={(1, 1)} />'},
 	],
 });

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/sort-class-names.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/sort-class-names.js
@@ -100,6 +100,19 @@ ruleTester.run('sort-class-names', rule, {
 			],
 			output: '<div className=" a b c  "></div>',
 		},
+		{
+
+			// Classname-ish.
+
+			code: '<CustomPopover triggerClassName="z y x" />',
+			errors: [
+				{
+					message,
+					type: 'Literal',
+				},
+			],
+			output: '<CustomPopover triggerClassName="x y z" />',
+		},
 	],
 
 	valid: [
@@ -112,5 +125,10 @@ ruleTester.run('sort-class-names', rule, {
 		// Note that we don't check template literals containing expressions.
 
 		{code: '<div className={`a c ${b} d`}></div>'},
+
+		// And we don't check "classname-ish" attributes that don't contain
+		// strings.
+
+		{code: '<CustomPopover triggerClassName={1} />'},
 	],
 });

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/trim-class-names.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/trim-class-names.js
@@ -80,6 +80,19 @@ ruleTester.run('trim-class-names', rule, {
 				<div className={\`foo \${bar} baz\`}></div>
 			`,
 		},
+		{
+
+			// Classname-ish.
+
+			code: '<CustomPopover triggerClassName=" popover " />',
+			errors: [
+				{
+					message,
+					type: 'Literal',
+				},
+			],
+			output: '<CustomPopover triggerClassName="popover" />',
+		},
 	],
 
 	valid: [
@@ -89,5 +102,10 @@ ruleTester.run('trim-class-names', rule, {
 		{code: "<div className={'foo bar'}></div>"},
 		{code: '<div className={`foo bar`}></div>'},
 		{code: '<div className={`foo ${bar} baz`}></div>'},
+
+		// Note that we don't check "classname-ish" attributes that
+		// don't contain strings.
+
+		{code: '<CustomPopover triggerClassName={   1   } />'},
 	],
 });

--- a/projects/eslint-config/test/integration.js
+++ b/projects/eslint-config/test/integration.js
@@ -112,8 +112,18 @@ describe('@liferay/eslint-config/liferay', () => {
 		// - trim-class-names (trims whitespace)
 
 		expect(plugin).toAutofix({
-			code: `<div className="   one two one three  "></div>`,
-			output: `<div className="one three two"></div>`,
+			code: `
+				<div>
+					<div className="   one two one three  "></div>
+					<CustomPopover triggerClassName="   foo foo bar  " />
+				</div>
+			`,
+			output: `
+				<div>
+					<div className="one three two"></div>
+					<CustomPopover triggerClassName="bar foo" />
+				</div>
+			`,
 		});
 	});
 });


### PR DESCRIPTION
Extends our three existing `class-names` rules:

- `no-duplicate-class-names`
- `sort-class-names`
- `trim-class-names`

to handle `"customClassName"` attributes with string keys as well, like these:

```jsx
<CustomPopover triggerClassName="   foo foo bar  " />
```

Which would be fixed to:

```jsx
<CustomPopover triggerClassName="bar foo" />
```

Closes: https://github.com/liferay/liferay-frontend-projects/issues/417