### PR TITLE
feat(npm-scripts): automatically run TS tests

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/config/jest.config.js
+++ b/projects/npm-tools/packages/npm-scripts/src/config/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
 	setupFiles: [require.resolve('../jest/setup.js')],
 	setupFilesAfterEnv: [require.resolve('../jest/setupAfterEnv.js')],
 	testEnvironment: 'jest-environment-jsdom-thirteen',
-	testMatch: ['**/test/**/*.js'],
+	testMatch: ['<rootDir>/test/**/*.{js,ts,tsx}'],
 	testPathIgnorePatterns: ['/node_modules/', '<rootDir>/test/stories/'],
 	testResultsProcessor: '@liferay/jest-junit-reporter',
 	testURL: 'http://localhost',


### PR DESCRIPTION
In PRs like:

- https://github.com/liferay-frontend/liferay-portal/pull/925
- https://github.com/liferay-frontend/liferay-portal/pull/942

We have had to explicitly adjust the `testMatch` directive to catch TS files. We may as well do this automatically throughout liferay-portal.

Seeing as I was changing this, note that I made the pattern a little stricter (adding `<rootDir>`) because this brings us into more exact alignment with our conventions (which clearly state that source should go in `src/` and tests should go in `test/`).

**Note:** When we integrate this with liferay-portal, we not only have to clean out the `jest.config.js` that exists in those two PRs, but also the `jest` field in the `package.json` of `remote-app-client-js`, which is mentioned below.

**Test plan:**

1. Run `yarn run test` in modules using TypeScript as a first spot check (`remote-app-client-js`, plus the two modules in the PRs above). Note that tests run correctly even when you delete the local `jest.config.js` overrides.

2. Run `portool test` from `modules/` (this is just a script that enables me to run `yarn run test` in every project that has tests) and see them all pass.