### PR TITLE
feat(js-publish): educate people about 2FA

### DIFF
--- a/.github/workflows/global.yml
+++ b/.github/workflows/global.yml
@@ -10,7 +10,7 @@ on:
 
 env:
     CI: true
-    yarn-cache-name: yarn-cache-2
+    yarn-cache-name: yarn-cache-3
     yarn-cache-path: .yarn
 
 jobs:

--- a/projects/npm-tools/packages/js-publish/src/index.js
+++ b/projects/npm-tools/packages/js-publish/src/index.js
@@ -202,10 +202,21 @@ async function runYarnPublish(pkg) {
 
 	const args = ['--non-interactive'];
 
-	const otp = await confirm('Please enter an OTP token or press ENTER:', '');
+	const otp = await confirm(
+		'Please enter an OTP token (https://git.io/JmaXU) or press ENTER:',
+		''
+	);
 
 	if (otp) {
 		args.push('--otp', otp);
+	}
+	else {
+		printBanner(
+			'Proceeding without 2FA (Two-Factor Autentication) ☠️ ',
+			'2FA is strongly recommended, to keep our packages secure.',
+			'Please consider activating it.',
+			'See https://git.io/JmaXU to learn more'
+		);
 	}
 
 	if (isPrereleaseVersion(pkg)) {


### PR DESCRIPTION
This comes from [the thread in Slack today](https://liferay.slack.com/archives/C3JBR21HA/p1616068068087200) where we saw that the meaning of "OTP" in the context of npm may not be clear to everybody.

So, instead of just asking for an OTP token, include a shortlink to [this page](https://github.com/liferay/liferay-frontend-projects/blob/master/guidelines/general/security/two_factor_authentication.md) that explains it in more detail.

In case you're wondering about whether git.io is a sketchy third-party service that could disappear or start redirecting to hostile sites any day now, don't worry; it's [an official GitHub service](https://github.blog/2011-11-10-git-io-github-url-shortener/).

As a bonus, if you are so audacious as to proceed without supplying an OTP, we now scold you as seen below:

    Run `yarn publish`? [y/n] y
    Please enter an OTP token (https://git.io/JmaXU) or press ENTER:

    Proceeding without 2FA (Two-Factor Autentication) ☠️

    2FA is strongly recommended, to keep our packages secure.

    Please consider activating it.

    See https://git.io/JmaXU to learn more

FWIW, in the code font here on GitHub the skull and cross-bones looks a bit lame, but at least in my terminal it looks like this: ☠️

![badass](https://user-images.githubusercontent.com/7074/111664477-16e7a200-8812-11eb-876d-203a445921b9.gif)
