### PR TITLE
feat(js-toolkit): support for autopresets

### DIFF
--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-autopreset/node_modules/autopreset/config.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-autopreset/node_modules/autopreset/config.json
@@ -1,0 +1,3 @@
+{
+	"output": "autopreset-build"
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-autopreset/node_modules/autopreset/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-autopreset/node_modules/autopreset/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "autopreset",
+	"version": "1.0.0",
+	"main": "config.json",
+	"dependencies": {
+		"liferay-npm-bundler": "*"
+	}
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-autopreset/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-autopreset/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "with-autopreset",
+	"version": "1.0.0",
+	"dependencies": {
+		"autopreset": "1.0.0"
+	}
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-ignored-autopreset/.npmbundlerrc
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-ignored-autopreset/.npmbundlerrc
@@ -1,0 +1,3 @@
+{
+	"preset": "preset"
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-ignored-autopreset/node_modules/autopreset/config.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-ignored-autopreset/node_modules/autopreset/config.json
@@ -1,0 +1,3 @@
+{
+	"output": "autopreset-build"
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-ignored-autopreset/node_modules/autopreset/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-ignored-autopreset/node_modules/autopreset/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "autopreset",
+	"version": "1.0.0",
+	"main": "config.json",
+	"dependencies": {
+		"liferay-npm-bundler": "*"
+	}
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-ignored-autopreset/node_modules/preset/config.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-ignored-autopreset/node_modules/preset/config.json
@@ -1,0 +1,3 @@
+{
+	"output": "preset-build"
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-ignored-autopreset/node_modules/preset/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-ignored-autopreset/node_modules/preset/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "preset",
+	"version": "1.0.0",
+	"main": "config.json"
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-ignored-autopreset/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-ignored-autopreset/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "with-ignored-autopreset",
+	"version": "1.0.0",
+	"dependencies": {
+		"autopreset": "1.0.0"
+	}
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-two-autopresets/node_modules/autopreset/config.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-two-autopresets/node_modules/autopreset/config.json
@@ -1,0 +1,3 @@
+{
+	"output": "autopreset-build"
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-two-autopresets/node_modules/autopreset/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-two-autopresets/node_modules/autopreset/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "autopreset",
+	"version": "1.0.0",
+	"main": "config.json",
+	"dependencies": {
+		"liferay-npm-bundler": "*"
+	}
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-two-autopresets/node_modules/autopreset2/config.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-two-autopresets/node_modules/autopreset2/config.json
@@ -1,0 +1,3 @@
+{
+	"output": "autopreset-build"
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-two-autopresets/node_modules/autopreset2/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-two-autopresets/node_modules/autopreset2/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "autopreset2",
+	"version": "1.0.0",
+	"main": "config.json",
+	"dependencies": {
+		"liferay-npm-bundler": "*"
+	}
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-two-autopresets/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/__fixtures__/project/with-two-autopresets/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "with-two-autopresets",
+	"version": "1.0.0",
+	"dependencies": {
+		"autopreset": "1.0.0",
+		"autopreset2": "1.0.0"
+	}
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/index.test.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/index.test.js
@@ -772,6 +772,43 @@ describe('honors presets', () => {
 	});
 });
 
+describe('handles autopresets', () => {
+	it('loads autopresets', () => {
+		const project = new Project(
+			path.join(__dirname, '__fixtures__', 'project', 'with-autopreset')
+		);
+
+		expect(project.buildDir.asPosix).toBe('./autopreset-build');
+	});
+
+	it('fails on multiple autopresets', () => {
+		expect(
+			() =>
+				new Project(
+					path.join(
+						__dirname,
+						'__fixtures__',
+						'project',
+						'with-two-autopresets'
+					)
+				)
+		).toThrowError(/Multiple autopreset.*autopreset.*autopreset2.*/);
+	});
+
+	it('ignores autopresets on explicitly configured preset', () => {
+		const project = new Project(
+			path.join(
+				__dirname,
+				'__fixtures__',
+				'project',
+				'with-ignored-autopreset'
+			)
+		);
+
+		expect(project.buildDir.asPosix).toBe('./preset-build');
+	});
+});
+
 describe('loads plugins as modules (as opposed to packages)', () => {
 	let project;
 

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/index.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/index.ts
@@ -363,11 +363,11 @@ export class Project {
 	}
 
 	_findAutopresets(): string[] {
-		const {dependencies, devDependencies} = this._pkgJson;
+		const {dependencies = {}, devDependencies = {}} = this._pkgJson;
 
 		return Object.keys({
-			...(dependencies || {}),
-			...(devDependencies || {}),
+			...dependencies,
+			...devDependencies,
 		}).reduce((autoPresets, pkgName) => {
 			try {
 				const {dependencies} = this.require(pkgName + '/package.json');

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/index.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/index.ts
@@ -362,6 +362,71 @@ export class Project {
 		}
 	}
 
+	_findAutopresets(): string[] {
+		const {dependencies, devDependencies} = this._pkgJson;
+
+		return Object.keys({
+			...(dependencies || {}),
+			...(devDependencies || {}),
+		}).reduce((autoPresets, pkgName) => {
+			try {
+				const {dependencies} = this.require(pkgName + '/package.json');
+
+				if (dependencies && dependencies['liferay-npm-bundler']) {
+					autoPresets.push(pkgName);
+				}
+			}
+			catch (err) {
+
+				// ignore
+
+			}
+
+			return autoPresets;
+		}, []);
+	}
+
+	_loadDefaultPreset(): string {
+		let presetFilePath;
+
+		const autoPresets = this._findAutopresets();
+
+		if (autoPresets.length > 1) {
+			throw new Error(
+				'Multiple autopreset dependencies found in project (' +
+					autoPresets +
+					'): please remove the invalid ones or ' +
+					'explicitly define the preset to be used in the ' +
+					'.npmbundlerrc file'
+			);
+		}
+		else if (autoPresets.length) {
+			presetFilePath = this.resolve(autoPresets[0]);
+
+			this._toolsDir = new FilePath(
+				path.dirname(this.resolve(autoPresets[0] + '/package.json'))
+			);
+		}
+		else {
+
+			// If no preset was found, use the default one
+
+			presetFilePath = require.resolve(
+				'liferay-npm-bundler-preset-standard'
+			);
+
+			this._toolsDir = new FilePath(
+				path.dirname(
+					require.resolve(
+						'liferay-npm-bundler-preset-standard/package.json'
+					)
+				)
+			);
+		}
+
+		return presetFilePath;
+	}
+
 	_loadNpmbundlerrc(): void {
 		const npmbundlerrcPath = this._configFile.asNative;
 
@@ -374,17 +439,7 @@ export class Project {
 		let presetFilePath;
 
 		if (config.preset === undefined) {
-			presetFilePath = require.resolve(
-				'liferay-npm-bundler-preset-standard'
-			);
-
-			this._toolsDir = new FilePath(
-				path.dirname(
-					require.resolve(
-						'liferay-npm-bundler-preset-standard/package.json'
-					)
-				)
-			);
+			presetFilePath = this._loadDefaultPreset();
 		}
 		else if (config.preset === '' || config.preset === false) {
 
@@ -437,7 +492,7 @@ export class Project {
 	private _configFile: FilePath;
 
 	private _npmbundlerrc: object;
-	private _pkgJson: object;
+	private _pkgJson: {dependencies: object; devDependencies: object};
 	private _pkgManager: PkgManager;
 
 	/** Absolute path to project directory */


### PR DESCRIPTION
This implements https://github.com/liferay/liferay-frontend-projects/issues/542

I've tested it locally using a local npm registry for the preset and yarn-linking the bundler in a local copy of [the PoC project](https://github.com/izaera/fat-jar-sample/tree/886597222590a965ab1b641d91cc1bd41d8f2f44) and it works as expected.

In addition I've provided some unit tests to avoid breaking it in the future.