### PR TITLE
docs(guidelines): fix broken image links

### DIFF
--- a/guidelines/dxp/code_review.md
+++ b/guidelines/dxp/code_review.md
@@ -17,7 +17,7 @@ These are guidelines that the Frontend Infrastructure Team follows when developi
 8.  **Ensure quality by analyzing test results.** At the time of writing, even a pull with a green CI result and "no unique failures" should be carefully inspected before running `ci:forward`, and specifically, "failures in common with upstream" should be examined to make sure that the pull does not introduce _additional_ failure that happens to overlap with existing failure in the upstream. If in doubt, ask QA for help, either in the `#d-quality-assurance` Slack channel, or directly mentioning our QA on GitHub or in the team Slack channel.
 9.  **Allow edits from maintainers.** When you create your pull, please be sure check the "Allow edits and access to secrets by maintainers" box at the bottom of the pull request form. This allows other collaborators on the repo to push to the pull's corresponding branch on your fork, thus updating the pull. This can save wasteful round trips, which can be expensive due to time-zone delays.
 
-    ![Allow edits from maintainers checkbox](/images/github-allow-edits-from-maintainers.png)
+    ![Allow edits from maintainers checkbox](../images/github-allow-edits-from-maintainers.png)
 
     Note that if you create PRs with [the `gh` command-line tool](https://www.npmjs.com/package/gh) you obviously can't see or check a checkbox. In that case, you may wish to add the people who most frequently review your code as [collaborators to your repo](https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/inviting-collaborators-to-a-personal-repository), as well as the team members who tend to be generally involved in code review:
 
@@ -38,7 +38,7 @@ These are guidelines that the Frontend Infrastructure Team follows when developi
     -   `is:pr is:open no:assignee`: Open PRs with no assignee.
 12. **Watch the repo so that you can be notified when new PRs arrive.** Even when you are not an explicit reviewer or assignee of a change, you can learn useful knowledge and information by being aware of what is going on in the repo. See the following section for information about filtering notifications.
 
-    ![GitHub Watch menu](/images/github-watch.png)
+    ![GitHub Watch menu](..//images/github-watch.png)
 
 ## Filtering and notifications
 

--- a/guidelines/dxp/debugging.md
+++ b/guidelines/dxp/debugging.md
@@ -18,7 +18,7 @@ So, this leads us to our overall philosophy:
 
 [The loader](https://github.com/liferay/liferay-amd-loader) in [Liferay DXP](https://github.com/liferay/liferay-amd-loader) is a great example of how useful information can can "grow into a flood", but fortunately, you have full control over how much information it outputs. By default and in normal operation, it won't log anything, but if you ever need to troubleshoot a loading issue you can turn on "Explain Module Resolutions" in the DXP Control Panel, as well as set the log level ("Warn" is a reasonable starting point). To do this, visit the Control Panel &raquo; Configuration &raquo; System Settings &raquo; Infrastructure &raquo; JavaScript Loader:
 
-![JavaScript Loader settings](/images/dxp-javascript-loader-settings.png)
+![JavaScript Loader settings](../images/dxp-javascript-loader-settings.png)
 
 ## Use of `NODE_ENV=development`
 


### PR DESCRIPTION
Just noticed will preparing [another PR](https://github.com/liferay/liferay-frontend-projects/pull/493) that these image links are broken (and would have been broken since these docs got migrated into the monorepo).