### PR TITLE
fix(npm-scripts): don't post-process TypeScript if there is no TS

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/typescript/runTSC.js
+++ b/projects/npm-tools/packages/npm-scripts/src/typescript/runTSC.js
@@ -71,6 +71,10 @@ async function runTSC() {
 }
 
 async function postProcess({compilerOptions: {outDir: baseDir}}) {
+	if (!fs.existsSync(baseDir)) {
+		return;
+	}
+
 	const paths = expandGlobs(['**/*.d.ts'], [], {baseDir});
 
 	if (!paths.length) {


### PR DESCRIPTION
Noticed while preparing [this PR](https://github.com/liferay-frontend/liferay-portal/pull/970) yesterday that if you try to start porting a module to TypeScript by doing this:

```sh
touch tsconfig.json
yarn run build
```

that it will die with:

    ENOENT: no such file or directory, scandir './types'

This happens because you haven't created any `.ts` files yet, and so `tsc` never creates the `types` directory. That in turn means that when we try to post-process everything matching `**/*.d.ts` in `types/` glob expansion is going to complain that there _is_ no `types/` directory.

**Test plan:**

    # Before this commit, in liferay-portal project (eg. wiki-web):

    touch tsconfig.json
    yarn run build # see ENOENT

    # After copying this commit:

    touch tsconfig.json
    yarn run build # see tsconfig.json get filled out; no error