### PR TITLE
fix: don't treat ourselves as a valid import

### DIFF
--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-exclude-imports/src/__tests__/index.test.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-exclude-imports/src/__tests__/index.test.js
@@ -25,6 +25,9 @@ it('empties files when package is listed in imports', () => {
 			},
 			config: {},
 			log: new PluginLogger(),
+			rootPkgJson: {
+				name: 'root',
+			},
 		},
 		{
 			files,
@@ -53,6 +56,40 @@ it('leaves files untouched when package is missing from imports', () => {
 			},
 			config: {},
 			log: new PluginLogger(),
+			rootPkgJson: {
+				name: 'root',
+			},
+		},
+		{
+			files,
+		}
+	);
+
+	expect(files).toEqual(originalFiles);
+});
+
+it('leaves files untouched when package is self-imported from project', () => {
+	const originalFiles = ['1.js', '2.js', '3.js'];
+	const files = originalFiles.slice();
+
+	plugin(
+		{
+			pkg: {
+				name: 'pkg-a',
+				version: '1.0.0',
+			},
+			globalConfig: {
+				imports: {
+					root: {
+						'pkg-a': '^1.0.0',
+					},
+				},
+			},
+			config: {},
+			log: new PluginLogger(),
+			rootPkgJson: {
+				name: 'root',
+			},
 		},
 		{
 			files,

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-exclude-imports/src/index.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-exclude-imports/src/index.js
@@ -8,12 +8,17 @@ import {unrollImportsConfig} from 'liferay-npm-build-tools-common/lib/imports';
 /**
  * @return {void}
  */
-export default function ({config, globalConfig, log, pkg}, {files}) {
+export default function (
+	{config, globalConfig, log, pkg, rootPkgJson},
+	{files}
+) {
 	let imports = config.imports || globalConfig.imports || {};
 
 	imports = unrollImportsConfig(imports);
 
-	if (imports[pkg.name]) {
+	// Exclude third party deps when imported, but not if coming from us
+
+	if (imports[pkg.name] && imports[pkg.name].name !== rootPkgJson.name) {
 		files.length = 0;
 
 		log.info(

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-inject-imports-dependencies/src/index.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-inject-imports-dependencies/src/index.js
@@ -17,7 +17,21 @@ export default function ({config, globalConfig, log, rootPkgJson}, {pkgJson}) {
 	pkgJson.dependencies = pkgJson.dependencies || {};
 
 	Object.keys(imports).forEach((namespace) => {
+
+		// Don't import third party deps from ourselves
+
+		if (namespace === rootPkgJson.name) {
+			return;
+		}
+
 		Object.keys(imports[namespace]).forEach((pkgName) => {
+
+			// Don't import ourselves
+
+			if (namespace === '' && pkgName === rootPkgJson.name) {
+				return;
+			}
+
 			const localName = ns.addNamespace(pkgName, rootPkgJson);
 
 			const importVersion = imports[namespace][pkgName];


### PR DESCRIPTION
This is needed since we allowed to inherit the base configuration from the liferay-portal project in
npm-scripts.

This is because now we don't have a way to disable the inherited imports other than setting them
to false one by one. But that makes it very difficult to configure projects, because if we add a new
import to the base config, we need to check all other projects one by one.

With this change, we can use the same base config in all projects without making the build fail
because a project excludes itself from the JAR because the bundler thought it was imported
(rather than the project being built).

Example: the [current base npm-scripts config](https://github.com/liferay/liferay-portal/blob/8cf1bfb038cd72870018de6b9f37c082b71e4519/modules/npmscripts.config.js#L32) in portal imports react from frontend-js-react-web and that makes bundler think that it shouldn't include react inside frontend-js-react-web JAR :roll_eyes: .

A way to fix that would be creating this npmscripts.config.js file in `frontend-js-react-web`:

```javascript
module.exports = {
	build: {
		bundler: {
			config: {
				imports: {
				  "@liferay/frontend-js-react-web": false,
...
```

But that's ugly and doesn't scale well because if we add a new import for an existing project we need to remember to modify the existing project. This, in addition to being error prone, may be quite hard to debug so better avoid it with this fix.