### PR TITLE
fix(js-toolkit): declare Liferay mock before requiring main module when running 'npm run start'

### DIFF
--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-support/src/resources/start/index.js.ejs
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-support/src/resources/start/index.js.ejs
@@ -1,3 +1,16 @@
+window.Liferay = {
+	Language: {
+		get: function(key) {
+			return key;
+		}
+	},
+	ThemeDisplay: {
+		getPathContext: function() {
+			return '';
+		}
+	}
+};
+
 var main = require('<%= mainModule %>');
 
 var params = {
@@ -7,14 +20,6 @@ var params = {
 	configuration: {
 		portletPreferences: {},
 		system: {}
-	}
-};
-
-window.Liferay = {
-	Language: {
-		get: function(key) {
-			return key;
-		}
 	}
 };
 


### PR DESCRIPTION
Recently created an Angular Widget using `yo liferay-js` and tried to run `npm run start` and got the following error:
![image](https://user-images.githubusercontent.com/2421869/116713313-0b5bcf00-a9ab-11eb-94b9-2dc5cb43532f.png)


I moved the declaration of the mocked Liferay object before requiring the main module. I also added the mock for `Liferay.ThemeDisplay.getPathContext` which is used by the Angular components to declare the `templateUrl` property:

```
@Component({
	templateUrl: 
		Liferay.ThemeDisplay.getPathContext() + 
		'/o/angular-sample/app/app.component.html'
})
export class AppComponent {
...
```