### PR TITLE
fix(js-toolkit): support spread operator when bundling modules

### DIFF
--- a/maintenance/projects/js-toolkit/packages/babel-preset-liferay-standard/package.json
+++ b/maintenance/projects/js-toolkit/packages/babel-preset-liferay-standard/package.json
@@ -9,6 +9,7 @@
 		"babel-plugin-namespace-modules": "2.24.3",
 		"babel-plugin-normalize-requires": "2.24.3",
 		"babel-plugin-transform-node-env-inline": "0.4.3",
+		"babel-plugin-transform-object-rest-spread": "6.26.0",
 		"babel-plugin-wrap-modules-amd": "2.24.3"
 	},
 	"description": "Babel preset for bundling standard Liferay projects.",

--- a/maintenance/projects/js-toolkit/packages/babel-preset-liferay-standard/src/index.js
+++ b/maintenance/projects/js-toolkit/packages/babel-preset-liferay-standard/src/index.js
@@ -11,6 +11,7 @@ import babelPluginNamespaceAmdDefine from 'babel-plugin-namespace-amd-define';
 import babelPluginNamespaceModules from 'babel-plugin-namespace-modules';
 import babelPluginNormalizeRequires from 'babel-plugin-normalize-requires';
 import babelPluginTransformNodeEnvInline from 'babel-plugin-transform-node-env-inline';
+import babelPluginTransformObjetRestSpread from 'babel-plugin-transform-object-rest-spread';
 import babelPluginWrapModulesAmd from 'babel-plugin-wrap-modules-amd';
 
 /**
@@ -31,6 +32,7 @@ export default function () {
 					keepFnName: true,
 				},
 			],
+			babelPluginTransformObjetRestSpread,
 			babelPluginWrapModulesAmd,
 			babelPluginNameAmdModules,
 			babelPluginNamespaceModules,

--- a/maintenance/projects/js-toolkit/yarn.lock
+++ b/maintenance/projects/js-toolkit/yarn.lock
@@ -2194,6 +2194,11 @@ babel-plugin-normalize-requires@2.13.2:
   dependencies:
     liferay-npm-build-tools-common "2.13.2"
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+  integrity sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=
+
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
@@ -2393,6 +2398,14 @@ babel-plugin-transform-node-env-inline@0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-node-env-inline/-/babel-plugin-transform-node-env-inline-0.4.3.tgz#8c84cd74d58f17b0fdf76144a3589f610c3c2497"
   integrity sha1-jITNdNWPF7D992FEo1ifYQw8JJc=
+
+babel-plugin-transform-object-rest-spread@6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  integrity sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-regenerator@^6.24.1:
   version "6.26.0"


### PR DESCRIPTION
Fixes #565

Tested locally with the same project I used to reproduce it (an empty shared bundle with just `recoil` dependency)