### PR TITLE
feat(npm-scripts): teach getJestModuleNameMapper about TS manifests

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/utils/getJestModuleNameMapper.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/getJestModuleNameMapper.js
@@ -80,20 +80,42 @@ function getJestModuleNameMapper() {
 					if (main) {
 						const entry = path.join(project, ...SRC_PATH, main);
 
-						if (fs.existsSync(entry)) {
-							const resources = path.relative(
-								cwd,
-								path.join(project, ...SRC_PATH)
-							);
+						// Handle typical formats for "main":
+						//
+						// - index        -> index.js
+						// - index.es     -> index.es.js
+						// - index.es.js  -> index.es.js
+						// - index.js     -> index.js
+						// - index.js     -> index.ts
 
-							mappings[`^${name}$`] = `<rootDir>${path.relative(
-								cwd,
-								entry
-							)}`;
+						const candidates = [entry];
 
-							mappings[
-								`^${name}/(.*)`
-							] = `<rootDir>${resources}/$1`;
+						if (entry.endsWith('.js')) {
+							candidates.push(entry.replace(/\.js$/, '.ts'));
+						}
+						else {
+							candidates.push(entry + '.js');
+						}
+
+						for (let i = 0; i < candidates.length; i++) {
+							const candidate = candidates[i];
+
+							if (fs.existsSync(candidate)) {
+								const resources = path.relative(
+									cwd,
+									path.join(project, ...SRC_PATH)
+								);
+
+								mappings[
+									`^${name}$`
+								] = `<rootDir>${path.relative(cwd, candidate)}`;
+
+								mappings[
+									`^${name}/(.*)`
+								] = `<rootDir>${resources}/$1`;
+
+								break;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
As noted [here](https://github.com/liferay-frontend/liferay-portal/pull/925) we are adding TS to modules in DXP, but we will continue to use names like "index.js" in our "main" fields in our "package.json" files (this is because our bundler/loader/registry use "main" and expect it to point to an ES5-ish file that is ready to serve to the browser). That is, in a module that has an "index.ts" file in the "src/" folder, we will still say "index.js" in the "main" field, because that is the name of the built-module that we can expect to exist at runtime.

Doing a quick survey of "main" fields in DXP you can see that the most common names are things like "index.js" and "index.es.js", but we also have "index.es" in some places. In other words, the extension is optional, but we do expect the file on disk to be JS (basically ES5-ish).

So, this commit teaches `getJestModuleNameMapper()` to look for "index.ts" files when "index.js" is specified in the "main" field. Technically, it is a bit more general than that because it is also going to look for "index.js" if "main" says "index", and "index.es.js" if it says "index.es".

With this change, a test can import modules from another file like this in (eg.) frontend-js-react-web:

    import {State} from '@liferay/frontend-js-state-web';

As opposed to spelling out the path fully:

    import State from '@liferay/frontend-js-state-web/src/main/resources/META-INF/resources/State';

which is what we were doing in [an earlier iteration of that PR](https://github.com/wincent/liferay-portal/pull/375).

Test plan: Copy paste the new implementation into `node_modules` in DXP and see new tests in frontend-js-react-web pass.