### PR TITLE
fix(npm-scripts): deal with symlinks in `inCurrentWorkingDirectory()`

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/utils/inCurrentWorkingDirectory.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/inCurrentWorkingDirectory.js
@@ -25,9 +25,9 @@ const path = require('path');
  * entire repo.
  */
 async function inCurrentWorkingDirectory(callback) {
-	const cwd = process.cwd();
+	const cwd = realpath(process.cwd());
 
-	const INIT_CWD = process.env.INIT_CWD || cwd;
+	const INIT_CWD = realpath(process.env.INIT_CWD || cwd);
 
 	let directory = INIT_CWD;
 
@@ -61,6 +61,29 @@ async function inCurrentWorkingDirectory(callback) {
 	}
 	finally {
 		process.chdir(cwd);
+	}
+}
+
+/**
+ * Normalize a path to account for macOS oddities such as the fact that a
+ * path like:
+ *
+ *      /private/var/folders/yc/1x2y2qld1g95tvtjpd89hdrm0000gp/T/format-1HaaBt
+ *
+ * May be reported as-is by `process.cwd()` but come in like this via the
+ * `INIT_CWD` environment variable:
+ *
+ *      /var/folders/yc/1x2y2qld1g95tvtjpd89hdrm0000gp/T/format-1HaaBt
+ */
+function realpath(directory) {
+	try {
+		return fs.realpathSync(directory);
+	}
+	catch {
+
+		// Most likely "ENOENT: no such file or directory".
+
+		return '';
 	}
 }
 


### PR DESCRIPTION
This is a fix on top of [#484](https://github.com/liferay/liferay-frontend-projects/pull/484).

I wrote that one from the Linux box, and tests were green there (as they were on Linux and Windows in the CI environment), but on running them on macOS today I see failures caused by the fact that macOS uses symlinks in the directory hierarchy used for temporary files. This means that we can "see" a path like:

    /private/var/folders/yc/1x2y2qld1g95tvtjpd89hdrm0000gp/T/format-1HaaBt

from `process.cwd()`, but get a different version of that via the `INIT_CWD` environment variable:

    /var/folders/yc/1x2y2qld1g95tvtjpd89hdrm0000gp/T/format-1HaaBt

But note, they are the same directory. This breaks our equality check in the tests on macOS and has us `cd`-ing up all the way to `/`. Whoops.

So, even though this example comes up in the contexts of the tests and not a runtime in a normal liferay-portal checkout, we should still fix this and make it robust in the face of possible symlinks.

If there is an error (eg. ENOENT), which is unlikely, we'll return an empty string and that in turn means we wind up operating in the current directory, which seems fine.

Test plan: `yarn test` on macOS.