### PR TITLE
feat: show documentation on what to expect about dependency version numbers

### DIFF
--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/generator-liferay-theme/lib/util.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/generator-liferay-theme/lib/util.js
@@ -156,6 +156,18 @@ function sayHello(generator) {
 
 		https://github.com/liferay/liferay-frontend-projects/tree/master/projects/js-themes-toolkit#compatibility
 
+		`,
+		info`
+		For detailed information regarding which version numbers of:
+
+		  · {unstyled}, {styled}, {classic} and {admin} themes 
+		  · {liferay-frontend-css-common} and {@clayui/css} npm packages
+		  · {Bootstrap} framework
+
+		are used by each release of Liferay DXP and Portal CE see the table at:
+
+		https://github.com/liferay/clay/wiki/Liferay-Portal-@clayui-css-Versions
+
 		`
 	);
 }

--- a/projects/js-themes-toolkit/packages/generator-liferay-theme/lib/util.js
+++ b/projects/js-themes-toolkit/packages/generator-liferay-theme/lib/util.js
@@ -130,6 +130,18 @@ function sayHello(generator) {
 			> npm install -g generator-liferay-theme@^8.0.0 ↩
 			> yo ${generatorNamespace} ↩
 
+		`,
+		info`
+		For detailed information regarding which version numbers of:
+
+		  · {unstyled}, {styled}, {classic} and {admin} themes 
+		  · {liferay-frontend-css-common} and {@clayui/css} npm packages
+		  · {Bootstrap} framework
+
+		are used by each release of Liferay DXP and Portal CE see the table at:
+
+		https://github.com/liferay/clay/wiki/Liferay-Portal-@clayui-css-Versions
+
 		`
 	);
 }


### PR DESCRIPTION
This PR shows a message when the generator is run showing a link to the [themes versions table](https://github.com/liferay/clay/wiki/Liferay-Portal-@clayui-css-Versions) inside Clay.

Something like this:

```sh
my-project $ yo liferay-theme


Welcome to the splendid Themes SDK generator!


ℹ️ This version of the Themes SDK (10.0.2) supports Liferay DXP
and Portal CE from 7.2 to 7.3.

For older versions, please use v8 of the toolkit:

> npm install -g generator-liferay-theme@^8.0.0 ↩
> yo liferay-theme:app ↩


ℹ️ For detailed information on version numbers of unstyled, styled,
classic, admin, frontend-css-common, @clayui/css and Bootstrap
used by each release of Liferay DXP and Portal CE see the table at:

https://github.com/liferay/clay/wiki/Liferay-Portal-@clayui-css-Versions


? What would you like to call your theme? (My Liferay Theme) _
```

---

@pat270 said he would maintain that table up-to-date. We trust him :muscle: .