### PR TITLE
docs(monorepo): update top-level README to include Senna links

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,19 @@ This is a collection of utilities to deal with building [liferay-portal](https:/
     -   [jest-junit-reporter](https://www.npmjs.com/package/@liferay/jest-junit-reporter)
     -   [js-insights](https://www.npmjs.com/package/@liferay/js-insights)
 
+## Maintenance
+
+These are projects that are not under active development but which may receive bug fixes.
+
+-   Projects
+    -   [Senna.js](./maintenance/projects/senna): Single Page Application engine.
+-   Issues
+    -   [label: `npm-tools`, `js-insights`](https://github.com/liferay/liferay-frontend-projects/issues?q=is%3Aissue+is%3Aopen+label%3Anpm-tools+label%3Asenna)
+-   Pull requests
+    -   [label: `senna`](https://github.com/liferay/liferay-frontend-projects/pulls?q=is%3Apr+is%3Aopen+label%3Asenna)
+-   npm packages
+    -   [senna](https://www.npmjs.com/package/senna)
+
 ## Third-party
 
 In addition to our own projects listed above, we sometimes have the need to apply small patches on top of third-party code.


### PR DESCRIPTION
This was originally going to be [like this](https://gist.github.com/wincent/801e9f3695a41018c4951a0b4b8f65f0) but due to merge conflicts I dropped the `README.md` changes, leaving only 3e9fae69736a1d00b757d8bc81b7.

Now that the dust has settled, looping back and re-doing it in the new format.

Right now we have a "Projects" section that already includes some links to stuff under `maintenance/`, so this new "Maintenance" section stands out a bit. But I know @izaera wants to keep evolving this, so I'll leave it up to him to think about new ways of categorizing stuff.

As noted in [this Slack thread](https://liferay.slack.com/archives/C3JBR21HA/p1618585240124300?thread_ts=1618573703.116200&cid=C3JBR21HA) we haven't explicitly explained what `maintenance/` is for, apart from in commit messages and pull request descriptions:

> because v2 of the toolkit (maintenance/projects/js-toolkit) is not under active feature development you can contrast that with v3 (projects/js-toolkit) which is where bundler v3 was being developed (and which has an uncertain future at this point, seeing as we switched to focus on webpack federation and then rolled that back... maybe bundler 3 will rise from the ashes some day)
>
> (similar thing with js-themes-toolkit — active development version is under projects/ and legacy versions that we still lightly maintain live under maintenance/projects/)
>
> i can give you more context if you want in the form of links to discussions about this, but when we consolidated (most of our) projects into the monorepo, we decided to focus development on the current version of each on the master branch, and not have separate branches for the older versions, which could have gotten quite messy quite fast.