### PR TITLE
feat(npm-scripts): format generated `.d.ts` files

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/index.js
+++ b/projects/npm-tools/packages/npm-scripts/src/index.js
@@ -57,8 +57,8 @@ module.exports = async function () {
 			require('./scripts/theme').run(...ARGS_ARRAY.slice(1));
 		},
 
-		types() {
-			require('./scripts/types')();
+		async types() {
+			await require('./scripts/types')();
 		},
 
 		webpack() {

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
@@ -95,7 +95,7 @@ module.exports = async function (...args) {
 		const isTypeScript = fs.existsSync('tsconfig.json');
 
 		if (isTypeScript) {
-			runTSC();
+			await runTSC();
 		}
 
 		runBabel(

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/check.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/check.js
@@ -9,11 +9,7 @@ const format = require('./format');
 const lint = require('./lint');
 
 async function check() {
-	await spawnMultiple(
-		() => preflight(),
-		() => format({check: true}),
-		() => lint()
-	);
+	await spawnMultiple(preflight, () => format({check: true}), lint);
 }
 
 module.exports = check;

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/check/preflight.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/check/preflight.js
@@ -67,11 +67,11 @@ const DISALLOWED_CONFIG_FILE_NAMES = {
 
 const IGNORE_FILE = '.eslintignore';
 
-function preflight() {
+async function preflight() {
 	const errors = [
 		...checkConfigFileNames(),
 		...checkPackageJSONFiles(),
-		...checkTypeScriptTypeArtifacts(),
+		...(await checkTypeScriptTypeArtifacts()),
 	];
 
 	if (errors.length) {
@@ -156,7 +156,7 @@ function checkPackageJSONFiles() {
  * that could warrant such a check, and only in the context of CI (ie. when
  * LIFERAY_NPM_SCRIPTS_WORKING_BRANCH_NAME is set).
  */
-function checkTypeScriptTypeArtifacts() {
+async function checkTypeScriptTypeArtifacts() {
 	const upstream = process.env.LIFERAY_NPM_SCRIPTS_WORKING_BRANCH_NAME;
 
 	const errors = [];
@@ -180,7 +180,7 @@ function checkTypeScriptTypeArtifacts() {
 					// Changes were detected in the directories we care about.
 
 					try {
-						types();
+						await types();
 					}
 					catch (error) {
 						errors.push(

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/fix.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/fix.js
@@ -9,11 +9,7 @@ const format = require('./format');
 const lint = require('./lint');
 
 async function fix() {
-	await spawnMultiple(
-		() => preflight(),
-		() => lint({fix: true}),
-		() => format()
-	);
+	await spawnMultiple(preflight, () => lint({fix: true}), format);
 }
 
 module.exports = fix;

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/types.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/types.js
@@ -11,7 +11,7 @@ const runTSC = require('../typescript/runTSC');
 const findRoot = require('../utils/findRoot');
 const log = require('../utils/log');
 
-function types() {
+async function types() {
 	const cwd = process.cwd();
 	const root = findRoot();
 
@@ -42,7 +42,7 @@ function types() {
 		try {
 			process.chdir(directory);
 
-			if (runTSC()) {
+			if (await runTSC()) {
 				upToDateCount++;
 			}
 		}

--- a/projects/npm-tools/packages/npm-scripts/src/typescript/configureTypeScript.js
+++ b/projects/npm-tools/packages/npm-scripts/src/typescript/configureTypeScript.js
@@ -24,8 +24,7 @@ const TSCONFIG_JSON = 'tsconfig.json';
  * the fly during the build, this file must be committed to the repo in
  * order for editors and IDEs to benefit from LSP integration.
  *
- * Returns `true` if the `tsconfig.json` file was already up-to-date, and
- * `false` otherwise.
+ * As a convenience, returns the generated configuration object.
  *
  * Note that up-to-date-ness is determined in a structural equality
  * sense (ie. are the values in the file the same) without regard
@@ -131,11 +130,9 @@ function configureTypeScript(graph) {
 		updatedConfig[GENERATED] !== hash(previousConfig)
 	) {
 		fs.writeFileSync(TSCONFIG_JSON, stringify(updatedConfig), 'utf8');
-
-		return false;
 	}
 
-	return true;
+	return updatedConfig;
 }
 
 function hash(config) {

--- a/projects/npm-tools/packages/npm-scripts/src/typescript/runTSC.js
+++ b/projects/npm-tools/packages/npm-scripts/src/typescript/runTSC.js
@@ -3,10 +3,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+const fs = require('fs');
 const path = require('path');
 
+const prettier = require('../prettier');
 const color = require('../utils/color');
+const expandGlobs = require('../utils/expandGlobs');
 const findRoot = require('../utils/findRoot');
+const getMergedConfig = require('../utils/getMergedConfig');
 const git = require('../utils/git');
 const log = require('../utils/log');
 const spawnSync = require('../utils/spawnSync');
@@ -24,12 +28,16 @@ const getTypeScriptDependencyGraph = require('./getTypeScriptDependencyGraph');
  * successfully but the definitions were stale. In all other cases
  * throws an error.
  */
-function runTSC() {
+async function runTSC() {
 	const graph = getTypeScriptDependencyGraph();
 
-	configureTypeScript(graph);
+	const config = configureTypeScript(graph);
 
 	spawnSync('tsc', ['--emitDeclarationOnly']);
+
+	// Format the generated files, because: https://git.io/JYNZp
+
+	await postProcess(config);
 
 	// Check for stale (uncommitted) type artifacts.
 
@@ -60,6 +68,45 @@ function runTSC() {
 	}
 
 	return true;
+}
+
+async function postProcess({compilerOptions: {outDir: baseDir}}) {
+	const paths = expandGlobs(['**/*.d.ts'], [], {baseDir});
+
+	if (!paths.length) {
+		return;
+	}
+
+	const config = getMergedConfig('prettier');
+
+	for (const filepath of paths) {
+		try {
+			const source = fs.readFileSync(filepath, 'utf8');
+
+			const prettierOptions = {
+				...config,
+				filepath,
+			};
+
+			const formatted = await prettier.format(source, prettierOptions);
+
+			// Fix missing trailing space after license header.
+
+			const fixed = formatted.replace(
+				/^\/\*\*\n(?: \*[^\n]*\n)* \*\/\n[^\n]/,
+				(match) => {
+					return match.slice(0, -1) + '\n' + match.slice(-1);
+				}
+			);
+
+			fs.writeFileSync(filepath, fixed);
+		}
+		catch {
+
+			// Shouldn't happen, but could be a syntax error.
+
+		}
+	}
 }
 
 module.exports = runTSC;

--- a/projects/npm-tools/packages/npm-scripts/test/typescript/configureTypeScript.js
+++ b/projects/npm-tools/packages/npm-scripts/test/typescript/configureTypeScript.js
@@ -162,25 +162,37 @@ describe('configureTypeScript()', () => {
 			/* eslint-enable sort-keys */
 		});
 
-		it('returns true if the config is already up-to-date', () => {
+		it('returns the config', () => {
+			const config = {
+				...BASE_CONFIG,
+				'@generated': 'bcba4b119d3cf7bdcb52b5d3d5a71d24f5290ca2',
+				compilerOptions: {
+					...BASE_CONFIG.compilerOptions,
+					typeRoots: [
+						'../../../node_modules/@types',
+						'./node_modules/@types',
+					],
+				},
+			};
+
+			// Returns a valid config object when the config isn't set up yet.
+
 			resetConfig(project);
 
-			// Returns false when the config isn't set up yet.
+			expect(configure(project, graph)).toEqual(config);
 
-			expect(configure(project, graph)).toBe(false);
+			// Returns the same config when it already is up-to-date.
 
-			// Returns true when it already is up-to-date.
-
-			expect(configure(project, graph)).toBe(true);
+			expect(configure(project, graph)).toEqual(config);
 
 			// Note that up-to-date-ness only cares about structural equality,
 			// not whitespace.
 
 			writeConfig(project, `\t\t${readConfig(project)}\n\n`);
 
-			expect(configure(project, graph)).toBe(true);
+			expect(configure(project, graph)).toEqual(config);
 
-			// As soon as we mutate a value, returns false again.
+			// And if we mutate a value, returns the same config again.
 
 			writeConfig(
 				project,
@@ -190,7 +202,7 @@ describe('configureTypeScript()', () => {
 				})
 			);
 
-			expect(configure(project, graph)).toBe(false);
+			expect(configure(project, graph)).toEqual(config);
 
 			// Breaking the hash also forces an update.
 
@@ -206,7 +218,7 @@ describe('configureTypeScript()', () => {
 				})
 			);
 
-			expect(configure(project, graph)).toBe(false);
+			expect(configure(project, graph)).toEqual(config);
 		});
 
 		it('merges @overrides into the generated fields', () => {


### PR DESCRIPTION
As [requested here](https://github.com/brianchandotcom/liferay-portal/pull/100574#issuecomment-814446826).

Note that this still isn't going to be the most beautiful code ever, but here is the change:

- [Before gist](https://gist.github.com/wincent/9a55b26389b9e1e15ec802f7feef0b13)
- [After gist](https://gist.github.com/wincent/3ff31e80550cc00d3df39a03659ed0b0)

Note that `tsc` tends to run things together, avoiding totally empty lines, so the style is quite cramped. We don't have any lints that force stuff to be spaced out (ie. even if I were to run ESLint over the files in addition to Prettier), so this is about as good as it gets. Note that at least the docblock comments have an empty line above them, so that's something. Also note that we hackily insert an extra line after the license header to stop it from looking horrible. But more than that, I don't think is worth doing.

Also note that I had to make a few functions `async` so that I could `await` on the result of `configureTypeScript()`, because I actually need to know the `outDir` in order where to figure out where to look for `.d.ts` files to format. And obviously, I changed the return type of that function from boolean to instead return the config itself.

One final thing to note (it's all about the notes): a `.tsx` file will produce a `.d.ts` file, not a `.d.tsx` file, so that's why we only need the former in our glob patterns.

**Test plan:** Copy this over to a liferay-portal checkout. Run `yarn run liferay-npm-scripts types` and see it apply changes like those I already showed in the Gist links above. See a warning printed about the artifacts not being up-to-date. Commit them. Run it again. See no warning. Rejoice.