### PR TITLE
feat(npm-scripts): manage TS type artifacts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,6 +17,8 @@
 /projects/js-toolkit/**/generators
 /projects/js-toolkit/**/lib
 
+/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/**/tsconfig.json
+
 #
 # Templates.
 #

--- a/projects/npm-tools/packages/npm-scripts/.gitignore
+++ b/projects/npm-tools/packages/npm-scripts/.gitignore
@@ -1,1 +1,1 @@
-node_modules
+/__fixtures__/typescript/**/tsconfig.json

--- a/projects/npm-tools/packages/npm-scripts/README.md
+++ b/projects/npm-tools/packages/npm-scripts/README.md
@@ -165,6 +165,14 @@ liferay-npm-scripts theme build
 
 Runs the "build" task, providing it with the configuration it needs to find core dependencies such as the [`liferay-frontend-theme-styled` base theme files](https://github.com/liferay/liferay-portal/tree/master/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled).
 
+### types
+
+```sh
+liferay-npm-scripts types
+```
+
+Freshens all TypeScript type definition files in a `liferay-portal` checkout. Normally, these artifacts (`.d.ts` and `tsconfig.tsbuildinfo` files) would be committed along with changes to the corresponding module, but this command exists as a convenience for doing a global refresh across the entire repo (which would otherwise be tedious to do by hand because the projects must be built in dependency order).
+
 ## Config
 
 > Note: as of v2.x the config file was renamed from `.liferaynpmscriptsrc` to `npmscripts.config.js`

--- a/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/apps/frontend-js/frontend-js-clay-sample-web/package.json
+++ b/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/apps/frontend-js/frontend-js-clay-sample-web/package.json
@@ -1,0 +1,8 @@
+{
+	"dependencies": {
+		"@liferay/frontend-js-react-web": "*",
+		"@liferay/frontend-js-state-web": "*"
+	},
+	"main": "js/App.es",
+	"name": "frontend-js-clay-sample-web"
+}

--- a/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/apps/frontend-js/frontend-js-react-web/package.json
+++ b/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/apps/frontend-js/frontend-js-react-web/package.json
@@ -1,0 +1,7 @@
+{
+	"dependencies": {
+		"@liferay/frontend-js-state-web": "*"
+	},
+	"main": "js/index.js",
+	"name": "@liferay/frontend-js-react-web"
+}

--- a/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/apps/frontend-js/frontend-js-state-web/package.json
+++ b/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/apps/frontend-js/frontend-js-state-web/package.json
@@ -1,0 +1,4 @@
+{
+	"main": "index.js",
+	"name": "@liferay/frontend-js-state-web"
+}

--- a/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/apps/remote-app/remote-app-client-js/package.json
+++ b/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/apps/remote-app/remote-app-client-js/package.json
@@ -1,0 +1,4 @@
+{
+	"main": "js/index.js",
+	"name": "remote-app-client-js"
+}

--- a/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/yarn.lock
+++ b/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/yarn.lock
@@ -1,0 +1,2 @@
+# Not a real yarn.lock, but needed in order for code to identify
+# the top-level "modules/" root.

--- a/projects/npm-tools/packages/npm-scripts/jest.config.js
+++ b/projects/npm-tools/packages/npm-scripts/jest.config.js
@@ -4,6 +4,7 @@
  */
 
 module.exports = {
+	modulePathIgnorePatterns: ['<rootDir>/__fixtures__'],
 	setupFilesAfterEnv: ['<rootDir>/support/jest/matchers.js'],
 	testEnvironment: 'node',
 	testMatch: ['**/test/**/*.js'],

--- a/projects/npm-tools/packages/npm-scripts/src/config/tsconfig-base.json
+++ b/projects/npm-tools/packages/npm-scripts/src/config/tsconfig-base.json
@@ -15,6 +15,7 @@
 		"sourceMap": false,
 		"strict": true,
 		"target": "es6",
+		"tsBuildInfoFile": "tmp/tsconfig.tsbuildinfo",
 		"typeRoots": []
 	},
 	"include": ["src/**/*", "test/**/*"],

--- a/projects/npm-tools/packages/npm-scripts/src/config/tsconfig-base.json
+++ b/projects/npm-tools/packages/npm-scripts/src/config/tsconfig-base.json
@@ -7,6 +7,7 @@
 		"allowSyntheticDefaultImports": true,
 		"baseUrl": ".",
 		"composite": true,
+		"jsx": "react",
 		"module": "es6",
 		"moduleResolution": "node",
 		"outDir": "./types",

--- a/projects/npm-tools/packages/npm-scripts/src/config/tsconfig-base.json
+++ b/projects/npm-tools/packages/npm-scripts/src/config/tsconfig-base.json
@@ -1,0 +1,21 @@
+{
+	"@generated": null,
+	"@overrides": {},
+	"@readonly": "** AUTO-GENERATED: DO NOT EDIT OUTSIDE @overrides **",
+	"@see": "https://git.io/JY2EA",
+	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
+		"baseUrl": ".",
+		"composite": true,
+		"module": "es6",
+		"moduleResolution": "node",
+		"outDir": "./types",
+		"paths": {},
+		"sourceMap": false,
+		"strict": true,
+		"target": "es6",
+		"typeRoots": []
+	},
+	"include": ["src/**/*", "test/**/*"],
+	"references": []
+}

--- a/projects/npm-tools/packages/npm-scripts/src/index.js
+++ b/projects/npm-tools/packages/npm-scripts/src/index.js
@@ -57,6 +57,10 @@ module.exports = async function () {
 			require('./scripts/theme').run(...ARGS_ARRAY.slice(1));
 		},
 
+		types() {
+			require('./scripts/types')();
+		},
+
 		webpack() {
 			require('./scripts/webpack')(...ARGS_ARRAY.slice(1));
 		},

--- a/projects/npm-tools/packages/npm-scripts/src/index.js
+++ b/projects/npm-tools/packages/npm-scripts/src/index.js
@@ -7,6 +7,7 @@ const minimist = require('minimist');
 
 const ProcessExitError = require('./utils/ProcessExitError');
 const instrument = require('./utils/instrument');
