### PR TITLE
perf(monorepo): run tests "in band" in CI environment

### DIFF
--- a/support/packages/workspace-scripts/src/index.js
+++ b/support/packages/workspace-scripts/src/index.js
@@ -236,6 +236,10 @@ function test(...args) {
 
 	const root = getRoot();
 
+	if (process.env.CI && !args.includes('--runInBand')) {
+		args.push('--runInBand');
+	}
+
 	if (local !== root) {
 		yarn('--cwd', getRoot(), 'run', 'jest', path.basename(local), ...args);
 	}


### PR DESCRIPTION
Via this astute tip about Jest's `--runInBand` feature:

> useful in resource-constrained environments like CI, where the overhead of worker processes is higher than the speedup of running tests in parallel.

from [this blog post](https://ivantanev.com/make-jest-faster/) and corroborated by [this issue](https://github.com/facebook/jest/issues/8202).

We only do this when `CI` is set to a non-empty value, and in a GitHub action, [it will be](https://docs.github.com/en/actions/reference/environment-variables).

**Test plan:** Will see what happens in CI, but locally, I see:

    > yarn run test
    Time:        38.629 s

    > env CI=true yarn run test
    Time:        76.354 s

Will comment on this PR with results from actual CI run. I'm expecting that Windows in particular might be a shade faster, but we'll see. 🤷 