### PR TITLE
feat(eslint-config)!: adapt no-use-before-define set-up for TypeScript

### DIFF
--- a/maintenance/projects/js-toolkit/packages/babel-plugin-alias-modules/src/index.ts
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-alias-modules/src/index.ts
@@ -21,24 +21,6 @@ const absPrjDirPath = project.dir.asNative;
 const absBuildDirPath = project.dir.join(project.buildDir).asNative;
 let t;
 
-/**
- * @return {object} a babel visitor
- */
-export default function ({types}) {
-	t = types;
-
-	return {
-		visitor: {
-			CallExpression(bpath, state) {
-				state.visitor.CallExpression(bpath);
-			},
-			Program(bpath, state) {
-				new Visitor(state);
-			},
-		},
-	};
-}
-
 export class Visitor {
 	constructor(state) {
 		const babelIpcObject: BabelIpcObject = babelIpc.get(state, {});
@@ -298,4 +280,22 @@ export class Visitor {
 	private readonly _aliasFields: string[];
 	private readonly _absFile: FilePath;
 	private readonly _log: PluginLogger;
+}
+
+/**
+ * @return {object} a babel visitor
+ */
+export default function ({types}) {
+	t = types;
+
+	return {
+		visitor: {
+			CallExpression(bpath, state) {
+				state.visitor.CallExpression(bpath);
+			},
+			Program(bpath, state) {
+				new Visitor(state);
+			},
+		},
+	};
 }

--- a/projects/eslint-config/index.js
+++ b/projects/eslint-config/index.js
@@ -24,6 +24,10 @@ const config = {
 						varsIgnorePattern: '^_',
 					},
 				],
+				'@typescript-eslint/no-use-before-define': [
+					'error',
+					{functions: false},
+				],
 
 				// These rules can be turned off because the corresponding
 				// errors are caught by the TypeScript compiler itself.
@@ -32,6 +36,7 @@ const config = {
 				'no-undef': 'off',
 				'no-unused-expressions': 'off',
 				'no-unused-vars': 'off',
+				'no-use-before-define': 'off',
 			},
 		},
 		{


### PR DESCRIPTION
As seen in PRs such as:

- https://github.com/liferay-frontend/liferay-portal/pull/925
- https://github.com/liferay-frontend/liferay-portal/pull/942

We need to tweak the ESLint rules in order to accommodate our growing TypeScript usage. Without this, some common idiomatic patterns create false positives.

Without this, even a simple

    import React from 'react';

will lead to:

    17:8  error  'React' was used before it was defined.  no-use-before-define

Note that we're allowing functions to be used before they are defined because:

1.  Function hoisting is an oft-exploited idiomatic feature of JS.
2.  Liferay likes keeping things in alphabetical, not topological, order.

Technically a breaking change because this will lead to new lint errors popping up if/when this is backported to much older branches (where the vanilla ESLint version of this rule is not active); at the time of writing, [the oldest version the rule is active on is 7.3.x](https://github.com/liferay/liferay-portal/blob/b143af27485d180c017b7fc14dd6587ddf1fe21d/modules/.eslintrc.js#L40-L47).

**Test plan:**

1.  Copy these changes into `node_modules` in liferay-portal.
2.  Comment out these lines in `modules/.eslintrc.js`:

              'no-use-before-define': [
                      'error',
                      {
                              classes: true,
                              functions: false,
                              variables: true,
                      },
              ],

    **NOTE:** this means that when integrating this PR with liferay-portal we must remember to make the above change there too.

    For reference, we added that config in [this commit](https://github.com/liferay/liferay-portal/commit/39b3fea37dca18482a7355edabe599dc0a72793b), but the new TypeScript-based config should be equivalent.
3.  `yarn run checkFormat` on a PR like the one linked above (with the local `.eslintrc.js` removed).
4.  See a clean run.