### PR TITLE
fix(js-toolkit): support scoped packages when building JAR files

### DIFF
--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/scoped/.npmbundlerrc
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/scoped/.npmbundlerrc
@@ -1,0 +1,5 @@
+{
+	"create-jar": {
+		"output-dir": "dist"
+	}
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/scoped/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/scoped/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "@scoped/project",
+	"version": "1.0.0"
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/index.test.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/index.test.js
@@ -158,6 +158,14 @@ describe('project.jar.outputFilename', () => {
 
 		expect(project.jar.outputFilename).toBe('bool-create-jar-1.0.0.jar');
 	});
+
+	it('returns a correct file name for scoped packages', () => {
+		const project = new Project(
+			path.join(__dirname, '__fixtures__', 'project', 'scoped')
+		);
+
+		expect(project.jar.outputFilename).toBe('@scoped_project-1.0.0.jar');
+	});
 });
 
 describe('project.jar.requireJsExtender', () => {

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/jar.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/jar.ts
@@ -125,12 +125,19 @@ export default class Jar {
 		const {npmbundlerrc, pkgJson} = this._project;
 
 		if (this._outputFilename === undefined) {
+			let defaultValue;
+
+			if (this.supported) {
+				defaultValue =
+					pkgJson['name'] + '-' + pkgJson['version'] + '.jar';
+
+				defaultValue = defaultValue.replace(/\//g, '_');
+			}
+
 			this._outputFilename = prop.get(
 				npmbundlerrc,
 				'create-jar.output-filename',
-				this.supported
-					? pkgJson['name'] + '-' + pkgJson['version'] + '.jar'
-					: undefined
+				defaultValue
 			);
 		}
 


### PR DESCRIPTION
Tested locally with a scoped project.

Closes #446