### PR TITLE
fix(eslint-config): fix group-imports edge case

### DIFF
--- a/projects/eslint-config/plugins/liferay/lib/common/imports.js
+++ b/projects/eslint-config/plugins/liferay/lib/common/imports.js
@@ -19,12 +19,29 @@ function getLeadingComments(node, context) {
 			break;
 		}
 
+		// To be considered preceding, must be the last (closest)
+		// comment, or immediately adjacent to the comments that follow
+		// (no blank lines in between).
+		//
+		//      // I'm not considered a leading comment.
+		//
+		//      // But I am.
+		//
+		//      something();
+
 		const precedes =
+			i === comments.length - 1 ||
 			comment.loc.end.line === successor.loc.start.line - 1 ||
 			comment.loc.end.line === successor.loc.start.line;
 
+		if (!precedes) {
+			break;
+		}
+
 		// In order to be considered "leading", comments must not be "trailing"
-		// anything else.
+		// anything else; eg.
+		//
+		//      something(); // I'm a trailing comment.
 
 		const tokenBefore = context.getTokenBefore(comment, {
 			includeComments: true,
@@ -33,7 +50,7 @@ function getLeadingComments(node, context) {
 		const trailing =
 			tokenBefore && tokenBefore.loc.end.line === comment.loc.start.line;
 
-		if (precedes && !trailing) {
+		if (!trailing) {
 			leadingComments.unshift(comment);
 
 			successor = comment;

--- a/projects/eslint-config/test/integration.js
+++ b/projects/eslint-config/test/integration.js
@@ -14,6 +14,30 @@ const {default: diff} = require('jest-diff');
 describe('@liferay/eslint-config/liferay', () => {
 	const plugin = '@liferay/eslint-config/liferay';
 
+	it('formats comments with lines-around-comment', () => {
+		expect(plugin).toAutofix({
+			code: `
+				function add() {
+					const x = arguments[0];
+					const y = arguments[1];
+
+					// Actually do the math.
+					return x + y;
+				}
+			`,
+			output: `
+				function add() {
+					const x = arguments[0];
+					const y = arguments[1];
+
+					// Actually do the math.
+
+					return x + y;
+				}
+			`,
+		});
+	});
+
 	it('formats imports', () => {
 
 		// This shows how these rules work together to format imports:
@@ -160,18 +184,6 @@ expect.extend({
 		const linter =
 			linters[plugin] ||
 			(function () {
-				let rules;
-
-				if (plugin === '@liferay/eslint-config/liferay') {
-					({rules} = require('../plugins/liferay'));
-				}
-				else if (plugin === '@liferay/eslint-config/portal') {
-					({rules} = require('../plugins/portal'));
-				}
-				else {
-					throw new Error(`Unknown plugin: ${plugin}`);
-				}
-
 				const linter = new Linter();
 
 				linter.defineParser('@typescript-eslint/parser', parser);
@@ -186,10 +198,73 @@ expect.extend({
 					rules: {},
 				};
 
-				Object.entries(rules).forEach(([name, rule]) => {
+				const baseRules = linter.getRules();
+
+				const baseConfig = require('../index');
+
+				// Selectively add some rules from the base set of core ESLint
+				// rules to make the examples more realistic.
+
+				addRule('lines-around-comment');
+
+				function addRule(name) {
+					let rule;
+
+					const configs = [baseConfig];
+
+					const baseName = name.replace(/^@liferay\/\w+\//, '');
+
+					if (name.startsWith('@liferay/liferay/')) {
+						rule = require('../plugins/liferay').rules[baseName];
+					}
+					else if (name.startsWith('@liferay/portal/')) {
+						rule = require('../plugins/portal').rules[baseName];
+
+						configs.unshift(require('../react'));
+					}
+					else {
+						rule = baseRules.get(name);
+					}
+
 					linter.defineRule(name, rule);
-					config.rules[name] = 'error';
-				});
+
+					const found = configs.some(({rules}) => {
+						if (rules[name]) {
+							config.rules[name] = rules[name];
+
+							return true;
+						}
+					});
+
+					if (!found) {
+						config.rules[name] = 'error';
+					}
+				}
+
+				if (plugin === '@liferay/eslint-config/liferay') {
+					[
+						...Object.keys(require('../index').rules),
+						...Object.keys(require('../plugins/liferay').rules).map(
+							(name) => {
+								return `@liferay/liferay/${name}`;
+							}
+						),
+					].forEach(addRule);
+				}
+				else if (plugin === '@liferay/eslint-config/portal') {
+					[
+						...Object.keys(require('../index').rules),
+						...Object.keys(require('../portal').rules),
+						...Object.keys(require('../plugins/portal').rules).map(
+							(name) => {
+								return `@liferay/portal/${name}`;
+							}
+						),
+					].forEach(addRule);
+				}
+				else {
+					throw new Error(`Unknown plugin: ${plugin}`);
+				}
 
 				linters[plugin] = {
 					verifyAndFix(code) {

--- a/projects/eslint-config/test/integration.js
+++ b/projects/eslint-config/test/integration.js
@@ -244,11 +244,6 @@ expect.extend({
 
 				const baseConfig = require('../index');
 
-				// Selectively add some rules from the base set of core ESLint
-				// rules to make the examples more realistic.
-
-				addRule('lines-around-comment');
-
 				function addRule(name) {
 					let rule;
 

--- a/projects/eslint-config/test/integration.js
+++ b/projects/eslint-config/test/integration.js
@@ -95,7 +95,6 @@ describe('@liferay/eslint-config/liferay', () => {
 
 				// Hack to get around frontend-js-web not being in TS
 				// @ts-ignore
-
 				import {ALIGN_POSITIONS as POSITIONS, align, delegate} from 'frontend-js-web';
 				import React, {
 					useEffect,

--- a/projects/eslint-config/test/integration.js
+++ b/projects/eslint-config/test/integration.js
@@ -82,6 +82,48 @@ describe('@liferay/eslint-config/liferay', () => {
 		});
 	});
 
+	it('handles comments in between imports', () => {
+
+		// Regression test for issue reported here:
+		//
+		// https://github.com/liferay-frontend/liferay-portal/pull/992#issuecomment-827803097
+
+		expect(plugin).toAutofix({
+			code: `
+				import ClayTooltip from '@clayui/tooltip';
+				import {render, useTimeout} from '@liferay/frontend-js-react-web';
+
+				// Hack to get around frontend-js-web not being in TS
+				// @ts-ignore
+
+				import {ALIGN_POSITIONS as POSITIONS, align, delegate} from 'frontend-js-web';
+				import React, {
+					useEffect,
+					useLayoutEffect,
+					useReducer,
+					useRef,
+					useState,
+				} from 'react';
+			`,
+			output: `
+				import ClayTooltip from '@clayui/tooltip';
+				import {render, useTimeout} from '@liferay/frontend-js-react-web';
+
+				// Hack to get around frontend-js-web not being in TS
+				// @ts-ignore
+
+				import {ALIGN_POSITIONS as POSITIONS, align, delegate} from 'frontend-js-web';
+				import React, {
+					useEffect,
+					useLayoutEffect,
+					useReducer,
+					useRef,
+					useState,
+				} from 'react';
+			`,
+		});
+	});
+
 	it('formats require statements', () => {
 
 		// This shows how these rules work together to format require


### PR DESCRIPTION
Stops spurious complaints about `imports must be grouped (unexpected blank line before: "frontend-js-web")` given code as seen in the included regression test.

Closes: https://github.com/liferay/liferay-frontend-projects/issues/515