### PR TITLE
feat(eslint-config)!: add several packages to the no-metal-plugin eslint rule

### DIFF
--- a/projects/eslint-config/plugins/portal/lib/rules/no-metal-plugins.js
+++ b/projects/eslint-config/plugins/portal/lib/rules/no-metal-plugins.js
@@ -4,14 +4,24 @@
  */
 
 const DEPRECATED_MODULES = [
+	'metal-affix',
 	'metal-ajax',
+	'metal-anim',
 	'metal-aop',
+	'metal-assertions',
 	'metal-clipboard',
 	'metal-debounce',
+	'metal-dom',
+	'metal-key',
 	'metal-keyboard-focus',
+	'metal-multimap',
+	'metal-path-parser',
+	'metal-position',
 	'metal-promise',
+	'metal-scrollspy',
 	'metal-storage',
 	'metal-structs',
+	'metal-throttle',
 	'metal-uri',
 	'metal-useragent',
 ];
@@ -44,22 +54,42 @@ module.exports = {
 		},
 		fixable: null,
 		messages: {
+			'no-metal-affix':
+				'metal-affix is deprecated; use native offset instead',
 			'no-metal-ajax':
 				"metal-ajax is deprecated; use `import {fetch} from 'frontend-js-web';` instead",
+			'no-metal-anim':
+				'metal-anim is deprecated; use native `window.requestAnimationFrame()` instead',
 			'no-metal-aop':
 				"metal-aop is deprecated; use `import {AOP} from 'frontend-js-web';` instead",
+			'no-metal-assertions':
+				'metal-assertions is deprecated; use native `typeof` instead',
 			'no-metal-clipboard':
 				'metal-clipboard is deprecated; use ClipboardJS instead',
 			'no-metal-debounce':
 				"metal-debounce is deprecated; use `import {debounce} from 'frontend-js-web';` instead",
+			'no-metal-dom':
+				'metal-dom is deprecated; see https://issues.liferay.com/browse/LPS-122383 to learn what to use instead',
+			'no-metal-key':
+				'metal-key is deprecated; use native key event handling instead',
 			'no-metal-keyboard-focus':
-				"metal-keyboard-focus is deprecated; use `import {debounce} from 'frontend-js-web';` instead",
+				'metal-keyboard-focus is deprecated; use native focus behaviour instead',
+			'no-metal-multimap':
+				'metal-multimap is deprecated; use native Set instead',
+			'no-metal-path-parser':
+				'metal-path-parser is deprecated; use native string manipulation instead',
+			'no-metal-position':
+				"metal-position is deprecated; use `import {ALIGN_POSITIONS, align} from 'frontend-js-web';` instead",
 			'no-metal-promise':
 				'metal-promise is deprecated; use native Promise instead',
+			'no-metal-scrollspy':
+				'metal-scrollspy is deprecated; use native scroll instead',
 			'no-metal-storage':
 				'metal-storage is deprecated; use a local implementation instead',
 			'no-metal-structs':
 				'metal-structs is deprecated; use plain objects instead',
+			'no-metal-throttle':
+				"metal-throttle is deprecated; `import {throttle} from 'frontend-js-web';` instead",
 			'no-metal-uri': 'metal-uri is deprecated; use native URL instead',
 			'no-metal-useragent':
 				'metal-useragent is deprecated; use `Liferay.Browser` instead',

--- a/projects/eslint-config/plugins/portal/lib/rules/no-metal-plugins.js
+++ b/projects/eslint-config/plugins/portal/lib/rules/no-metal-plugins.js
@@ -12,18 +12,23 @@ const DEPRECATED_MODULES = [
 	'metal-clipboard',
 	'metal-debounce',
 	'metal-dom',
+	'metal-isomorphic',
 	'metal-key',
 	'metal-keyboard-focus',
 	'metal-multimap',
+	'metal-pagination',
 	'metal-path-parser',
 	'metal-position',
 	'metal-promise',
+	'metal-router',
 	'metal-scrollspy',
 	'metal-storage',
 	'metal-structs',
 	'metal-throttle',
+	'metal-toggler',
 	'metal-uri',
 	'metal-useragent',
+	'metal-web-component',
 ];
 
 module.exports = {
@@ -54,45 +59,54 @@ module.exports = {
 		},
 		fixable: null,
 		messages: {
-			'no-metal-affix':
-				'metal-affix is deprecated; use native offset instead',
+			'no-metal-affix': 'metal-affix is deprecated; use offset instead',
 			'no-metal-ajax':
 				"metal-ajax is deprecated; use `import {fetch} from 'frontend-js-web';` instead",
 			'no-metal-anim':
-				'metal-anim is deprecated; use native `window.requestAnimationFrame()` instead',
+				'metal-anim is deprecated; use `requestAnimationFrame()` instead',
 			'no-metal-aop':
 				"metal-aop is deprecated; use `import {AOP} from 'frontend-js-web';` instead",
 			'no-metal-assertions':
-				'metal-assertions is deprecated; use native `typeof` instead',
+				'metal-assertions is deprecated; use `typeof` instead',
 			'no-metal-clipboard':
 				'metal-clipboard is deprecated; use ClipboardJS instead',
 			'no-metal-debounce':
 				"metal-debounce is deprecated; use `import {debounce} from 'frontend-js-web';` instead",
 			'no-metal-dom':
-				'metal-dom is deprecated; see https://issues.liferay.com/browse/LPS-122383 to learn what to use instead',
+				'metal-dom is deprecated; see https://issues.liferay.com/browse/LPS-122383',
+			'no-metal-isomorphic':
+				'metal-isomorphic is deprecated; see https://github.com/liferay/liferay-frontend-projects/pull/456',
 			'no-metal-key':
-				'metal-key is deprecated; use native key event handling instead',
+				'metal-key is deprecated; use key event handling instead',
 			'no-metal-keyboard-focus':
-				'metal-keyboard-focus is deprecated; use native focus behaviour instead',
+				'metal-keyboard-focus is deprecated; use focus behaviour instead',
 			'no-metal-multimap':
-				'metal-multimap is deprecated; use native Set instead',
+				'metal-multimap is deprecated; use Map instead',
+			'no-metal-pagination':
+				'metal-pagination is deprecated; use https://clayui.com/docs/components/pagination.html',
 			'no-metal-path-parser':
-				'metal-path-parser is deprecated; use native string manipulation instead',
+				'metal-path-parser is deprecated; use string manipulation instead',
 			'no-metal-position':
 				"metal-position is deprecated; use `import {ALIGN_POSITIONS, align} from 'frontend-js-web';` instead",
 			'no-metal-promise':
-				'metal-promise is deprecated; use native Promise instead',
+				'metal-promise is deprecated; use Promise instead',
+			'no-metal-router':
+				'metal-router is deprecated; see https://github.com/liferay/liferay-frontend-projects/pull/456',
 			'no-metal-scrollspy':
-				'metal-scrollspy is deprecated; use native scroll instead',
+				'metal-scrollspy is deprecated; use scroll instead',
 			'no-metal-storage':
 				'metal-storage is deprecated; use a local implementation instead',
 			'no-metal-structs':
 				'metal-structs is deprecated; use plain objects instead',
 			'no-metal-throttle':
 				"metal-throttle is deprecated; `import {throttle} from 'frontend-js-web';` instead",
-			'no-metal-uri': 'metal-uri is deprecated; use native URL instead',
+			'no-metal-toggler':
+				'metal-toggler is deprecated; use https://clayui.com/docs/components/toggle-switch.html',
+			'no-metal-uri': 'metal-uri is deprecated; use URL instead',
 			'no-metal-useragent':
 				'metal-useragent is deprecated; use `Liferay.Browser` instead',
+			'no-metal-web-component':
+				'metal-web-component is deprecated; see https://github.com/liferay/liferay-frontend-projects/pull/456',
 		},
 		schema: [],
 		type: 'problem',

--- a/projects/eslint-config/plugins/portal/tests/lib/rules/no-metal-plugins.js
+++ b/projects/eslint-config/plugins/portal/tests/lib/rules/no-metal-plugins.js
@@ -18,7 +18,7 @@ const ruleTester = new MultiTester(parserOptions);
 ruleTester.run('no-metal-plugins', rule, {
 	invalid: [
 		{
-			code: "import {Affix} from 'metal-affix';",
+			code: "import Affix from 'metal-affix';",
 			errors: [
 				{
 					messageId: 'no-metal-affix',
@@ -36,7 +36,7 @@ ruleTester.run('no-metal-plugins', rule, {
 			],
 		},
 		{
-			code: "import {Anim} from 'metal-anim';",
+			code: "import Anim from 'metal-anim';",
 			errors: [
 				{
 					messageId: 'no-metal-anim',
@@ -45,7 +45,7 @@ ruleTester.run('no-metal-plugins', rule, {
 			],
 		},
 		{
-			code: "import {AOP} from 'metal-aop';",
+			code: "import AOP from 'metal-aop';",
 			errors: [
 				{
 					messageId: 'no-metal-aop',
@@ -54,7 +54,7 @@ ruleTester.run('no-metal-plugins', rule, {
 			],
 		},
 		{
-			code: "import {assertBoolean} from 'metal-assertions';",
+			code: "import assertBoolean from 'metal-assertions';",
 			errors: [
 				{
 					messageId: 'no-metal-assertions',
@@ -72,7 +72,7 @@ ruleTester.run('no-metal-plugins', rule, {
 			],
 		},
 		{
-			code: "import {debounce} from 'metal-debounce';",
+			code: "import debounce from 'metal-debounce';",
 			errors: [
 				{
 					messageId: 'no-metal-debounce',
@@ -81,10 +81,19 @@ ruleTester.run('no-metal-plugins', rule, {
 			],
 		},
 		{
-			code: "import {on} from 'metal-dom';",
+			code: "import on from 'metal-dom';",
 			errors: [
 				{
 					messageId: 'no-metal-dom',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
+			code: "import 'metal-isomorphic';",
+			errors: [
+				{
+					messageId: 'no-metal-isomorphic',
 					type: 'ImportDeclaration',
 				},
 			],
@@ -99,7 +108,7 @@ ruleTester.run('no-metal-plugins', rule, {
 			],
 		},
 		{
-			code: "import {MultiMap} from 'metal-multimap';",
+			code: "import MultiMap from 'metal-multimap';",
 			errors: [
 				{
 					messageId: 'no-metal-multimap',
@@ -108,7 +117,16 @@ ruleTester.run('no-metal-plugins', rule, {
 			],
 		},
 		{
-			code: "import {Align} from 'metal-position';",
+			code: "import Pagination from 'metal-pagination';",
+			errors: [
+				{
+					messageId: 'no-metal-pagination',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
+			code: "import Align from 'metal-position';",
 			errors: [
 				{
 					messageId: 'no-metal-position',
@@ -117,7 +135,7 @@ ruleTester.run('no-metal-plugins', rule, {
 			],
 		},
 		{
-			code: "import {CancellablePromise} from 'metal-promise';",
+			code: "import CancellablePromise from 'metal-promise';",
 			errors: [
 				{
 					messageId: 'no-metal-promise',
@@ -126,7 +144,16 @@ ruleTester.run('no-metal-plugins', rule, {
 			],
 		},
 		{
-			code: "import {Scrollspy} from 'metal-scrollspy';",
+			code: "import Router from 'metal-router';",
+			errors: [
+				{
+					messageId: 'no-metal-router',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
+			code: "import Scrollspy from 'metal-scrollspy';",
 			errors: [
 				{
 					messageId: 'no-metal-scrollspy',
@@ -145,7 +172,7 @@ ruleTester.run('no-metal-plugins', rule, {
 			],
 		},
 		{
-			code: "import {MultiMap} from 'metal-structs';",
+			code: "import MultiMap from 'metal-structs';",
 			errors: [
 				{
 					messageId: 'no-metal-structs',
@@ -154,10 +181,19 @@ ruleTester.run('no-metal-plugins', rule, {
 			],
 		},
 		{
-			code: "import {throttle} from 'metal-throttle';",
+			code: "import throttle from 'metal-throttle';",
 			errors: [
 				{
 					messageId: 'no-metal-throttle',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
+			code: "import Toggler from 'metal-toggler';",
+			errors: [
+				{
+					messageId: 'no-metal-toggler',
 					type: 'ImportDeclaration',
 				},
 			],
@@ -176,6 +212,15 @@ ruleTester.run('no-metal-plugins', rule, {
 			errors: [
 				{
 					messageId: 'no-metal-useragent',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
+			code: "import defineWebComponent from 'metal-web-component';",
+			errors: [
+				{
+					messageId: 'no-metal-web-component',
 					type: 'ImportDeclaration',
 				},
 			],

--- a/projects/eslint-config/plugins/portal/tests/lib/rules/no-metal-plugins.js
+++ b/projects/eslint-config/plugins/portal/tests/lib/rules/no-metal-plugins.js
@@ -18,6 +18,15 @@ const ruleTester = new MultiTester(parserOptions);
 ruleTester.run('no-metal-plugins', rule, {
 	invalid: [
 		{
+			code: "import {Affix} from 'metal-affix';",
+			errors: [
+				{
+					messageId: 'no-metal-affix',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
 			code: "import Ajax from 'metal-ajax';",
 			errors: [
 				{
@@ -27,10 +36,28 @@ ruleTester.run('no-metal-plugins', rule, {
 			],
 		},
 		{
+			code: "import {Anim} from 'metal-anim';",
+			errors: [
+				{
+					messageId: 'no-metal-anim',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
 			code: "import {AOP} from 'metal-aop';",
 			errors: [
 				{
 					messageId: 'no-metal-aop',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
+			code: "import {assertBoolean} from 'metal-assertions';",
+			errors: [
+				{
+					messageId: 'no-metal-assertions',
 					type: 'ImportDeclaration',
 				},
 			],
@@ -54,6 +81,15 @@ ruleTester.run('no-metal-plugins', rule, {
 			],
 		},
 		{
+			code: "import {on} from 'metal-dom';",
+			errors: [
+				{
+					messageId: 'no-metal-dom',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
 			code: "import KeyboardFocusManager from 'metal-keyboard-focus';",
 			errors: [
 				{
@@ -63,10 +99,37 @@ ruleTester.run('no-metal-plugins', rule, {
 			],
 		},
 		{
+			code: "import {MultiMap} from 'metal-multimap';",
+			errors: [
+				{
+					messageId: 'no-metal-multimap',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
+			code: "import {Align} from 'metal-position';",
+			errors: [
+				{
+					messageId: 'no-metal-position',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
 			code: "import {CancellablePromise} from 'metal-promise';",
 			errors: [
 				{
 					messageId: 'no-metal-promise',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
+			code: "import {Scrollspy} from 'metal-scrollspy';",
+			errors: [
+				{
+					messageId: 'no-metal-scrollspy',
 					type: 'ImportDeclaration',
 				},
 			],
@@ -86,6 +149,15 @@ ruleTester.run('no-metal-plugins', rule, {
 			errors: [
 				{
 					messageId: 'no-metal-structs',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
+			code: "import {throttle} from 'metal-throttle';",
+			errors: [
+				{
+					messageId: 'no-metal-throttle',
 					type: 'ImportDeclaration',
 				},
 			],


### PR DESCRIPTION
Fixes https://github.com/liferay/liferay-frontend-projects/issues/386

Hey crew, first time doing something like this so please let me know if I missed something or done something wrong, but here's what I've done.

- added `affix`, `position`, and `throttle` and others to the list of deprecated modules. There are leftover modules but they're still used
- fixed the warning text of `keyboard-focus`. I couldn't find our own implementation, other than `useKeyboardNavigation` but that one didn't look the same, so just referenced a default focus behaviour
- added tests for the new deprecated modules

## Notes: 
- It wasn't clear to me if I'm supposed to go to do what @wincent mentioned in https://github.com/liferay/liferay-frontend-projects/issues/386#issuecomment-766996855 - the 7.2 and 7.3 config update
- `metal-isomorphic` is like a testing library it seems, so not sure what to do about that one
- `metal-pagination` is a component with UI, so not sure what to do about that one
- `metal-router` is a Metal variant of the React Router, do we recommend people to use that one, or something else, not sure
- `metal-toggler` is a component with UI, same as pagination
- `metal-web-component` is a specific case too, not sure what to do with it either