### PR TITLE
chore(npm-scripts): bump @liferay/eslint-config version from v22.0 to v23.0

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/package.json
+++ b/projects/npm-tools/packages/npm-scripts/package.json
@@ -14,7 +14,7 @@
 		"@babel/preset-env": "^7.4.2",
 		"@babel/preset-react": "^7.8.3",
 		"@babel/preset-typescript": "^7.10.4",
-		"@liferay/eslint-config": "22.0.0",
+		"@liferay/eslint-config": "23.0.0",
 		"@liferay/jest-junit-reporter": "1.2.0",
 		"@liferay/js-toolkit-core": "3.0.1",
 		"@testing-library/dom": "^5.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1402,21 +1402,6 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@liferay/eslint-config@22.0.0":
-  version "22.0.0"
-  resolved "https://registry.yarnpkg.com/@liferay/eslint-config/-/eslint-config-22.0.0.tgz#f52f343316d6eb1aa8b99d5a9c393d25872827e2"
-  integrity sha512-aLOyJdORT2y0MoUcdakf8XFTu7gbHtxz1ygKmw5mZkmd/9Ihdgurly28tI3fBRbxjpZ2YMZCHGV/dLfK6vYFiQ==
-  dependencies:
-    "@typescript-eslint/eslint-plugin" "4.3.0"
-    "@typescript-eslint/parser" "4.3.0"
-    eslint-config-prettier "6.12.0"
-    eslint-plugin-no-for-of-loops "^1.0.0"
-    eslint-plugin-no-only-tests "^2.1.0"
-    eslint-plugin-notice "0.9.10"
-    eslint-plugin-react "^7.21.3"
-    eslint-plugin-react-hooks "^4.1.2"
-    eslint-plugin-sort-destructure-keys "^1.3.5"
-
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
Not sure if I needed to push the generated `yarn.lock` file, so I opted not to.

This is a fix that @wincent mentioned in https://github.com/liferay/liferay-frontend-projects/pull/460