+const log = require('./utils/log');
 
 module.exports = async function () {
 	const ARGS_ARRAY = process.argv.slice(2);
@@ -37,17 +38,15 @@ module.exports = async function () {
 			// Storybook is temporarily disabled until it supports webpack 5
 			// require('./scripts/storybook')();
 
-			/* eslint-disable-next-line no-console */
-			console.log(`
-			
-	WARNING:
-
-	Storybook has been temporarily disabled because it does not support 
-	webpack 5.
-
-	See https://bit.ly/35zFX4E for more information.
-
-`);
+			log(
+				'',
+				'WARNING:',
+				'',
+				'Storybook has been temporarily disabled because it does not',
+				'support webpack 5.',
+				'',
+				'See https://bit.ly/35zFX4E for more information.'
+			);
 		},
 
 		test() {

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const path = require('path');
 
 let buildSass = require('../sass/build');
+let runTSC = require('../typescript/runTSC');
 const createTempFile = require('../utils/createTempFile');
 const getMergedConfig = require('../utils/getMergedConfig');
 const instrument = require('../utils/instrument');
@@ -16,7 +17,6 @@ let runBridge = require('../utils/runBridge');
 let runBundler = require('../utils/runBundler');
 const setEnv = require('../utils/setEnv');
 let {buildSoy, cleanSoy, soyExists, translateSoy} = require('../utils/soy');
-const spawnSync = require('../utils/spawnSync');
 const validateConfig = require('../utils/validateConfig');
 let createBridges = require('../webpack/createBridges');
 let webpack = require('./webpack');
@@ -32,6 +32,7 @@ const CWD = process.cwd();
 	runBabel,
 	runBridge,
 	runBundler,
+	runTSC,
 	soyExists,
 	translateSoy,
 	webpack,
@@ -44,6 +45,7 @@ const CWD = process.cwd();
 	runBabel,
 	runBridge,
 	runBundler,
+	runTSC,
 	soyExists,
 	translateSoy,
 	webpack,
@@ -90,8 +92,10 @@ module.exports = async function (...args) {
 	const runLegacyBuild = !federation || federation.mode !== 'default';
 
 	if (inputPathExists && runLegacyBuild) {
-		if (fs.existsSync('tsconfig.json')) {
-			spawnSync('tsc', ['--noEmit']);
+		const isTypeScript = fs.existsSync('tsconfig.json');
+
+		if (isTypeScript) {
+			runTSC();
 		}
 
 		runBabel(

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/lint.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/lint.js
@@ -9,6 +9,7 @@ const path = require('path');
 
 const isJSP = require('../jsp/isJSP');
 const lintJSP = require('../jsp/lintJSP');
+const color = require('../utils/color');
 const getMergedConfig = require('../utils/getMergedConfig');
 const getPaths = require('../utils/getPaths');
 const log = require('../utils/log');
@@ -162,29 +163,6 @@ async function lint(options = {}) {
 		throw new SpawnError();
 	}
 }
-
-function color(name) {
-	if (process.stdout.isTTY) {
-		return (
-			{
-				BOLD: '\x1b[1m',
-				RED: '\x1b[31m',
-				RESET: '\x1b[0m',
-				UNDERLINE: '\x1b[4m',
-				YELLOW: '\x1b[33m',
-			}[name] || ''
-		);
-	}
-	else {
-		return '';
-	}
-}
-
-color.BOLD = color('BOLD');
-color.RED = color('RED');
-color.RESET = color('RESET');
-color.UNDERLINE = color('UNDERLINE');
-color.YELLOW = color('YELLOW');
 
 /**
  * @see https://codepoints.net/U+2716?lang=en

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/types.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/types.js
@@ -32,6 +32,8 @@ function types() {
 
 	const projects = getTypeScriptBuildOrder(graph);
 
+	let upToDateCount = 0;
+
 	for (let i = 0; i < projects.length; i++) {
 		const {directory, name} = projects[i];
 
@@ -40,11 +42,25 @@ function types() {
 		try {
 			process.chdir(directory);
 
-			runTSC();
+			if (runTSC()) {
+				upToDateCount++;
+			}
 		}
 		finally {
 			process.chdir(cwd);
 		}
+	}
+
+	const staleCount = projects.length - upToDateCount;
+
+	if (staleCount) {
+		const description =
+			staleCount === 1 ? '1 project was' : `${staleCount} projects were`;
+
+		throw new Error(
+			`Type generation was successful but ${description} out of date. ` +
+				'Please commit updated versions of the artifacts in the projects listed above.'
+		);
 	}
 }
 

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/types.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/types.js
@@ -1,0 +1,51 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const path = require('path');
+
+const getTypeScriptBuildOrder = require('../typescript/getTypeScriptBuildOrder');
+const getTypeScriptDependencyGraph = require('../typescript/getTypeScriptDependencyGraph');
+const runTSC = require('../typescript/runTSC');
+const findRoot = require('../utils/findRoot');
+const log = require('../utils/log');
+
+function types() {
+	const cwd = process.cwd();
+	const root = findRoot();
+
+	if (root && root !== cwd) {
+		log(
+			'You ran "liferay-npm-scripts types" from:',
+			'',
+			`    ${path.relative(root, process.cwd())}`,
+			'',
+			'But generating types is a global process; will run from:',
+			'',
+			`    ${root}`,
+			''
+		);
+	}
+
+	const graph = getTypeScriptDependencyGraph();
+
+	const projects = getTypeScriptBuildOrder(graph);
+
+	for (let i = 0; i < projects.length; i++) {
+		const {directory, name} = projects[i];
+
+		log(`Generating types (${i + 1} of ${projects.length}): ${name}`);
+
+		try {
+			process.chdir(directory);
+
+			runTSC();
+		}
+		finally {
+			process.chdir(cwd);
+		}
+	}
+}
+
+module.exports = types;

--- a/projects/npm-tools/packages/npm-scripts/src/typescript/README.md
+++ b/projects/npm-tools/packages/npm-scripts/src/typescript/README.md
@@ -1,0 +1,62 @@
+# TypeScript build support in Liferay DXP
+
+If you're reading this page you may have arrived from a link inside a `tsconfig.json` file in [`liferay-portal`](https://github.com/liferay/liferay-portal). The purpose of this document is to describe how those configuration files are managed and how the TypeScript build process works in general.
+
+## High-level overview
+
+We use [TypeScript's](https://www.typescriptlang.org/) [project references feature](https://www.typescriptlang.org/docs/handbook/project-references.html) because it allows us to share type information between projects (corresponding to OSGi modules) without having to perform a global build of all TypeScript in DXP for every change.
+
+Each project writes out a set of `.d.ts` files and a `tsconfig.tsbuildinfo` file in a `types` directory that sits alongside `src` and should be committed to the repo. Any project which wishes to depend on another can use the previously committed type information, thus relying on the other project without needing to build it first. This will enable us to preserve fast "local" development inside each project even as the overall amount of TypeScript across the repo grows.
+
+Note that we use `tsc` (the TypeScript compiler) _only_ for type-checking. The actual work of transforming code from `src/` for deployment is done via Babel (which just strips out the TypeScript type annotations without performing any type-checking of its own) or webpack.
+
+## How configuration works
+
+Each project must have a `tsconfig.json` file at its root, alongside the `package.json`. To start using TypeScript in a project, a `touch tsconfig.json` is sufficient. When running `yarn build` (either directly, or indirectly, via `gradle deploy` or similar), `npm-scripts` will update the configuration file based on three inputs:
+
+1. **[The base config](../config/tsconfig-base.json) that is bundled inside `npm-scripts` and is common across all projects.**
+2. **An optional `@overrides` field that the project can use to overwrite the default settings.** For the most part, this should not be used; please [open an issue](https://github.com/liferay/liferay-frontend-projects/issues/new/choose) if you discover a use case that is not met by the default configuration.
+3. **Information about the TypeScript dependency graph that is derived from the `dependencies` declared in the `package.json` files in `liferay-portal`.** That is, for a project like `@liferay/frontend-js-react-web` to depend on `@liferay/frontend-js-state-web`, it must declare that dependency in the `package.json` file. Note that adding something to `dependencies` makes the dependency visible to our TypeScript build process _but it has nothing to do with how modules are loaded at runtime_; be aware that you may need a `liferay-npm-bundler` `imports` configuration as well ([defaults can be seen here](https://github.com/liferay/liferay-portal/blob/5523f3a3b89cd25deb367a6fdea3d8bcbe420b04/modules/npmscripts.config.js#L31-L194)) in order for one project to load JS from another project at runtime.
+
+Any time the contents of this file are out of date, the `build` subcommand will print a large warning reminding you to include the changes in a commit.
+
+**Note:** The `main` field in the `package.json` must be correctly configured for any module that uses TypeScript. It should indicate the path of the main entry point for the module, relative to the `src/main/resources/META-INF/resources/` directory, and it should end with a `.js` extension, even if the source file is a `.ts` file. This is because the `main` field is used at _runtime_ by our module loading infrastructure, so it should reflect the name that the file will have _after_ it has been transformed from TS into JS.
+
+## How building works
+
+As stated above, our build process uses project references to allow each sub-project to be built in relative isolation. But note that if `A` depends on `B`, and `B` depends on `C`, then a build of `A` can only succeed if `B` has been built first (and the resulting artifacts committed to the repository), and in turn `B` won't succeed unless `C` has been built first.
+
+As such, our tooling will print a reminder to commit updated artifacts any time they change, and our `check` script (described below) will report stale artifacts when run in the context of CI (`ci:test:sf`) if there are any changes that affect a TypeScript module. (Note that we don't have much TypeScript yet, so this check is very fast; as adoption grows, we will monitor performance of both the build and the check.)
+
+If you try to build a project when its dependencies have not previously been built, you will see an error like:
+
+```
+error TS6305: Output file '../some/path/to/something/like/index.d.ts'
+has not been built from source file '../some/path/to/something/like/index.ts'.
+```
+
+If such a situation arises (although it shouldn't, due to the `ci:test:sf` measures already mentioned), you can either build the dependent project by hand (eg. `cd ../path/to/other/project && yarn build`) or you can run the provided `types` subcommand to refresh _all_ of the types in the repo at once, in dependency order (eg. `yarn run liferay-npm-scripts types`).
+
+## How checking works
+
+In order to keep `ci:test:sf` fast, we only check for stale TypeScript artifacts if a PR includes changes that touch a directory containing a `tsconfig.json` file. Under the covers, we detect this situation by observing the `LIFERAY_NPM_SCRIPTS_WORKING_BRANCH_NAME` environment variable, which is only set in CI, and running a `git diff` against the merge base (ie. the point where the PR's branch diverged from the main line, usually `master`).
+
+Note that type-checking is a fundamentally global operation, because a change in any part of the system can in theory affect any other part. Due to the small number of projects we are starting with, we are not making any attempts to optimize this away, but we do have options available to us for parallelizing the checks, as permitted by the dependency graph. So, for now, if any changes are made to a TypeScript project, we check the types for all TypeScript projects and report a failure if any of them are stale.
+
+## Porting existing projects to TypeScript
+
+[This example PR](https://github.com/liferay-frontend/liferay-portal/pull/942) shows how a module (in this case `@liferay/frontend-js-react-web`) can be ported in steps. For example, a single file can be ported to TypeScript without interfering with the build, and then successively other files can be migrated until coverage is complete (although, see "Limitations" below). To port a file, simply change the extension from `.js` to `.ts` and run the build (`yarn run build`) and fix any reported errors.
+
+Note that `yarn run tsc --noEmit --watch` will put the compiler into "watch" mode for a shorter feedback loop. And for an even tighter loop, configure your editor to use tooling based on the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/); this will vary by environment, but can offer many useful features such as inline documentation (tooltips), autocomplete, "jump-to-definition", and so on.
+
+## Limitations
+
+At the time of writing, we still rely quite heavily on the `Liferay` global object that is assembled (defined and later augmented) in several dispersed locations within the repo. We plan to provide some centralized type information for this critical object soon, which should help catch usage mistakes from inside TypeScript files.
+
+## See also
+
+-   [Original PR implementing build support](https://github.com/liferay/liferay-frontend-projects/pull/478).
+
+---
+
+> ☢️ **NOTE:** This document is linked to from the `tsconfig.json` build files via a shortlink ([git.io/JY2EA](https://git.io/JY2EA)), so please do not rename or move it without leaving a forwarding link.

--- a/projects/npm-tools/packages/npm-scripts/src/typescript/configureTypeScript.js
+++ b/projects/npm-tools/packages/npm-scripts/src/typescript/configureTypeScript.js
@@ -1,0 +1,151 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const BASE_CONFIG = require('../config/tsconfig-base.json');
+const deepMerge = require('../utils/deepMerge');
+const findRoot = require('../utils/findRoot');
+
+const GENERATED = '@generated';
+const OVERRIDES = '@overrides';
+const TSCONFIG_JSON = 'tsconfig.json';
+
+/**
+ * Given a dependency graph (from `getTypeScriptDependencyGraph()`),
+ * configures the `tsconfig.json` file in the current working directory
+ * and writes it back to disk if changes are needed. Unlike some other
+ * config files involved in our build process which can be generated on
+ * the fly during the build, this file must be committed to the repo in
+ * order for editors and IDEs to benefit from LSP integration.
+ *
+ * Returns `true` if the `tsconfig.json` file was already up-to-date, and
+ * `false` otherwise.
+ *
+ * Note that up-to-date-ness is determined in a structural equality
+ * sense (ie. are the values in the file the same) without regard
+ * to formatting. This is so that we don't make things worse than
+ * they already are in the conflict between Prettier and the Java
+ * SourceFormatter (which generally disagree about how JSON should be
+ * formatted).
+ */
+function configureTypeScript(graph) {
+	if (!fs.existsSync('tsconfig.json')) {
+		throw new Error(
+			`configureTypeScript(): no tsconfig.json exists in ${process.cwd()}`
+		);
+	}
+
+	const basename = path.basename(process.cwd());
+
+	const project = graph[basename] || graph[`@liferay/${basename}`];
+
+	if (!project) {
+		throw new Error(
+			`configureTypeScript(): project ${basename} not found in dependency graph`
+		);
+	}
+
+	const root = findRoot();
+
+	const contents = fs.readFileSync('tsconfig.json', 'utf8');
+
+	const previousConfig = JSON.parse(contents.trim() ? contents : '{}');
+
+	const paths = {};
+
+	const references = [];
+
+	for (const name of Object.keys(project.dependencies)) {
+		const dependency = graph[name];
+
+		// Note that "main" fields usually end with ".js" so that the loader can
+		// find built files at runtime, but we actually care about source files
+		// (which will have a ".ts" extension instead).
+
+		const main = dependency.main.replace(/\.js$/, '.ts');
+
+		paths[name] = [
+
+			// TODO: don't hard-code "src/main/resources/META-INF/resources"
+			// (we currently also hard-coded in `getJestModuleNameMapper()`)
+
+			path.relative(
+				'',
+				path.join(
+					dependency.directory,
+					'src',
+					'main',
+					'resources',
+					'META-INF',
+					'resources',
+					main
+				)
+			),
+		];
+
+		references.push({path: path.relative('', dependency.directory)});
+	}
+
+	const updatedConfig = deepMerge([
+		{
+			...BASE_CONFIG,
+			compilerOptions: {
+				...BASE_CONFIG.compilerOptions,
+				paths: {
+					...BASE_CONFIG.compilerOptions.paths,
+					...paths,
+				},
+				typeRoots: [
+					root &&
+						path.relative(
+							'',
+							path.join(root, 'node_modules', '@types')
+						),
+					'./node_modules/@types',
+				].filter(Boolean),
+			},
+			references: [...BASE_CONFIG.references, ...references],
+		},
+		previousConfig[OVERRIDES] || {},
+	]);
+
+	updatedConfig[GENERATED] = hash(updatedConfig);
+
+	if (
+		updatedConfig[GENERATED] !== previousConfig[GENERATED] ||
+		updatedConfig[GENERATED] !== hash(previousConfig)
+	) {
+		fs.writeFileSync(TSCONFIG_JSON, format(updatedConfig), 'utf8');
+
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Stringifies config as JSON in a manner pleasing to the Java SourceFormatter.
+ */
+function format(config) {
+	return JSON.stringify(config, null, '\t');
+}
+
+function hash(config) {
+	const shasum = crypto.createHash('sha1');
+
+	shasum.update(
+		JSON.stringify({
+			...config,
+			[GENERATED]: null,
+		})
+	);
+
+	return shasum.digest('hex');
+}
+
+module.exports = configureTypeScript;

--- a/projects/npm-tools/packages/npm-scripts/src/typescript/configureTypeScript.js
+++ b/projects/npm-tools/packages/npm-scripts/src/typescript/configureTypeScript.js
@@ -95,9 +95,12 @@ function configureTypeScript(graph) {
 		});
 	}
 
+	const overrides = previousConfig[OVERRIDES] || {};
+
 	const updatedConfig = deepMerge([
 		{
 			...BASE_CONFIG,
+			[OVERRIDES]: overrides,
 			compilerOptions: {
 				...BASE_CONFIG.compilerOptions,
 				paths: {
@@ -117,7 +120,7 @@ function configureTypeScript(graph) {
 			},
 			references: [...BASE_CONFIG.references, ...references],
 		},
-		previousConfig[OVERRIDES] || {},
+		overrides,
 	]);
 
 	updatedConfig[GENERATED] = hash(updatedConfig);

--- a/projects/npm-tools/packages/npm-scripts/src/typescript/configureTypeScript.js
+++ b/projects/npm-tools/packages/npm-scripts/src/typescript/configureTypeScript.js
@@ -74,21 +74,25 @@ function configureTypeScript(graph) {
 			// TODO: don't hard-code "src/main/resources/META-INF/resources"
 			// (we currently also hard-coded in `getJestModuleNameMapper()`)
 
-			path.relative(
-				'',
-				path.join(
-					dependency.directory,
-					'src',
-					'main',
-					'resources',
-					'META-INF',
-					'resources',
-					main
+			toPosix(
+				path.relative(
+					'',
+					path.join(
+						dependency.directory,
+						'src',
+						'main',
+						'resources',
+						'META-INF',
+						'resources',
+						main
+					)
 				)
 			),
 		];
 
-		references.push({path: path.relative('', dependency.directory)});
+		references.push({
+			path: toPosix(path.relative('', dependency.directory)),
+		});
 	}
 
 	const updatedConfig = deepMerge([
@@ -102,9 +106,11 @@ function configureTypeScript(graph) {
 				},
 				typeRoots: [
 					root &&
-						path.relative(
-							'',
-							path.join(root, 'node_modules', '@types')
+						toPosix(
+							path.relative(
+								'',
+								path.join(root, 'node_modules', '@types')
+							)
 						),
 					'./node_modules/@types',
 				].filter(Boolean),
@@ -146,6 +152,10 @@ function hash(config) {
 	);
 
 	return shasum.digest('hex');
+}
+
+function toPosix(name) {
+	return name.split(path.sep).join(path.posix.sep);
 }
 
 module.exports = configureTypeScript;

--- a/projects/npm-tools/packages/npm-scripts/src/typescript/configureTypeScript.js
+++ b/projects/npm-tools/packages/npm-scripts/src/typescript/configureTypeScript.js
@@ -10,6 +10,7 @@ const path = require('path');
 const BASE_CONFIG = require('../config/tsconfig-base.json');
 const deepMerge = require('../utils/deepMerge');
 const findRoot = require('../utils/findRoot');
+const stringify = require('../utils/stringify');
 
 const GENERATED = '@generated';
 const OVERRIDES = '@overrides';
@@ -129,19 +130,12 @@ function configureTypeScript(graph) {
 		updatedConfig[GENERATED] !== previousConfig[GENERATED] ||
 		updatedConfig[GENERATED] !== hash(previousConfig)
 	) {
-		fs.writeFileSync(TSCONFIG_JSON, format(updatedConfig), 'utf8');
+		fs.writeFileSync(TSCONFIG_JSON, stringify(updatedConfig), 'utf8');
 
 		return false;
 	}
 
 	return true;
-}
-
-/**
- * Stringifies config as JSON in a manner pleasing to the Java SourceFormatter.
- */
-function format(config) {
-	return JSON.stringify(config, null, '\t');
 }
 
 function hash(config) {

--- a/projects/npm-tools/packages/npm-scripts/src/typescript/getTypeScriptBuildOrder.js
+++ b/projects/npm-tools/packages/npm-scripts/src/typescript/getTypeScriptBuildOrder.js
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * Figure out necessary build order via topological sort.
+ */
+function getTypeScriptBuildOrder(graph) {
+	const order = [];
+
+	const done = new Set();
+
+	function visit(item, pending = new Set()) {
+		pending.add(item);
+
+		Object.keys(item.dependencies).forEach((dependency) => {
+			const project = graph[dependency];
+
+			checkCycle(pending, project);
+
+			if (!done.has(project)) {
+				visit(project, pending);
+			}
+		});
+
+		order.push(item);
+		pending.delete(item);
+		done.add(item);
+	}
+
+	const projects = Object.values(graph);
+
+	projects.forEach((project) => {
+		if (!done.has(project)) {
+			visit(project);
+		}
+	});
+
+	return order;
+}
+
+function checkCycle(pending, project) {
+	if (pending.has(project)) {
+		const projects = Array.from(pending).concat([project]);
+
+		projects.splice(0, projects.indexOf(project));
+
+		throw new Error(
+			`getTypeScriptBuildOrder(): dependency cycle detected ${projects
+				.map(({name}) => name)
+				.join(' -> ')}`
+		);
+	}
+}
+
+module.exports = getTypeScriptBuildOrder;

--- a/projects/npm-tools/packages/npm-scripts/src/typescript/getTypeScriptDependencyGraph.js
+++ b/projects/npm-tools/packages/npm-scripts/src/typescript/getTypeScriptDependencyGraph.js
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const getWorkspaces = require('../utils/getWorkspaces');
+
+/**
+ * Across the set of Yarn workspaces, determine the dependency graph of
+ * TypeScript projects.
+ *
+ * Note that in the future, `tsc` itself may be able to do this for us.
+ *
+ * See: https://github.com/microsoft/TypeScript/issues/25376
+ */
+function getTypeScriptDependencyGraph() {
+	const graph = {};
+
+	getWorkspaces()
+		.filter((workspace) => {
+			return fs.existsSync(path.join(workspace, 'tsconfig.json'));
+		})
+		.map((workspace) => {
+			const {dependencies, devDependencies, main, name} = JSON.parse(
+				fs.readFileSync(path.join(workspace, 'package.json'), 'utf8')
+			);
+
+			return {
+				dependencies: {
+					...dependencies,
+					...devDependencies,
+				},
+				directory: workspace,
+				main,
+				name,
+			};
+		})
+		.forEach((project) => {
+			if (graph[project.name]) {
+				throw new Error(
+					`getTypeScriptDependencyGraph(): duplicate project name ${project.name}`
+				);
+			}
+
+			graph[project.name] = project;
+		});
+
+	Object.values(graph).forEach((project) => {
+		Object.keys(project.dependencies).forEach((dependency) => {
+			if (!graph[dependency]) {
+				delete project.dependencies[dependency];
+			}
+		});
+	});
+
+	return graph;
+}
+
+module.exports = getTypeScriptDependencyGraph;

--- a/projects/npm-tools/packages/npm-scripts/src/typescript/runTSC.js
+++ b/projects/npm-tools/packages/npm-scripts/src/typescript/runTSC.js
@@ -10,6 +10,8 @@ const findRoot = require('../utils/findRoot');
 const git = require('../utils/git');
 const log = require('../utils/log');
 const spawnSync = require('../utils/spawnSync');
+const configureTypeScript = require('./configureTypeScript');
+const getTypeScriptDependencyGraph = require('./getTypeScriptDependencyGraph');
 
 /**
  * Runs the TypeScript compiler, `tsc`, in the current working directory.
@@ -23,6 +25,10 @@ const spawnSync = require('../utils/spawnSync');
  * throws an error.
  */
 function runTSC() {
+	const graph = getTypeScriptDependencyGraph();
+
+	configureTypeScript(graph);
+
 	spawnSync('tsc', ['--emitDeclarationOnly']);
 
 	// Check for stale (uncommitted) type artifacts.

--- a/projects/npm-tools/packages/npm-scripts/src/typescript/runTSC.js
+++ b/projects/npm-tools/packages/npm-scripts/src/typescript/runTSC.js
@@ -17,6 +17,10 @@ const spawnSync = require('../utils/spawnSync');
  * Currently in liferay-portal we use either webpack or Babel to do
  * code-generation; `tsc` is only doing type-checking and emitting type
  * definitions.
+ *
+ * Returns `true` on success, `false` if type-checking completed
+ * successfully but the definitions were stale. In all other cases
+ * throws an error.
  */
 function runTSC() {
 	spawnSync('tsc', ['--emitDeclarationOnly']);
@@ -45,7 +49,11 @@ function runTSC() {
 			output,
 			color.RESET
 		);
+
+		return false;
 	}
+
+	return true;
 }
 
 module.exports = runTSC;

--- a/projects/npm-tools/packages/npm-scripts/src/typescript/runTSC.js
+++ b/projects/npm-tools/packages/npm-scripts/src/typescript/runTSC.js
@@ -1,0 +1,51 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const path = require('path');
+
+const color = require('../utils/color');
+const findRoot = require('../utils/findRoot');
+const git = require('../utils/git');
+const log = require('../utils/log');
+const spawnSync = require('../utils/spawnSync');
+
+/**
+ * Runs the TypeScript compiler, `tsc`, in the current working directory.
+ *
+ * Currently in liferay-portal we use either webpack or Babel to do
+ * code-generation; `tsc` is only doing type-checking and emitting type
+ * definitions.
+ */
+function runTSC() {
+	spawnSync('tsc', ['--emitDeclarationOnly']);
+
+	// Check for stale (uncommitted) type artifacts.
+
+	const output = git('status', '--porcelain', '--', 'types');
+
+	if (output.length) {
+		const root = findRoot() || '';
+
+		const location = path.relative(root, path.join(process.cwd(), 'types'));
+
+		log(
+			`${color.YELLOW}${color.BOLD}`,
+			'***************',
+			'*** WARNING ***',
+			'***************',
+			'',
+			'Out-of-date TypeScript build artifacts at:',
+			'',
+			`    ${location}`,
+			'',
+			'Please commit them.',
+			'',
+			output,
+			color.RESET
+		);
+	}
+}
+
+module.exports = runTSC;

--- a/projects/npm-tools/packages/npm-scripts/src/utils/color.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/color.js
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+function color(name) {
+	if (process.stdout.isTTY) {
+		return (
+			{
+				BOLD: '\x1b[1m',
+				RED: '\x1b[31m',
+				RESET: '\x1b[0m',
+				UNDERLINE: '\x1b[4m',
+				YELLOW: '\x1b[33m',
+			}[name] || ''
+		);
+	}
+	else {
+		return '';
+	}
+}
+
+color.BOLD = color('BOLD');
+color.RED = color('RED');
+color.RESET = color('RESET');
+color.UNDERLINE = color('UNDERLINE');
+color.YELLOW = color('YELLOW');
+
+module.exports = color;

--- a/projects/npm-tools/packages/npm-scripts/src/utils/getWorkspaces.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/getWorkspaces.js
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const expandGlobs = require('./expandGlobs');
+const findRoot = require('./findRoot');
+const log = require('./log');
+
+const IGNORE_GLOBS = ['node_modules/**'];
+
+/**
+ * Returns a list of workspaces.
+ *
+ * These are directories containing "package.json" files in locations
+ * that match the top-level "workspaces" globs defined in
+ * "modules/package.json".
+ */
+function getWorkspaces() {
+	const root = findRoot();
+
+	if (root) {
+		const cwd = process.cwd();
+
+		try {
+			process.chdir(root);
+
+			const {workspaces} = JSON.parse(
+				fs.readFileSync('package.json', 'utf8')
+			);
+
+			const projects = expandGlobs(workspaces.packages, IGNORE_GLOBS, {
+				maxDepth: 3,
+				type: 'directory',
+			});
+
+			return projects
+				.filter((project) => {
+					const packageJson = path.join(project, 'package.json');
+
+					return fs.existsSync(packageJson);
+				})
+				.map((project) => {
+					return path.join(root, project);
+				});
+		}
+		catch (error) {
+			log(`getWorkspaces(): error \`${error}\``);
+		}
+		finally {
+			process.chdir(cwd);
+		}
+	}
+
+	return [];
+}
+
+module.exports = getWorkspaces;

--- a/projects/npm-tools/packages/npm-scripts/src/utils/stringify.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/stringify.js
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * Stringifies config as JSON in a manner pleasing to the Java SourceFormatter.
+ */
+function stringify(config, level = 0) {
+	const indent = '\t'.repeat(level);
+
+	if (config === undefined) {
+		return;
+	}
+	else if (Array.isArray(config)) {
+		const items = config.map((item) => {
+			if (item === undefined) {
+				return `${indent}\tnull`;
+			}
+			else {
+				return `${indent}\t` + stringify(item, level + 1).trimStart();
+			}
+		});
+
+		return (
+			`${indent}[\n` +
+			(items.length ? items.join(',\n') + '\n' : '') +
+			`${indent}]`
+		);
+	}
+	else if (config && typeof config === 'object') {
+		const entries = Object.entries(config)
+			.map(([key, value]) => {
+				if (value === undefined) {
+					return;
+				}
+				else {
+					return (
+						`${indent}\t${JSON.stringify(key)}: ` +
+						stringify(value, level + 1).trimStart()
+					);
+				}
+			})
+			.filter(Boolean);
+
+		return (
+			`${indent}{\n` +
+			(entries.length ? entries.join(',\n') + '\n' : '') +
+			`${indent}}`
+		);
+	}
+	else {
+		return `${indent}${JSON.stringify(config)}`;
+	}
+}
+
+module.exports = stringify;

--- a/projects/npm-tools/packages/npm-scripts/test/sass/build.js
+++ b/projects/npm-tools/packages/npm-scripts/test/sass/build.js
@@ -15,6 +15,11 @@ jest.mock('../../src/utils/log');
 const FIXTURES = path.resolve(__dirname, '../../__fixtures__/sass');
 const OUTPUT_SASS_DIR = '.sass-cache';
 
+const pause = (ms) =>
+	new Promise((resolve) => {
+		setTimeout(resolve, ms);
+	});
+
 describe('sass', () => {
 	let tempDir;
 	let tempSassDir;
@@ -99,7 +104,7 @@ describe('sass', () => {
 	`);
 	});
 
-	it('rebuilds sass if any file has been modified', () => {
+	it('rebuilds sass if any file has been modified', async () => {
 		const mainScssFilePath = path.join(tempDir, 'modified.scss');
 
 		expect(fs.existsSync(mainScssFilePath)).toBe(false);
@@ -110,29 +115,33 @@ describe('sass', () => {
 
 		expect(fs.existsSync(mainScssFilePath)).toBe(true);
 
-		const fileCreationTime1 = fs.statSync(mainScssFilePath).ctime.getTime();
+		const fileCreationTime1 = fs.statSync(mainScssFilePath).ctimeMs;
+
+		await pause(100);
 
 		buildSass(path.join(FIXTURES, 'modified'), {
 			outputDir: tempDir,
 		});
 
-		const fileCreationTime2 = fs.statSync(mainScssFilePath).ctime.getTime();
+		const fileCreationTime2 = fs.statSync(mainScssFilePath).ctimeMs;
 
 		expect(fileCreationTime2).toBe(fileCreationTime1);
 
 		fs.unlinkSync(mainScssFilePath);
 
+		await pause(100);
+
 		buildSass(path.join(FIXTURES, 'modified'), {
 			outputDir: tempDir,
 		});
 
-		const fileCreationTime3 = fs.statSync(mainScssFilePath).ctime.getTime();
+		const fileCreationTime3 = fs.statSync(mainScssFilePath).ctimeMs;
 
 		expect(fileCreationTime3).toBeGreaterThan(fileCreationTime1);
 		expect(fileCreationTime3).toBeGreaterThan(fileCreationTime2);
 	});
 
-	it('rebuilds sass if partial has been modified', () => {
+	it('rebuilds sass if partial has been modified', async () => {
 		const mainScssFilePath = path.join(tempDir, 'partial.scss');
 
 		expect(fs.existsSync(mainScssFilePath)).toBe(false);
@@ -143,23 +152,27 @@ describe('sass', () => {
 
 		expect(fs.existsSync(mainScssFilePath)).toBe(true);
 
-		const fileCreationTime1 = fs.statSync(mainScssFilePath).ctime.getTime();
+		const fileCreationTime1 = fs.statSync(mainScssFilePath).ctimeMs;
+
+		await pause(100);
 
 		buildSass(path.join(FIXTURES, 'partial'), {
 			outputDir: tempDir,
 		});
 
-		const fileCreationTime2 = fs.statSync(mainScssFilePath).ctime.getTime();
+		const fileCreationTime2 = fs.statSync(mainScssFilePath).ctimeMs;
 
 		expect(fileCreationTime2).toBe(fileCreationTime1);
 
 		fs.unlinkSync(path.join(tempDir, '_some-partial.scss'));
 
+		await pause(100);
+
 		buildSass(path.join(FIXTURES, 'partial'), {
 			outputDir: tempDir,
 		});
 
-		const fileCreationTime3 = fs.statSync(mainScssFilePath).ctime.getTime();
+		const fileCreationTime3 = fs.statSync(mainScssFilePath).ctimeMs;
 
 		expect(fileCreationTime3).toBeGreaterThan(fileCreationTime1);
 		expect(fileCreationTime3).toBeGreaterThan(fileCreationTime2);

--- a/projects/npm-tools/packages/npm-scripts/test/typescript/configureTypeScript.js
+++ b/projects/npm-tools/packages/npm-scripts/test/typescript/configureTypeScript.js
@@ -1,0 +1,366 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const BASE_CONFIG = require('../../src/config/tsconfig-base.json');
+const configureTypeScript = require('../../src/typescript/configureTypeScript');
+const expandGlobs = require('../../src/utils/expandGlobs');
+
+const FIXTURES = path.join(__dirname, '..', '..', '__fixtures__', 'typescript');
+const MODULES = path.join(FIXTURES, 'modules');
+
+const EXPECT_HASH = expect.stringMatching(/^[0-9a-f]{40}$/);
+
+const MOCK_PROJECT_PATHS = {};
+
+expandGlobs(['**/*-web', '**/*-*-js'], [], {
+	baseDir: MODULES,
+	type: 'directory',
+}).forEach((project) => {
+	MOCK_PROJECT_PATHS[path.basename(project)] = project;
+});
+
+describe('configureTypeScript()', () => {
+	function cd(projectOrPath, callback) {
+		const cwd = process.cwd();
+
+		try {
+			process.chdir(MOCK_PROJECT_PATHS[projectOrPath] || projectOrPath);
+
+			return callback();
+		}
+		finally {
+			process.chdir(cwd);
+		}
+	}
+
+	function configure(project, graph) {
+		return cd(project, () => configureTypeScript(graph));
+	}
+
+	function getDependencyGraph(...mockProjects) {
+		let getTypeScriptDependencyGraph;
+
+		jest.isolateModules(() => {
+			jest.resetModules();
+
+			jest.mock('../../src/utils/getWorkspaces', () => {
+				return () => {
+					return mockProjects.map((name) => MOCK_PROJECT_PATHS[name]);
+				};
+			});
+
+			getTypeScriptDependencyGraph = require('../../src/typescript/getTypeScriptDependencyGraph');
+		});
+
+		return cd(MODULES, () => getTypeScriptDependencyGraph());
+	}
+
+	function readConfig(project) {
+		return fs.readFileSync(
+			path.join(MOCK_PROJECT_PATHS[project], 'tsconfig.json'),
+			'utf8'
+		);
+	}
+
+	function resetConfig(...projects) {
+		projects.forEach((project) => {
+			writeConfig(project, '');
+		});
+	}
+
+	function writeConfig(project, contents) {
+		fs.writeFileSync(
+			path.join(MOCK_PROJECT_PATHS[project], 'tsconfig.json'),
+			contents,
+			'utf8'
+		);
+	}
+
+	describe('when there is no pre-existing tsconfig.json file', () => {
+		it('complains', () => {
+			expect(() => {
+				cd(MODULES, () => configureTypeScript({}));
+			}).toThrow(/no tsconfig.json exists/);
+		});
+	});
+
+	describe('when run from outside of our dependency graph', () => {
+		it('complains', () => {
+			const graph = getDependencyGraph('frontend-js-state-web');
+
+			expect(() => configure('remote-app-client-js', graph)).toThrow(
+				/not found in dependency graph/
+			);
+		});
+	});
+
+	describe('when the existing config is not valid JSON', () => {
+		let graph;
+
+		const project = 'frontend-js-state-web';
+
+		beforeEach(() => {
+			graph = getDependencyGraph(project);
+		});
+
+		it('complains', () => {
+			writeConfig(project, '{"haha you so funny');
+
+			expect(() => configure(project, graph)).toThrow(/JSON/);
+		});
+
+		it('accepts totally blank files', () => {
+			writeConfig(project, '');
+
+			expect(() => configure(project, graph)).not.toThrow();
+
+			writeConfig(project, '\n');
+
+			expect(() => configure(project, graph)).not.toThrow();
+		});
+	});
+
+	describe('with a simple dependency graph with no dependencies', () => {
+		let graph;
+
+		const project = 'frontend-js-state-web';
+
+		beforeEach(() => {
+			graph = getDependencyGraph(project);
+		});
+
+		it('generates basic config given a simple graph with no dependencies', () => {
+			resetConfig(project);
+
+			configure(project, graph);
+
+			const config = JSON.parse(readConfig(project));
+
+			/* eslint-disable sort-keys */
+
+			expect(config).toEqual({
+				...BASE_CONFIG,
+				compilerOptions: {
+					...BASE_CONFIG.compilerOptions,
+					typeRoots: [
+
+						// Dynamically generated:
+
+						'../../../node_modules/@types',
+						'./node_modules/@types',
+					],
+				},
+				'@generated': EXPECT_HASH,
+			});
+
+			/* eslint-enable sort-keys */
+		});
+
+		it('returns true if the config is already up-to-date', () => {
+			resetConfig(project);
+
+			// Returns false when the config isn't set up yet.
+
+			expect(configure(project, graph)).toBe(false);
+
+			// Returns true when it already is up-to-date.
+
+			expect(configure(project, graph)).toBe(true);
+
+			// Note that up-to-date-ness only cares about structural equality,
+			// not whitespace.
+
+			writeConfig(project, `\t\t${readConfig(project)}\n\n`);
+
+			expect(configure(project, graph)).toBe(true);
+
+			// As soon as we mutate a value, returns false again.
+
+			writeConfig(
+				project,
+				JSON.stringify({
+					...JSON.parse(readConfig(project)),
+					references: null,
+				})
+			);
+
+			expect(configure(project, graph)).toBe(false);
+
+			// Breaking the hash also forces an update.
+
+			writeConfig(
+				project,
+				JSON.stringify({
+					...JSON.parse(readConfig(project)),
+
+					// Special prize to anybody who can guess the input string that
+					// led to this hash!
+
+					'@generated': 'e0fee1adf795c84eec4735f039503eb18d9c35cc',
+				})
+			);
+
+			expect(configure(project, graph)).toBe(false);
+		});
+
+		it('merges @overrides into the generated fields', () => {
+			resetConfig();
+
+			configure(project, graph);
+
+			const hash = JSON.parse(readConfig(project))['@generated'];
+
+			// Examples of the kind of overrides we have to do in
+			// remote-app-client-js:
+
+			writeConfig(
+				project,
+				JSON.stringify({
+					'@overrides': {
+						compilerOptions: {
+							outDir: './build/node/packageRunBuild/dist/',
+							target: 'es5',
+							typeRoots: [
+								'./src/main/resources/META-INF/resources/js/types',
+							],
+						},
+					},
+				})
+			);
+
+			configure(project, graph);
+
+			const config = JSON.parse(readConfig(project));
+
+			/* eslint-disable sort-keys */
+
+			expect(config).toEqual({
+				...BASE_CONFIG,
+				compilerOptions: {
+					...BASE_CONFIG.compilerOptions,
+					outDir: './build/node/packageRunBuild/dist/',
+					target: 'es5',
+					typeRoots: [
+
+						// (Still) dynamically generated:
+
+						'../../../node_modules/@types',
+						'./node_modules/@types',
+
+						// Added via overrides:
+
+						'./src/main/resources/META-INF/resources/js/types',
+					],
+				},
+				'@generated': EXPECT_HASH,
+			});
+
+			/* eslint-enable sort-keys */
+
+			// Note that hash reflects the effect of the overrides:
+
+			expect(config['@generated']).not.toEqual(hash);
+		});
+	});
+
+	describe('with a basic dependency graph with a actual dependencies', () => {
+		beforeEach(() => {
+			const projects = [
+				'frontend-js-react-web',
+				'frontend-js-state-web',
+				'frontend-js-clay-sample-web',
+			];
+
+			const graph = getDependencyGraph(...projects);
+
+			projects.forEach((project) => configure(project, graph));
+		});
+
+		it('sets up "references" and "paths" in a project with one dependency', () => {
+			/* eslint-disable sort-keys */
+
+			expect(JSON.parse(readConfig('frontend-js-react-web'))).toEqual({
+				...BASE_CONFIG,
+				compilerOptions: {
+					...BASE_CONFIG.compilerOptions,
+					paths: {
+						'@liferay/frontend-js-state-web': [
+							'../frontend-js-state-web/src/main/resources/META-INF/resources/index.ts',
+						],
+					},
+					typeRoots: [
+						'../../../node_modules/@types',
+						'./node_modules/@types',
+					],
+				},
+				references: [
+					{
+						path: '../frontend-js-state-web',
+					},
+				],
+				'@generated': EXPECT_HASH,
+			});
+
+			/* eslint-enable sort-keys */
+		});
+
+		it('sets up "references" and "paths" in a project with two dependencies', () => {
+			/* eslint-disable sort-keys */
+
+			expect(
+				JSON.parse(readConfig('frontend-js-clay-sample-web'))
+			).toEqual({
+				...BASE_CONFIG,
+				compilerOptions: {
+					...BASE_CONFIG.compilerOptions,
+					paths: {
+						'@liferay/frontend-js-react-web': [
+							'../frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts',
+						],
+						'@liferay/frontend-js-state-web': [
+							'../frontend-js-state-web/src/main/resources/META-INF/resources/index.ts',
+						],
+					},
+					typeRoots: [
+						'../../../node_modules/@types',
+						'./node_modules/@types',
+					],
+				},
+				references: [
+					{
+						path: '../frontend-js-react-web',
+					},
+					{
+						path: '../frontend-js-state-web',
+					},
+				],
+				'@generated': EXPECT_HASH,
+			});
+
+			/* eslint-enable sort-keys */
+		});
+
+		it('sets leaves "references" and "paths" in a project with no dependencies', () => {
+			/* eslint-disable sort-keys */
+
+			expect(JSON.parse(readConfig('frontend-js-state-web'))).toEqual({
+				...BASE_CONFIG,
+				compilerOptions: {
+					...BASE_CONFIG.compilerOptions,
+					typeRoots: [
+						'../../../node_modules/@types',
+						'./node_modules/@types',
+					],
+				},
+				'@generated': EXPECT_HASH,
+			});
+
+			/* eslint-enable sort-keys */
+		});
+	});
+});

--- a/projects/npm-tools/packages/npm-scripts/test/typescript/configureTypeScript.js
+++ b/projects/npm-tools/packages/npm-scripts/test/typescript/configureTypeScript.js
@@ -22,6 +22,7 @@ expandGlobs(['**/*-web', '**/*-*-js'], [], {
 	type: 'directory',
 }).forEach((project) => {
 	MOCK_PROJECT_PATHS[path.basename(project)] = project;
+	fs.writeFileSync(path.join(project, 'tsconfig.json'), '');
 });
 
 describe('configureTypeScript()', () => {

--- a/projects/npm-tools/packages/npm-scripts/test/typescript/configureTypeScript.js
+++ b/projects/npm-tools/packages/npm-scripts/test/typescript/configureTypeScript.js
@@ -210,7 +210,7 @@ describe('configureTypeScript()', () => {
 		});
 
 		it('merges @overrides into the generated fields', () => {
-			resetConfig();
+			resetConfig(project);
 
 			configure(project, graph);
 
@@ -219,18 +219,20 @@ describe('configureTypeScript()', () => {
 			// Examples of the kind of overrides we have to do in
 			// remote-app-client-js:
 
+			const overrides = {
+				compilerOptions: {
+					outDir: './build/node/packageRunBuild/dist/',
+					target: 'es5',
+					typeRoots: [
+						'./src/main/resources/META-INF/resources/js/types',
+					],
+				},
+			};
+
 			writeConfig(
 				project,
 				JSON.stringify({
-					'@overrides': {
-						compilerOptions: {
-							outDir: './build/node/packageRunBuild/dist/',
-							target: 'es5',
-							typeRoots: [
-								'./src/main/resources/META-INF/resources/js/types',
-							],
-						},
-					},
+					'@overrides': overrides,
 				})
 			);
 
@@ -242,6 +244,7 @@ describe('configureTypeScript()', () => {
 
 			expect(config).toEqual({
 				...BASE_CONFIG,
+				'@overrides': overrides,
 				compilerOptions: {
 					...BASE_CONFIG.compilerOptions,
 					outDir: './build/node/packageRunBuild/dist/',
@@ -279,7 +282,11 @@ describe('configureTypeScript()', () => {
 
 			const graph = getDependencyGraph(...projects);
 
-			projects.forEach((project) => configure(project, graph));
+			projects.forEach((project) => {
+				resetConfig(project);
+
+				configure(project, graph);
+			});
 		});
 
 		it('sets up "references" and "paths" in a project with one dependency', () => {

--- a/projects/npm-tools/packages/npm-scripts/test/typescript/getTypeScriptBuildOrder.js
+++ b/projects/npm-tools/packages/npm-scripts/test/typescript/getTypeScriptBuildOrder.js
@@ -1,0 +1,234 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const getTypeScriptBuildOrder = require('../../src/typescript/getTypeScriptBuildOrder');
+
+describe('getTypeScriptBuildOrder()', () => {
+	it('handles an empty graph', () => {
+		expect(getTypeScriptBuildOrder({})).toEqual([]);
+	});
+
+	it('handles a graph with one item', () => {
+		expect(
+			getTypeScriptBuildOrder({
+				'@liferay/remote-app-client-js': {
+					dependencies: {},
+					name: '@liferay/remote-app-client-js',
+				},
+			})
+		).toEqual([
+			{
+				dependencies: {},
+				name: '@liferay/remote-app-client-js',
+			},
+		]);
+	});
+
+	it('handles a graph with two items and no dependency', () => {
+		expect(
+			getTypeScriptBuildOrder({
+				'@liferay/remote-app-client-js': {
+					dependencies: {},
+					name: '@liferay/remote-app-client-js',
+				},
+				'@liferay/some-other-module': {
+					dependencies: {},
+					name: '@liferay/some-other-module',
+				},
+			})
+		).toEqual([
+			{
+				dependencies: {},
+				name: '@liferay/remote-app-client-js',
+			},
+			{
+				dependencies: {},
+				name: '@liferay/some-other-module',
+			},
+		]);
+	});
+
+	it('handles a graph with two items having a dependency relationship', () => {
+		expect(
+			getTypeScriptBuildOrder({
+				'@liferay/frontend-js-react-web': {
+					dependencies: {
+						'@liferay/frontend-js-state-web': '*',
+					},
+					name: '@liferay/frontend-js-react-web',
+				},
+				'@liferay/frontend-js-state-web': {
+					dependencies: {},
+					name: '@liferay/frontend-js-state-web',
+				},
+			})
+		).toEqual([
+			{
+				dependencies: {},
+				name: '@liferay/frontend-js-state-web',
+			},
+			{
+				dependencies: {
+					'@liferay/frontend-js-state-web': '*',
+				},
+				name: '@liferay/frontend-js-react-web',
+			},
+		]);
+
+		// Note that reversing the input order does not change the output order.
+
+		expect(
+			getTypeScriptBuildOrder({
+				/* eslint-disable sort-keys */
+
+				'@liferay/frontend-js-state-web': {
+					dependencies: {},
+					name: '@liferay/frontend-js-state-web',
+				},
+				'@liferay/frontend-js-react-web': {
+					dependencies: {
+						'@liferay/frontend-js-state-web': '*',
+					},
+					name: '@liferay/frontend-js-react-web',
+				},
+
+				/* eslint-enable sort-keys */
+			})
+		).toEqual([
+			{
+				dependencies: {},
+				name: '@liferay/frontend-js-state-web',
+			},
+			{
+				dependencies: {
+					'@liferay/frontend-js-state-web': '*',
+				},
+				name: '@liferay/frontend-js-react-web',
+			},
+		]);
+	});
+
+	it('handles a diamond-shaped dependency graph', () => {
+
+		//         C
+		//        / \        ^
+		//       A   D       | dependencies point upwards
+		//        \ /        |
+		//         B
+
+		/* eslint-disable sort-keys */
+
+		const a = {name: 'a', dependencies: {c: '*'}};
+		const b = {name: 'b', dependencies: {a: '*', d: '*'}};
+		const c = {name: 'c', dependencies: {}};
+		const d = {name: 'd', dependencies: {c: '*'}};
+
+		expect(getTypeScriptBuildOrder({a, b, c, d})).toEqual([c, a, d, b]);
+
+		// Note that input order _mostly_ doesn't affect output order (a
+		// non-exhaustive list of examples).
+
+		expect(getTypeScriptBuildOrder({a, b, d, c})).toEqual([c, a, d, b]);
+		expect(getTypeScriptBuildOrder({a, c, b, d})).toEqual([c, a, d, b]);
+		expect(getTypeScriptBuildOrder({a, c, d, b})).toEqual([c, a, d, b]);
+		expect(getTypeScriptBuildOrder({a, d, b, c})).toEqual([c, a, d, b]);
+		expect(getTypeScriptBuildOrder({a, d, c, b})).toEqual([c, a, d, b]);
+		expect(getTypeScriptBuildOrder({b, a, c, d})).toEqual([c, a, d, b]);
+		expect(getTypeScriptBuildOrder({b, a, d, c})).toEqual([c, a, d, b]);
+		expect(getTypeScriptBuildOrder({b, c, a, d})).toEqual([c, a, d, b]);
+		expect(getTypeScriptBuildOrder({b, c, d, a})).toEqual([c, a, d, b]);
+		expect(getTypeScriptBuildOrder({b, d, a, c})).toEqual([c, a, d, b]);
+		expect(getTypeScriptBuildOrder({b, d, c, a})).toEqual([c, a, d, b]);
+		expect(getTypeScriptBuildOrder({c, a, b, d})).toEqual([c, a, d, b]);
+		expect(getTypeScriptBuildOrder({c, a, d, b})).toEqual([c, a, d, b]);
+		expect(getTypeScriptBuildOrder({c, b, d, a})).toEqual([c, a, d, b]);
+		expect(getTypeScriptBuildOrder({c, b, d, a})).toEqual([c, a, d, b]);
+
+		// But note that we can get different (but still valid) orderings:
+
+		expect(getTypeScriptBuildOrder({c, d, a, b})).toEqual([c, d, a, b]);
+		expect(getTypeScriptBuildOrder({c, d, b, a})).toEqual([c, d, a, b]);
+		expect(getTypeScriptBuildOrder({d, a, b, c})).toEqual([c, d, a, b]);
+		expect(getTypeScriptBuildOrder({d, a, c, b})).toEqual([c, d, a, b]);
+		expect(getTypeScriptBuildOrder({d, b, a, c})).toEqual([c, d, a, b]);
+		expect(getTypeScriptBuildOrder({d, b, c, a})).toEqual([c, d, a, b]);
+		expect(getTypeScriptBuildOrder({d, c, a, b})).toEqual([c, d, a, b]);
+		expect(getTypeScriptBuildOrder({d, c, b, a})).toEqual([c, d, a, b]);
+
+		// And we can get a similar effect by changing the order of
+		// dependencies _inside_ "b"; again, a different (but still
+		// valid) ordering.
+
+		const b2 = {name: 'b2', dependencies: {d: '*', a: '*'}};
+
+		expect(getTypeScriptBuildOrder({b2, a, c, d})).toEqual([c, d, a, b2]);
+
+		/* eslint-enable sort-keys */
+	});
+
+	it('handles a more complex example', () => {
+
+		//            Y
+		//            | \
+		//        Z   X  \   ^
+		//       /|\ /|   \  | dependencies point upwards
+		//      J K L M N |  |
+		//      | | |\|/ /
+		//      A B C D-/
+
+		/* eslint-disable sort-keys */
+
+		const a = {name: 'a', dependencies: {j: '*'}};
+		const b = {name: 'b', dependencies: {k: '*'}};
+		const c = {name: 'c', dependencies: {l: '*'}};
+		const d = {name: 'd', dependencies: {l: '*', m: '*', n: '*', y: '*'}};
+		const j = {name: 'j', dependencies: {z: '*'}};
+		const k = {name: 'k', dependencies: {z: '*'}};
+		const l = {name: 'l', dependencies: {z: '*', x: '*'}};
+		const m = {name: 'm', dependencies: {x: '*'}};
+		const n = {name: 'n', dependencies: {}};
+		const x = {name: 'x', dependencies: {y: '*'}};
+		const y = {name: 'y', dependencies: {}};
+		const z = {name: 'z', dependencies: {}};
+
+		expect(
+			getTypeScriptBuildOrder({a, b, c, d, j, k, l, m, n, x, y, z})
+		).toEqual([z, j, a, k, b, y, x, l, c, m, n, d]);
+
+		/* eslint-enable sort-keys */
+	});
+
+	it('complains if it detects a cycle', () => {
+		/* eslint-disable sort-keys */
+
+		// Self-reference.
+
+		expect(() =>
+			getTypeScriptBuildOrder({a: {name: 'a', dependencies: {a: '*'}}})
+		).toThrow(/dependency cycle detected a -> a/);
+
+		// Immediate cycle.
+
+		expect(() =>
+			getTypeScriptBuildOrder({
+				a: {name: 'a', dependencies: {b: '*'}},
+				b: {name: 'b', dependencies: {a: '*'}},
+			})
+		).toThrow(/dependency cycle detected a -> b -> a/);
+
+		// Indirect cycle.
+
+		expect(() =>
+			getTypeScriptBuildOrder({
+				a: {name: 'a', dependencies: {b: '*'}},
+				b: {name: 'b', dependencies: {c: '*'}},
+				c: {name: 'c', dependencies: {d: '*'}},
+				d: {name: 'd', dependencies: {b: '*'}},
+			})
+		).toThrow(/dependency cycle detected b -> c -> d -> b/);
+
+		/* eslint-enable sort-keys */
+	});
+});

--- a/projects/npm-tools/packages/npm-scripts/test/utils/stringify.js
+++ b/projects/npm-tools/packages/npm-scripts/test/utils/stringify.js
@@ -1,0 +1,198 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const stringify = require('../../src/utils/stringify');
+
+describe('stringify()', () => {
+	it('stringifies null', () => {
+		expect(stringify(null)).toBe('null');
+	});
+
+	it('stringifies true', () => {
+		expect(stringify(true)).toBe('true');
+	});
+
+	it('stringifies false', () => {
+		expect(stringify(false)).toBe('false');
+	});
+
+	it('stringifies a string', () => {
+		expect(stringify('yo "hi"')).toBe('"yo \\"hi\\""');
+	});
+
+	it('stringifies a number', () => {
+		expect(stringify(100)).toBe('100');
+	});
+
+	it('stringifies undefined', () => {
+		expect(stringify(undefined)).toBe(undefined);
+
+		// ie. we match the behavior of JSON.stringify.
+
+		expect(JSON.stringify(undefined)).toBe(undefined);
+	});
+
+	it('stringifies an empty array', () => {
+		expect(stringify([])).toBe('[\n' + ']');
+	});
+
+	it('stringifies a simple array', () => {
+		expect(stringify([1, true, 'foo'])).toBe(
+			'[\n' + '\t1,\n' + '\ttrue,\n' + '\t"foo"\n' + ']'
+		);
+	});
+
+	it('stringifies nested arrays', () => {
+		expect(
+			stringify([1, ['foo', [true, null, 2], ['bar'], [[false]]], 3])
+		).toBe(
+			'[\n' +
+				'\t1,\n' +
+				'\t[\n' +
+				'\t\t"foo",\n' +
+				'\t\t[\n' +
+				'\t\t\ttrue,\n' +
+				'\t\t\tnull,\n' +
+				'\t\t\t2\n' +
+				'\t\t],\n' +
+				'\t\t[\n' +
+				'\t\t\t"bar"\n' +
+				'\t\t],\n' +
+				'\t\t[\n' +
+				'\t\t\t[\n' +
+				'\t\t\t\tfalse\n' +
+				'\t\t\t]\n' +
+				'\t\t]\n' +
+				'\t],\n' +
+				'\t3\n' +
+				']'
+		);
+	});
+
+	it('stringifies an array containing undefined', () => {
+		expect(stringify(['foo', undefined, 10])).toBe(
+			'[\n' + '\t"foo",\n' + '\tnull,\n' + '\t10\n' + ']'
+		);
+
+		// ie. match JSON.stringify behavior
+
+		expect(JSON.stringify(['foo', undefined, 10], null, '\t')).toBe(
+			'[\n' + '\t"foo",\n' + '\tnull,\n' + '\t10\n' + ']'
+		);
+	});
+
+	it('stringifies an empty object', () => {
+		expect(stringify({})).toBe('{\n' + '}');
+	});
+
+	it('stringifies a simple object', () => {
+		expect(stringify({a: true, b: null})).toBe(
+			'{\n' + '\t"a": true,\n' + '\t"b": null\n' + '}'
+		);
+	});
+
+	it('stringifies nested objects', () => {
+		expect(stringify({a: true, b: {c: [1, 'foo', {d: null}]}})).toBe(
+			'{\n' +
+				'\t"a": true,\n' +
+				'\t"b": {\n' +
+				'\t\t"c": [\n' +
+				'\t\t\t1,\n' +
+				'\t\t\t"foo",\n' +
+				'\t\t\t{\n' +
+				'\t\t\t\t"d": null\n' +
+				'\t\t\t}\n' +
+				'\t\t]\n' +
+				'\t}\n' +
+				'}'
+		);
+	});
+
+	it('stringifies an object containing an undefined value', () => {
+		expect(stringify({a: true, b: undefined, c: null})).toBe(
+			'{\n' + '\t"a": true,\n' + '\t"c": null\n' + '}'
+		);
+
+		// ie. match JSON.stringify behavior
+
+		expect(stringify({a: true, b: undefined, c: null}, null, '\t')).toBe(
+			'{\n' + '\t"a": true,\n' + '\t"c": null\n' + '}'
+		);
+	});
+
+	it('stringifies a real-world tsconfig.json configuration', () => {
+		expect(
+			stringify({
+				'@generated': 'abe9898d8a0d3e395d3fbc9373bd36ae6a1c7a90',
+				'@overrides': {
+					compilerOptions: {
+						outDir: './build/node/packageRunBuild/dist/',
+						target: 'es5',
+					},
+				},
+				'@readonly':
+					'** AUTO-GENERATED: DO NOT EDIT OUTSIDE @overrides **',
+				'@see': 'https://git.io/JY2EA',
+				compilerOptions: {
+					allowSyntheticDefaultImports: true,
+					baseUrl: '.',
+					composite: true,
+					jsx: 'react',
+					module: 'es6',
+					moduleResolution: 'node',
+					outDir: './build/node/packageRunBuild/dist/',
+					paths: {},
+					sourceMap: false,
+					strict: true,
+					target: 'es5',
+					tsBuildInfoFile: 'tmp/tsconfig.tsbuildinfo',
+					typeRoots: [
+						'../../../node_modules/@types',
+						'./node_modules/@types',
+					],
+				},
+				include: ['src/**/*', 'test/**/*'],
+				references: [],
+			})
+		).toBe(
+			'{\n' +
+				'\t"@generated": "abe9898d8a0d3e395d3fbc9373bd36ae6a1c7a90",\n' +
+				'\t"@overrides": {\n' +
+				'\t\t"compilerOptions": {\n' +
+				'\t\t\t"outDir": "./build/node/packageRunBuild/dist/",\n' +
+				'\t\t\t"target": "es5"\n' +
+				'\t\t}\n' +
+				'\t},\n' +
+				'\t"@readonly": "** AUTO-GENERATED: DO NOT EDIT OUTSIDE @overrides **",\n' +
+				'\t"@see": "https://git.io/JY2EA",\n' +
+				'\t"compilerOptions": {\n' +
+				'\t\t"allowSyntheticDefaultImports": true,\n' +
+				'\t\t"baseUrl": ".",\n' +
+				'\t\t"composite": true,\n' +
+				'\t\t"jsx": "react",\n' +
+				'\t\t"module": "es6",\n' +
+				'\t\t"moduleResolution": "node",\n' +
+				'\t\t"outDir": "./build/node/packageRunBuild/dist/",\n' +
+				'\t\t"paths": {\n' +
+				'\t\t},\n' +
+				'\t\t"sourceMap": false,\n' +
+				'\t\t"strict": true,\n' +
+				'\t\t"target": "es5",\n' +
+				'\t\t"tsBuildInfoFile": "tmp/tsconfig.tsbuildinfo",\n' +
+				'\t\t"typeRoots": [\n' +
+				'\t\t\t"../../../node_modules/@types",\n' +
+				'\t\t\t"./node_modules/@types"\n' +
+				'\t\t]\n' +
+				'\t},\n' +
+				'\t"include": [\n' +
+				'\t\t"src/**/*",\n' +
+				'\t\t"test/**/*"\n' +
+				'\t],\n' +
+				'\t"references": [\n' +
+				'\t]\n' +
+				'}'
+		);
+	});
+});


### PR DESCRIPTION
~This is still a WIP so parking it here as a draft.~

- [x] Teach `build` subcommand to emit TS type artifacts.
- [x] Add `types` subcommand to do a global build of all TS type artifacts across `liferay-portal`.
- [x] Teach `check` to confirm that TS type artifacts are up-to-date when running `ci:test:sf`.
- [x] Auto-generate `tsconfig.json` files.
- [x] Plug auto-generation into `build` subcommand.
- [x] Plug auto-generation into `check` subcommand.
- [x] Write human-facing docs of how this works.

~So tomorrow I'm going to look at that last one. The pieces I've already added to this PR should make it fairly straightforward: we have a function that returns us info about the dependency graph between TypeScript projects, including their name, their location on disk, what their `main` field points at etc, so we can use that to fill out the required `paths` and `references` section in the `tsconfig.json`.~

~My testing indicates that we can add extra fields to that file without `tsc` complaining, so we'll leverage that to put in some `__generated__` property and an optional `__overrides__` one which can be used in those expected rare cases (like `remote-app-client-js`) where the vanilla config won't work. So far, I think that all the other use cases are going to be just fine with the vanilla set-up. 🤞~