### PR TITLE
feat(js-toolkit): implement `npm run start eject`

### DIFF
--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-support/src/config.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-support/src/config.js
@@ -21,6 +21,10 @@ function loadConfig() {
 
 	// Normalize configurations
 
+	normalize(npmbuildrc, 'start', {
+		ejected: false,
+		dir: project.dir.join('.webpack').asPosix,
+	});
 	normalize(npmbuildrc, 'supportedLocales', []);
 	normalize(npmbuildrc, 'webpack.mainModule', 'index.js');
 	normalize(npmbuildrc, 'webpack.rules', []);
@@ -97,6 +101,22 @@ export function getWebpackProxy() {
  */
 export function getSupportedLocales() {
 	return npmbuildrc.supportedLocales;
+}
+
+/**
+ * Get the `npm run start` webpack's directory
+ * @return {string}
+ */
+export function getStartDir() {
+	return npmbuildrc.start.dir;
+}
+
+/**
+ * Check if `npm run start` configuration was ejected
+ * @return {boolean}
+ */
+export function isStartEjected() {
+	return npmbuildrc.start.ejected;
 }
 
 /**


### PR DESCRIPTION
This is a new sub-target that can be run once to detach the webpack configuration associated to
`npm run start` to further tweak it.

The idea behind this feature is that users willing to make `npm run start` more powerful can eject
the configuration so that the JS Toolkit does not regenerate prior to each run of `npm run start`.

This way, people wanting to mock the Liferay object or tweaking webpack configuration don't
need to send a PR and wait for another JS Toolkit release and/or pass through all the review
process.

It will also stop preventing users from doing things that cannot be generalized for everybody and,
thus don't fit in the JS Toolkit at all.

Fixes #235