### PR TITLE
feat(npm-scripts): allow format/lint to run without package.json

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/scripts/format.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/format.js
@@ -10,6 +10,7 @@ const isJSP = require('../jsp/isJSP');
 const prettier = require('../prettier');
 const getMergedConfig = require('../utils/getMergedConfig');
 const getPaths = require('../utils/getPaths');
+const inCurrentWorkingDirectory = require('../utils/inCurrentWorkingDirectory');
 const log = require('../utils/log');
 const {SpawnError} = require('../utils/spawnSync');
 
@@ -40,94 +41,97 @@ const IGNORE_FILE = '.prettierignore';
  * Prettier wrapper.
  */
 async function format(options = {}) {
-	const {check} = {
-		...DEFAULT_OPTIONS,
-		...options,
-	};
+	await inCurrentWorkingDirectory(async () => {
+		const {check} = {
+			...DEFAULT_OPTIONS,
+			...options,
+		};
 
-	const globs = check
-		? getMergedConfig('npmscripts', 'check')
-		: getMergedConfig('npmscripts', 'fix');
+		const globs = check
+			? getMergedConfig('npmscripts', 'check')
+			: getMergedConfig('npmscripts', 'fix');
 
-	const paths = getPaths(globs, EXTENSIONS, IGNORE_FILE);
+		const paths = getPaths(globs, EXTENSIONS, IGNORE_FILE);
 
-	if (!paths.length) {
-		return;
-	}
+		if (!paths.length) {
+			return;
+		}
 
-	const config = getMergedConfig('prettier');
+		const config = getMergedConfig('prettier');
 
-	let checked = 0;
-	let bad = 0;
-	let fixed = 0;
+		let checked = 0;
+		let bad = 0;
+		let fixed = 0;
 
-	for (const filepath of paths) {
-		checked++;
+		for (const filepath of paths) {
+			checked++;
 
-		try {
+			try {
 
-			// TODO: don't re-read file, run eslint on it too
+				// TODO: don't re-read file, run eslint on it too
 
-			const source = fs.readFileSync(filepath, 'utf8');
+				const source = fs.readFileSync(filepath, 'utf8');
 
-			const prettierOptions = {
-				...config,
-				filepath,
-			};
-
-			let checkFormat;
-			let format;
-
-			if (isJSP(filepath)) {
-				checkFormat = async (source, prettierOptions) => {
-					return (
-						source === (await formatJSP(source, prettierOptions))
-					);
+				const prettierOptions = {
+					...config,
+					filepath,
 				};
-				format = formatJSP;
-			}
-			else {
-				checkFormat = prettier.check;
-				format = prettier.format;
-			}
 
-			if (!(await checkFormat(source, prettierOptions))) {
-				if (check) {
-					log(`${filepath}: BAD`);
-					bad++;
+				let checkFormat;
+				let format;
+
+				if (isJSP(filepath)) {
+					checkFormat = async (source, prettierOptions) => {
+						return (
+							source ===
+							(await formatJSP(source, prettierOptions))
+						);
+					};
+					format = formatJSP;
 				}
 				else {
-					const formatted = await format(source, prettierOptions);
-					fs.writeFileSync(filepath, formatted);
-					fixed++;
+					checkFormat = prettier.check;
+					format = prettier.format;
+				}
+
+				if (!(await checkFormat(source, prettierOptions))) {
+					if (check) {
+						log(`${filepath}: BAD`);
+						bad++;
+					}
+					else {
+						const formatted = await format(source, prettierOptions);
+						fs.writeFileSync(filepath, formatted);
+						fixed++;
+					}
 				}
 			}
+			catch (error) {
+
+				// Generally this means a syntax error.
+
+				log(`${filepath}: ${error}`);
+				bad++;
+			}
 		}
-		catch (error) {
 
-			// Generally this means a syntax error.
+		const files = (count) => (count === 1 ? 'file' : 'files');
+		const have = (count) => (count === 1 ? 'has' : 'have');
 
-			log(`${filepath}: ${error}`);
-			bad++;
+		const summary = [`Prettier checked ${checked} ${files(checked)}`];
+
+		if (fixed) {
+			summary.push(`fixed ${fixed} ${files(fixed)}`);
 		}
-	}
 
-	const files = (count) => (count === 1 ? 'file' : 'files');
-	const have = (count) => (count === 1 ? 'has' : 'have');
-
-	const summary = [`Prettier checked ${checked} ${files(checked)}`];
-
-	if (fixed) {
-		summary.push(`fixed ${fixed} ${files(fixed)}`);
-	}
-
-	if (bad) {
-		summary.push(`${bad} ${files(bad)} ${have(bad)} problems`);
-		throw new SpawnError(summary.join(', '));
-	}
-	else {
-		log(summary.join(', '));
-	}
+		if (bad) {
+			summary.push(`${bad} ${files(bad)} ${have(bad)} problems`);
+			throw new SpawnError(summary.join(', '));
+		}
+		else {
+			log(summary.join(', '));
+		}
+	});
 }
 
 module.exports = format;

--- a/projects/npm-tools/packages/npm-scripts/src/utils/inCurrentWorkingDirectory.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/inCurrentWorkingDirectory.js
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Runs the `callback()` in the context of the "current" working directory,
+ * which may not be the working directory at the time `liferay-npm-scripts` was
+ * invoked.
+ *
+ * This seems to be an undocumented feature, but `yarn run liferay-npm-scripts`
+ * will walk up the directory tree looking for a `package.json` file and change
+ * to that directory before invoking us, but it will helpfully set the
+ * `INIT_CWD` environment variable so that we can tell where we came from:
+ *
+ *      https://twitter.com/kentcdodds/status/922875214173757440
+ *
+ * This means that you can run a command like `yarn run format` in an OSGi
+ * project that doesn't have a `package.json` (but may still have JS inside JSP
+ * files) and have it execute scoped to that project. This is much quicker than
+ * running `format` from the top, which would examine every eligible file in the
+ * entire repo.
+ */
+async function inCurrentWorkingDirectory(callback) {
+	const cwd = process.cwd();
+
+	const INIT_CWD = process.env.INIT_CWD || cwd;
+
+	let directory = INIT_CWD;
+
+	if (INIT_CWD !== cwd) {
+
+		// Walk up until we find the closest `package.json` or `build.gradle`.
+
+		while (directory) {
+			if (
+				fs.existsSync(path.join(directory, 'package.json')) ||
+				fs.existsSync(path.join(directory, 'build.gradle'))
+			) {
+				break;
+			}
+
+			if (path.dirname(directory) === directory) {
+
+				// Can't go any higher.
+
+				break;
+			}
+
+			directory = path.dirname(directory);
+		}
+	}
+
+	try {
+		process.chdir(directory);
+
+		return await callback();
+	}
+	finally {
+		process.chdir(cwd);
+	}
+}
+
+module.exports = inCurrentWorkingDirectory;

--- a/projects/npm-tools/packages/npm-scripts/test/scripts/format.js
+++ b/projects/npm-tools/packages/npm-scripts/test/scripts/format.js
@@ -16,6 +16,7 @@ jest.mock('../../src/jsp/formatJSP');
 jest.mock('../../src/utils/log');
 
 describe('scripts/format.js', () => {
+	let INIT_CWD;
 	let cwd;
 	let temp;
 
@@ -25,6 +26,8 @@ describe('scripts/format.js', () => {
 	};
 
 	beforeEach(() => {
+		INIT_CWD = process.env.INIT_CWD;
+
 		cwd = process.cwd();
 
 		jest.resetAllMocks();
@@ -33,6 +36,8 @@ describe('scripts/format.js', () => {
 		jest.spyOn(prettier, 'format');
 
 		temp = fs.mkdtempSync(path.join(os.tmpdir(), 'format-'));
+
+		process.env.INIT_CWD = temp;
 
 		process.chdir(temp);
 
@@ -44,6 +49,8 @@ describe('scripts/format.js', () => {
 
 	afterEach(() => {
 		process.chdir(cwd);
+
+		process.env.INIT_CWD = INIT_CWD;
 	});
 
 	it('invokes check() on our prettier.check() wrapper', async () => {


### PR DESCRIPTION
As noted in the doc comment, Yarn (when we do `yarn run liferay-npm-scripts`) will `cd` to the closest project root (ie. directory that has a `package.json` file) before invoking our tool. By that time, it is "too late", to know where we were invoked from. Fortunately, it sets an `INIT_CWD` environment variable with this information.

Whenever we run the `lint()` or `format()` functions (whether in `check` or `fix` modes), we check to see if `INIT_CWD` is defined and different from our apparent "current" working directory. If there is a discrepancy, that means that the user is probably working down inside a `src/` directory (or similar), or they are running in a project that doesn't have a `package.json` (eg. `click-to-chat-web`). Nevertheless, projects like `click-to-chat-web` do have JSP in them even though they don't have a `package.json`, so it is reasonable to want to format them with our frontend formatting tools.

Now, prior to this change, running `yarn run format` in a place like `click-to-chat-web` would result in `yarn` starting from the "top" level (`modules/`) directory and running formatting for the entire repo, which would work but is slow. Running from a subdirectory inside a project with a `package.json` (like `frontend-js-react-web`) wasn't quite as bad, because `yarn` would `cd` up to the project root where the `package.json` lives and run from there; our default globs would take effect (which have the form `/src/**/*.jsp` etc).

After this change, if we detect that `INIT_CWD` is set and different, that means we are "down" somewhere where there is no `package.json`. We walk up the filesystem looking for a `build.gradle` or a `package.json`, whichever we see first, and we run from there. This means that one of three scenarios may apply:

- Inside `click-to-chat-web` you get exactly what you would want and the JSP files get checked/formatted.
- Inside a subdirectory of `frontend-js-react-web` we behave as though we'd run from the project root.
- In a place like `modules/apps/frontend-js`, which does have a `build.gradle`, we stop there and run with the default globs (eg. `/src/**` etc) which effectively means we format nothing (previously we would format _everything_, which is slow).

So what we have is strictly an improvement over what we had, but we should note these "gotchas":

- `gradlew formatSource` will not invoke `liferay-npm-scripts` in modules without `package.json` files. This is something that we could ask Hugo to change if we cared. I suspect we don't want to do that though because it could have unpleasant side-effects (eg. on an older branch not using this version of `@liferay/npm-scripts`, it would fall back to the old behavior of running frontend formatting across the entire repo just because somebody ran `gradlew formatSource`; not good because it is too slow).
- I guess you could run this from "crazy" places which have `build.gradle` files but aren't really what we'd consider to be "projects" (I'm thinking of places under "third-party/" or "util/" or "sdk/" for example). But if you do that with an explicit `yarn run format` you probably are asking for it, and unintended formatting won't happen anyway unless your directory has `src/**` stuff in it. On the off chance that you do mess something up, our Java Source Formatter has a reasonable chance of catching anything egregious during `ci:test:sf`, and our formatting changes are supposed to be relatively benign in any case. Overall, I think it's worth it.

**Test plan:**

1. Copy over these changes to a liferay-portal checkout and add some `console.log()` to see the current working directory, globs, and paths after glob expansion. Run under all the scenarios listed above, plus from the `modules/` root and see that it continues working as before.
2. Run unit tests to make sure we didn't break anything. Note the hacky 😱 setting of `INIT_CWD` necessary to stop our `format()` tests from `cd`-ing out of where we want them to actually run.

Closes: https://github.com/liferay/liferay-frontend-projects/issues/483