### PR TITLE
fix(senna): don't try to navigate to `href="#"` links

### DIFF
--- a/maintenance/projects/senna/package.json
+++ b/maintenance/projects/senna/package.json
@@ -66,7 +66,8 @@
 		"format:check": "cd ../../.. && yarn format:check",
 		"lint": "cd ../../.. && yarn lint",
 		"lint:fix": "cd ../../.. && yarn lint:fix",
-		"prepublishOnly": "gulp && npm run compile"
+		"prepublishOnly": "gulp && npm run compile",
+		"test": "gulp test"
 	},
 	"version": "2.7.9",
 	"workspaces": []

--- a/maintenance/projects/senna/src/app/App.js
+++ b/maintenance/projects/senna/src/app/App.js
@@ -346,7 +346,10 @@ class App extends EventEmitter {
 
 		// Prevents navigation if it's a hash change on the same url.
 
-		if (uri.getHash() && utils.isCurrentBrowserPath(path)) {
+		if (
+			(uri.getHash() || url.endsWith('#')) &&
+			utils.isCurrentBrowserPath(path)
+		) {
 			return false;
 		}
 		if (!this.findRoute(path)) {

--- a/maintenance/projects/senna/test/app/App.js
+++ b/maintenance/projects/senna/test/app/App.js
@@ -511,7 +511,7 @@ describe('App', function () {
 			location: {
 				host: 'localhost',
 				hostname: 'localhost',
-				pathname: '/path',
+				pathname: '/base/path',
 				search: '',
 			},
 		};
@@ -523,6 +523,8 @@ describe('App', function () {
 		assert.ok(this.app.canNavigate('http://localhost/base/'));
 		assert.ok(this.app.canNavigate('http://localhost/base'));
 		assert.ok(this.app.canNavigate('http://localhost/base/path'));
+		assert.ok(!this.app.canNavigate('http://localhost/base/path#'));
+		assert.ok(!this.app.canNavigate('http://localhost/base/path#foo'));
 		assert.ok(!this.app.canNavigate('http://localhost/base/path1'));
 		assert.ok(!this.app.canNavigate('http://localhost/path'));
 		assert.ok(!this.app.canNavigate('http://external/path'));


### PR DESCRIPTION
This is a backport of [this fix that was applied to `frontend-js-spa-web`](https://github.com/brianchandotcom/liferay-portal/pull/97087).

Quoting [the original LPS-125077](https://issues.liferay.com/browse/LPS-125077).

> Steps to reproduce
>
> - Create a web content template for the Basic Web Content structure with the following content
>
> ```
> <p><a href="#">click me</a></p>
> <p><input type="text" /></p>
> ```
>
> - Add a web content using the web content template created in step 1
> - Add the web content display portlet to page and configure it to use the web content created in step 2
> - Publish the page
> - Type something into the input field
> - Click on the "click me" link
>
> **Expected behavior:** is that the link brings you to the top of the page, but whatever is typed into the input field remains.
>
> **Actual behavior:** is that the page refreshes and whatever is typed into the input field is lost.

Fix was [originally proposed in Slack](https://liferay.slack.com/archives/CNBG06JS3/p1608248988459900?thread_ts=1608248642.459400&cid=CNBG06JS3) by @bryceosterhaus.

> I believe senna is thinking you can navigate to just `#` since `getHash('#') === ''`
>
> `getHash('#clickme') === 'clickme'` which would cause the `canNavigate` method to return false.

**Test plan:**

1. Add tests.
2. `yarn test`; see them fail.
3. Add fix.
4. `yarn test`; see them pass.

Closes: https://github.com/liferay/liferay-frontend-projects/issues/369

cc: @holatuwol