### PR TITLE
style(js-toolkit): fix broken formatting on `master`

### DIFF
--- a/maintenance/projects/js-toolkit/lerna.json
+++ b/maintenance/projects/js-toolkit/lerna.json
@@ -9,9 +9,7 @@
 		}
 	},
 	"npmClient": "yarn",
-	"packages": [
-		"packages/*"
-	],
+	"packages": ["packages/*"],
 	"tagVersionPrefix": "liferay-js-toolkit/v",
 	"useWorkspaces": true,
 	"version": "2.24.3"


### PR DESCRIPTION
Cause: an interrupted publish, as [described here](https://liferay.slack.com/archives/C3JBR21HA/p1618385383026400). Seeing as this is causing other PRs (eg. [this one](https://github.com/liferay/liferay-frontend-projects/pull/496)) to fail CI when they get merged (eg. [this run](https://github.com/liferay/liferay-frontend-projects/runs/2351121348)), just sending this quick fix to stop the noise.