### PR TITLE
test(npm-scripts): avoid unhandled promise rejection in tests

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/test/scripts/lint.js
+++ b/projects/npm-tools/packages/npm-scripts/test/scripts/lint.js
@@ -74,8 +74,18 @@ describe('scripts/lint.js', () => {
 	});
 
 	describe('when running from the top-level "modules/"  directory', () => {
+		let INIT_CWD;
+
 		beforeEach(() => {
+			INIT_CWD = process.env.INIT_CWD;
+
+			process.env.INIT_CWD = MODULES;
+
 			process.chdir(MODULES);
+		});
+
+		afterEach(() => {
+			process.env.INIT_CWD = INIT_CWD;
 		});
 
 		it("calls ESLint's `executeOnFiles()` function", async () => {


### PR DESCRIPTION
Today we have a new problem caused by 77db6f875cdb, and this time the fix we applied in 7cabd4f8efa9 doesn't cover it.

Our prior fix dealt with cases where a directory like "/var" might actually be a symlink to "/private/var", meaning that you can't detect the "identity" of a directory using `===` without first resolving symlinks. Probably never happens in actual use, but could (and did) happen in the test suite. So, we added code to resolve symlinks before comparing.

Well, today we have another case of something that only happens in the test suite (which is why I am labeling this with the "test" scope instead of the "fix" scope, even though it is a bug).

In the lint tests, we `cd` down into our `modules` directory under `__fixtures__` folder and try to run lints. Now, `INIT_CWD` will be the `npm-scripts` root folder (or the monorepo root folder, depending on where you run `yarn test` from), and `cwd` will be something under that, with no symlinks in between. But, they are different paths, so, `inCurrentWorkingDirectory()` will do its thing and walk up looking for a `package.json` file. Turns out that it finds it in the `npm-scripts` root folder because there isn't one in our `modules` fixtures.

You might think we could just add a `package.json` file there to make the problem go away, but that won't work because, `inCurrentWorkingDirectory()`, in its infinite wisdom, starts its walk at `INIT_CWD`, not `cwd`, which means it will _still_ wind up running from the `npm-scripts` root.

Now, I thought for about 10 seconds of making `inCurrentWorkingDirectory()` _even_ "smarter", and detecting this case where `cwd` is actually a subdirectory inside the `INIT_CWD` hierarchy, instead of the other way around (which is the usual case), and thought better of it. Let's not make it even more complicated. Instead, just blast right over the `INIT_CWD` that is causing us this headache in the test. This kind of craziness will never come up in "real scenarios", so let's not complicate our runtime code to cater for it.

With this change, the directories match, and we run from the right place, so the mock gets called with the right list of files and we no longer see the unhandled promise rejection:

    (node:1557596) UnhandledPromiseRejectionWarning: Error: expect(jest.fn()).toBeCalledWith(...expected)

    - Expected
    + Received

      Array [
    -   "apps/segments/segments-web/src/index.es.js",
    +   ".eslintrc.js",
    +   ".prettierrc.js",
    ... [etc]

Somewhat annoying that a `toBeCalledWith()` assertion fails in this silent-ish way (without failing the run), but at first glance it seems to be a limitation of this kind of mock in an async test. We are not missing an `await` or anything like that...

**Test plan:** `yarn run test`