### PR TITLE
docs(guidelines): add missing info in css-custom-properties

### DIFF
--- a/guidelines/dxp/how_to_use_css_custom_properties.md
+++ b/guidelines/dxp/how_to_use_css_custom_properties.md
@@ -1,132 +1,111 @@
-# How to use CCP (CSS Custom Properties)?
+# How to use CSS Custom Properties in Liferay DXP?
 
-## What are CCP?
+## What are CSS Custom Properties?
 
-The CSS Custom Properties (CCP) are CSS variables that can be used and updated directly in the browser without having to be processed by a compiler like SCSS.
+CSS Custom Properties
 
-## When to use CCP?
+-   Are CSS variables that can be used to define styles dynamically
+-   Can be manipulated directly on the client side (Browser)
+-   Can be used to create easily customizable designs
+-   Can be used to create components that adapt to their context
 
-The power of CCP is that it can be used in instances of the component.
+## Why to use CSS Custom Properties?
 
 Let's say we have a general `.button` component and its default color is `red`.
 
-We can use the same component and change the color by just declaring the variable in the component or its parent.
+We can use the same component and change its color by just declaring the variable in the component's instance.
+
+**Base**
 
 ```html
-<!-- Simple HTML -->
-<div class="component">
-	<button class="button">...</button>
-</div>
-
-<div class="component-2">
-	<button class="button">...</button>
-</div>
-
-<div class="component-3">
-	<button class="button">...</button>
-</div>
+<button class="button">...</button>
 ```
 
 ```scss
-// General CSS
 :root {
-	--primary-color: red;
+	--btn-color: red;
 }
-
 .button {
-	color: var(--primary-color);
+	color: var(--btn-color);
 }
+```
+
+**Instances**
+
+```html
+<div class="card">
+	<button class="button">...</button>
+</div>
+<div class="table">
+	<button class="button">...</button>
+</div>
 ```
 
 ```scss
-// Instanced components
-.component-2 {
-	--primary-color: blue;
+.card {
+	--btn-color: blue;
 }
-
-.component-3 {
-	--primary-color: green;
+.table {
+	--btn-color: green;
 }
 ```
