### PR TITLE
chore(monorepo): temporarily fix lockfile failure in CI

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1402,6 +1402,21 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@liferay/eslint-config@22.0.0":
+  version "22.0.0"
+  resolved "https://registry.yarnpkg.com/@liferay/eslint-config/-/eslint-config-22.0.0.tgz#f52f343316d6eb1aa8b99d5a9c393d25872827e2"
+  integrity sha512-aLOyJdORT2y0MoUcdakf8XFTu7gbHtxz1ygKmw5mZkmd/9Ihdgurly28tI3fBRbxjpZ2YMZCHGV/dLfK6vYFiQ==
+  dependencies:
+    "@typescript-eslint/eslint-plugin" "4.3.0"
+    "@typescript-eslint/parser" "4.3.0"
+    eslint-config-prettier "6.12.0"
+    eslint-plugin-no-for-of-loops "^1.0.0"
+    eslint-plugin-no-only-tests "^2.1.0"
+    eslint-plugin-notice "0.9.10"
+    eslint-plugin-react "^7.21.3"
+    eslint-plugin-react-hooks "^4.1.2"
+    eslint-plugin-sort-destructure-keys "^1.3.5"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
[CI is failing](https://github.com/liferay/liferay-frontend-projects/runs/2140506487) on master (cfb2c217c449f717e473) right now because we just prepared the v23.0.0 release of `@liferay/eslint-config`, but `@liferay/npm-scripts` still depends on v22.0.0.

Now, @kresimir-coko will fix that tomorrow when he completes the release and updates the dependency, so for now I am just freshening the lockfile to keep CI green. (I could also fix this by updating the dependency myself, but that would require me to finish the release, and I don't want to do that.)