### PR TITLE
fix(npm-scripts): use correct paths for Windows

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/webpack/writeWebpackFederationEntryPoint.js
+++ b/projects/npm-tools/packages/npm-scripts/src/webpack/writeWebpackFederationEntryPoint.js
@@ -25,14 +25,13 @@ module.exports = function (filePath) {
 	const projectMainModuleFilePath = getProjectMainModuleFilePath();
 
 	if (fs.existsSync(projectMainModuleFilePath)) {
-		const projectMainModuleRelPath = path.relative(
-			path.dirname(filePath),
-			projectMainModuleFilePath
-		);
+		const projectMainModuleRelName = path
+			.relative(path.dirname(filePath), projectMainModuleFilePath)
+			.replace(/\\/g, '/');
 
 		code += `
-export {default} from './${projectMainModuleRelPath}';
-export * from './${projectMainModuleRelPath}';
+export {default} from './${projectMainModuleRelName}';
+export * from './${projectMainModuleRelName}';
 
 `;
 	}


### PR DESCRIPTION
This is the npm-scripts side fix of https://issues.liferay.com/browse/LPS-128988

It has been manually tested by @zhangyan0701 in a Windows box.