+
+The result will be:
+
+-   a `red` button as default
+-   a `blue` button inside the `card`
+-   a `green` button inside the `table`
 
 [Simple example](https://codepen.io/eduardoallegrini/pen/WNvgWMp)
 
-## How to use CCP?
+## How to use CSS Custom Properties?
 
-From the previous example we can see the main way to manipulate CCP is through CSS itself.
+From the previous example we can see the main method to change CSS Custom Properties is through CSS itself.
 
 This method can be extended to the theme or section following the cascade rule of CSS.
 
-### By CSS
+### Using CSS
 
 ```html
-<!-- Advanced HTML -->
-<body>
-	<section class="section-1">
-		<div class="component-1">
-			<button class="button">...</button>
-		</div>
+<section>
+	...
+	<div class="card">
+		...
+		<button class="button">...</button>
+	</div>
+</section>
 
-		<div class="component-1">
-			<button class="button">...</button>
-		</div>
-
-		<div class="component-1">
-			<button class="button">...</button>
-		</div>
-	</section>
-
-	<section class="section-2">
-		<div class="component-1">
-			<button class="button">...</button>
-		</div>
-
-		<div class="component-1">
-			<button class="button">...</button>
-		</div>
-
-		<div class="component-1">
-			<button class="button">...</button>
-		</div>
-	</section>
-</body>
+<section class="theme-dark">
+	...
+	<div class="card">
+		...
+		<button class="button">...</button>
+	</div>
+</section>
 ```
 
 ```scss
-// General CSS
 :root {
-	--primary-color: red;
+	--btn-color: red;
 }
-
 .button {
-	color: var(--primary-color);
+	color: var(--btn-color);
 }
-
-// Instanced components
-body {
-	--primary-color: blue;
-
-	.section-2 {
-		--primary-color: green;
-	}
-
-	.section-3 {
-		--primary-color: purple;
-
-		.component-3 {
-			--primary-color: orange;
-		}
-	}
+.theme-dark {
+	--btn-color: purple;
 }
 ```
 
+The result will be:
+
+-   a `red` button as default
+-   a `purple` button inside the `dark-theme` section
+
 [Advanced example](https://codepen.io/eduardoallegrini/pen/gOpdyKP)
 
-### By JS
+### Using JS
 
-Another method to use CCP in your application is with JS.
-
-`element.style.getPropertyValue("--variable");` allows us to get the custom-property of the element, if the element doesn't have a defined custom-property, the function will return an empty argument.
+`element.style.getPropertyValue("--variable");` allows us to get the value of the custom-property "--variable" of the element, if the element doesn't have a defined custom-property, the function will return an empty argument.
 
 ```js
 // get variable from inline style
@@ -149,110 +128,105 @@ element.style.setProperty('--my-var', jsVar + 4);
 
 [JS example](https://codepen.io/eduardoallegrini/pen/vYEGYZK)
 
-## How to use CCP in DXP?
+[View the complete documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties)
 
-Once we understand how it works in general, we can easily apply these concepts into a DXP environment.
+## How to use CSS Custom Properties in Liferay DXP?
 
-During the [CCP Epic](https://issues.liferay.com/browse/IFI-848) we created a reduced framework that allows us to use CCP with the most basic components from Clay.
+### StyleBook
 
--   Buttons
--   Alerts
--   Cards
--   Inputs
--   Navs and Navbars
--   Portlets and Portlet-toppers
--   Tables
--   Lists
+During the [CSS Custom Properties Epic](https://issues.liferay.com/browse/IFI-848) we created a small layer that allows the use of CSS Custom Properties with the most customized variables of Clay.
 
-And the essential variables we need to create a theme.
-
--   Colors
+-   Aspect ratios
+-   Blockquotes
+-   Border radius
+-   Buttons colors
+-   Container max widths
+-   Fonts
+-   Portlet colors
+-   Separator
+-   Shadows
 -   Spacers
--   Containers
--   General border-radius
--   General box shadows
--   General font families/sizes/weights
--   Title sizes
+-   Texts colors, sizes and variations
+-   Transitions
 
-### Example 1
+We paired this layer with the new StyleBook feature in order to create an integrated Client side style customizer, you can find it in Liferay DXP.
 
-Let's start with a simple example.
+Keep in mind that **these styles might be subject to changes so we don't recommend to using them in production**.
 
-Imagine, we need to create a page with the page builder system. We know for sure that the brand color is purple, let's say `#414289`. We need to set this color as primary for this particular page.
+### Custom Theme
 
-So these are the steps to follow:
+By default you can use the defined CSS Custom Properties in the frontend-theme-classic but, importing the right files, you can also use them in a custom theme.
 
-1. Import the CCP module in your theme.
+1. Copy the [custom_properties folder](https://github.com/liferay/liferay-portal/tree/master/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties) into your theme
 
-```scss
-// Page CSS
-@import 'custom_properties';
-```
-
-2. Find the `class` or `id` dedicated to the page.
-
-```html
-<!-- Page HTML -->
-<body class="dxp">
-	<div class="page-builder-page" id="page-builder-1234">
-		<section class="section-1">...</section>
-		...
-		<section class="section-n">...</section>
-	</div>
-</body>
-```
-
-3. Set the primary color.
+2. Import the CSS Custom Properties module into your main.scss file.
 
 ```scss
-// Page CSS
-#page-builder-1234 {
-	--primary: #414289;
+@import 'custom_properties/custom_properties_variables';
+@import 'custom_properties/custom_properties_set';
+```
+
+3. Modify the CSS Custom Properties in your theme (we recommend to use a namespace to avoid the bleeding of the styles outside your theme)
+
+```scss
+.my-custom-theme-namespace {
+	--body-bg: black;
+	--body-color: white;
 }
 ```
 
-That's it, pretty simple, huh? :)
-
-### Example 2
-
-Now, in the same page of the previous example, we need to create a section with pricing cards and one of them is recommended and it needs a different style.
-
-1. Import the CCP module in your theme.
-
-```scss
-// Page CSS
-@import 'custom_properties';
-```
-
-2. Find the class or id dedicated to the recommended pricing card.
-
 ```html
-<!-- Page HTML -->
-<body class="dxp">
-	<div class="page-builder-page">
-		<section class="section">
-			<div class="card">...</div>
-			<div class="card card-recommended" id>...</div>
-			<div class="card">...</div>
-		</section>
-	</div>
+<body class="my-custom-theme-namespace">
+	...
 </body>
 ```
 
-3. Set the style variation you need for that card.
-
-```scss
-// Page CSS
-.card-recommended {
-	--card-bg: #414289;
-	--card-border-radius: 30px;
-	--card-color: #ffffff;
-	--card-spacer-x: 15px;
-	--card-spacer-y: 15px;
-}
-```
+This will be the same as customizing these variables using the StyleBook but the customizations will be integrated into the custom theme.
 
 All the customizable properties are defined in [the variables file](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-theme/frontend-theme-classic/src/css/custom_properties/_custom_properties_variables.scss).
+
+### Customization Improvement
+
+As we've seen before, the real customization improvement comes with the component's instances.
+
+```html
+<body>
+	<header>
+		<h1>Liferay</h1>
+		...
+	</header>
+	<main>
+		<h1>Products</h1>
+		...
+	</main>
+	<footer>
+		<h1>Contacts</h1>
+		...
+	</footer>
+</body>
+```
+
+```scss
+header {
+	--h1-font-size: 2rem;
+}
+main {
+	--h1-font-size: 1.5rem;
+}
+footer {
+	--h1-font-size: 1rem;
+}
+```
+
+By changing a single variable in 3 different contexts we will create a component with a dynamic style.
+
+## When to use CSS Custom Properties?
+
+CSS Custom Properties are not supported by Internet Explorer (IE) and early versions of all the popular browsers ([view Compatibility Sheet](https://caniuse.com/css-variables)), so our recommendation is to use them in modern projects that don't need a certain level of browser accessibility.
+
+For the same reason we also recommend to be careful using CSS Custom Properties in DXP versions lower than 7.4.
+
+There are several Polyfills that can cover the lack of compatibility with IE11 but none of them provide the same experience of the native supported browsers.
 
 ---
 


### PR DESCRIPTION
In this PR:
- Added the warning "not supported in IE11"
- Added the warning "don't use it in production"
- Added "how to use it in custom theme"
- Added StyleBook references
- Updated supported components variables list
- Simplified examples