### PR TITLE
feat(npm-scripts): add a shim for npm's `process` to webpack federation build

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/package.json
+++ b/projects/npm-tools/packages/npm-scripts/package.json
@@ -61,6 +61,7 @@
 		"minimist": "^1.2.0",
 		"path-browserify": "^1.0.1",
 		"prettier": "^2.1.2",
+		"process": "^0.11.10",
 		"react": "*",
 		"react-dom": "*",
 		"react-test-renderer": "*",

--- a/projects/npm-tools/packages/npm-scripts/src/webpack/createFederationConfig.js
+++ b/projects/npm-tools/packages/npm-scripts/src/webpack/createFederationConfig.js
@@ -137,6 +137,7 @@ module.exports = async function () {
 		resolve: {
 			fallback: {
 				path: require.resolve('path-browserify'),
+				process: require.resolve('process/browser'),
 			},
 			plugins: [createWebpackSoyResolver()],
 		},

--- a/yarn.lock
+++ b/yarn.lock
@@ -12276,6 +12276,11 @@ process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
+
 progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"


### PR DESCRIPTION
We need this to be able to build the portal without `frontend-js-node-shims` (see [LPS-128668](https://issues.liferay.com/browse/LPS-128668))

Tested in local `ant all`