### PR TITLE
chore(npm-scripts): update to typescript@4.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"strip-ansi": "^6.0.0",
 		"terser-webpack-plugin": "^5.0.3",
 		"ts-jest": "^26.4.1",
-		"typescript": "^4.0.3",
+		"typescript": "^4.2.3",
 		"webpack": "^5.11.1",
 		"webpack-cli": "^4.2.0",
 		"webpack-dev-server": "^3.11.0",

--- a/projects/npm-tools/packages/npm-scripts/package.json
+++ b/projects/npm-tools/packages/npm-scripts/package.json
@@ -75,7 +75,7 @@
 		"stylelint": "^13.2.0",
 		"terser": "5.3.8",
 		"ts-loader": "^8.0.4",
-		"typescript": "^4.0.3",
+		"typescript": "^4.2.3",
 		"webpack": "^5.11.1",
 		"webpack-cli": "^4.2.0",
 		"webpack-dev-server": "^3.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15038,10 +15038,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
-  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
+typescript@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 typical@^5.0.0, typical@^5.2.0:
   version "5.2.0"


### PR DESCRIPTION
Seeing as we're sending TS stuff to liferay-portal, may as well take the opportunity to freshen things up.

**Test plan:** `yarn add -W --dev path/to/npm-scripts` in `modules/` and confirm that all TS modules still building and testing (ie. `remote-app-client-js`, `frontend-js-state-web`, and with https://github.com/liferay-frontend/liferay-portal/pull/942 checked out, `frontend-js-react-web`).