### PR TITLE
feat(npm-scripts): add @types/react-dom dependency

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/package.json
+++ b/projects/npm-tools/packages/npm-scripts/package.json
@@ -23,6 +23,7 @@
 		"@testing-library/react-hooks": "^3.4.2",
 		"@testing-library/user-event": "^4.2.4",
 		"@types/jest": "^26.0.14",
+		"@types/react-dom": "17.0.3",
 		"@types/vfile-message": "2.0.0",
 		"babel-eslint": "^10.0.3",
 		"babel-jest": "^25.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1811,6 +1811,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
+"@types/react-dom@17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.3.tgz#7fdf37b8af9d6d40127137865bb3fff8871d7ee1"
+  integrity sha512-4NnJbCeWE+8YBzupn/YrJxZ8VnjcJq5iR1laqQ1vkpQgBiA7bwk0Rp24fxsdNinzJY2U+HHS4dJJDPdoMjdJ7w==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-test-renderer@*":
   version "16.9.3"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz#96bab1860904366f4e848b739ba0e2f67bcae87e"


### PR DESCRIPTION
This allows us to use TS in React components, as seen in PRs like:

- https://github.com/liferay-frontend/liferay-portal/pull/925
- https://github.com/liferay-frontend/liferay-portal/pull/942

Note that `npm-scripts` may not be the definitive home for this; it's just one of the two places that we can put it:

1.  Inside `frontend-js-react-web`, because that's where our `react` dependency comes from, and it makes sense to version the React package and its type definitions together (better still would be if the React team shipped TypeScript types with the package).
2.  Inside `npm-scripts` because that is "The Blessed" way of getting devDependencies into liferay-portal; in fact, the only reason we get away with it in `frontend-js-react-web` is due to [a "temporary suppression"](https://github.com/liferay/liferay-portal/blob/a9386e72048dbab268d97ca5fd295449579ad0a6/source-formatter-suppressions.xml#L157-L159) that has been in the repo [since August 2019](https://github.com/liferay/liferay-portal/commit/0f14d0806adae5f425ed38e2da8913bd7c93d9b0).

So, this commit goes with "2". Once [the LPS](https://issues.liferay.com/browse/LPS-99901) cited in the above commit is resolved... whenever that is... we can reconsider things.

**Test plan:**

1. In the above PR, `yarn remove @types/react-dom` inside `frontend-js-react-web`.
2. In `modules/`, do `yarn add path/to/npm-scripts`.
3. Verify that `yarn run build` still works without errors inside `frontend-js-react-web`.