### PR TITLE
feat(@liferay/eslint-config): add rule to prevent developers from using createPortal directly from react-dom.

### DIFF
--- a/projects/eslint-config/plugins/portal/index.js
+++ b/projects/eslint-config/plugins/portal/index.js
@@ -10,6 +10,7 @@ module.exports = {
 		'no-global-fetch': require('./lib/rules/no-global-fetch'),
 		'no-loader-import-specifier': require('./lib/rules/no-loader-import-specifier'),
 		'no-metal-plugins': require('./lib/rules/no-metal-plugins'),
+		'no-react-dom-create-portal': require('./lib/rules/no-react-dom-create-portal'),
 		'no-react-dom-render': require('./lib/rules/no-react-dom-render'),
 		'no-side-navigation': require('./lib/rules/no-side-navigation'),
 	},

--- a/projects/eslint-config/plugins/portal/lib/rules/no-react-dom-create-portal.js
+++ b/projects/eslint-config/plugins/portal/lib/rules/no-react-dom-create-portal.js
@@ -4,9 +4,9 @@
  */
 
 const DESCRIPTION =
-	'Direct use of ReactDOM.render is discouraged; instead, use ' +
-	'the <react:component /> JSP taglib, or do: ' +
-	`import {render} from 'frontend-js-react-web';`;
+	'Direct use of ReactDOM.createPortal is discouraged; instead, use ' +
+	'the <ReactPortal /> component: ' +
+	`import {ReactPortal} from 'frontend-js-react-web';`;
 
 module.exports = {
 	create(context) {
@@ -47,7 +47,7 @@ module.exports = {
 
 		const report = (node) =>
 			context.report({
-				messageId: 'noReactDOMRender',
+				messageId: 'noReactDOMCreatePortal',
 				node,
 			});
 
@@ -73,10 +73,10 @@ module.exports = {
 						if (
 							node.callee.object.name === namespace.name &&
 							node.callee.property.type === 'Identifier' &&
-							node.callee.property.name === 'render'
+							node.callee.property.name === 'createPortal'
 						) {
 
-							// eg. Foo.render()
+							// eg. Foo.createPortal()
 
 							if (isSame(node.callee.object, namespace)) {
 
@@ -144,7 +144,7 @@ module.exports = {
 									variable.defs[0].node &&
 									variable.defs[0].node.imported &&
 									variable.defs[0].node.imported.name ===
-										'render'
+										'createPortal'
 								);
 							})
 					);
@@ -171,8 +171,8 @@ module.exports = {
 					}
 					else if (node.id.type === 'ObjectPattern') {
 
-						// eg. const {render} = require('react-dom');
-						// eg. const {render: x} = require('react-dom');
+						// eg. const {createPortal} = require('react-dom');
+						// eg. const {createPortal: x} = require('react-dom');
 
 						add(
 							foundBindings,
@@ -187,7 +187,7 @@ module.exports = {
 										variable.references[0].identifier.parent
 											.key &&
 										variable.references[0].identifier.parent
-											.key.name === 'render'
+											.key.name === 'createPortal'
 									);
 								})
 						);
@@ -206,7 +206,7 @@ module.exports = {
 		},
 		fixable: null,
 		messages: {
-			noReactDOMRender: DESCRIPTION,
+			noReactDOMCreatePortal: DESCRIPTION,
 		},
 		schema: [],
 		type: 'problem',

--- a/projects/eslint-config/plugins/portal/tests/lib/rules/no-react-dom-create-portal.js
+++ b/projects/eslint-config/plugins/portal/tests/lib/rules/no-react-dom-create-portal.js
@@ -1,0 +1,184 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const MultiTester = require('../../../../../scripts/MultiTester');
+const rule = require('../../../lib/rules/no-react-dom-create-portal');
+
+const parserOptions = {
+	ecmaFeatures: {
+		jsx: true,
+	},
+	ecmaVersion: 6,
+	sourceType: 'module',
+};
+
+const ruleTester = new MultiTester({parserOptions});
+
+const errors = [
+	{
+		messageId: 'noReactDOMCreatePortal',
+		type: 'CallExpression',
+	},
+];
+
+ruleTester.run('no-react-dom-render', rule, {
+	invalid: [
+		{
+			code: `
+				 import ReactDOM from 'react-dom';
+ 
+				 ReactDOM.createPortal(element, container);
+			 `,
+			errors,
+		},
+		{
+			code: `
+				 import SneakyDOM from 'react-dom';
+ 
+				 SneakyDOM.createPortal(element, container);
+			 `,
+			errors,
+		},
+		{
+			code: `
+				 import * as ReactDOM from 'react-dom';
+ 
+				 ReactDOM.createPortal(element, container);
+			 `,
+			errors,
+		},
+		{
+			code: `
+				 import * as SneakyDOM from 'react-dom';
+ 
+				 SneakyDOM.createPortal(element, container);
+			 `,
+			errors,
+		},
+		{
+			code: `
+				 import {createPortal} from 'react-dom';
+ 
+				 createPortal(element, container);
+			 `,
+			errors,
+		},
+		{
+			code: `
+				 import {createPortal, render} from 'react-dom';
+ 
+				 createPortal(element, container);
+				 render(element, container);
+			 `,
+			errors,
+		},
+		{
+			code: `
+				 import {createPortal as sneakyRender} from 'react-dom';
+ 
+				 sneakyRender(element, container);
+			 `,
+			errors,
+		},
+		{
+			code: `
+				 const ReactDOM = require('react-dom');
+ 
+				 ReactDOM.createPortal(element, container);
+			 `,
+			errors,
+		},
+		{
+			code: `
+				 const SneakyDOM = require('react-dom');
+ 
+				 SneakyDOM.createPortal(element, container);
+			 `,
+			errors,
+		},
+		{
+			code: `
+				 const {createPortal} = require('react-dom');
+ 
+				 createPortal(element, container);
+			 `,
+			errors,
+		},
+		{
+			code: `
+				 const {createPortal: sneakyRender} = require('react-dom');
+ 
+				 sneakyRender(element, container);
+			 `,
+			errors,
+		},
+		{
+			code: `
+				 import ReactDOM from 'react-dom';
+ 
+				 export default function outer() {
+					 function inner() {
+						 if (true) {
+							 // Show that we don't get confused by scopes.
+							 ReactDOM.createPortal(element, container);
+						 }
+					 }
+				 }
+			 `,
+			errors,
+		},
+	],
+
+	valid: [
+		{
+			code: `
+				 import {createPortal} from 'frontend-js-react-web';
+ 
+				 createPortal(element, container);
+			 `,
+		},
+		{
+			code: `
+				 // No sane person would ever do this, but let's prove that we
+				 // can avoid false positives.
+				 const ReactDOM = {
+					 createPortal(...args) {},
+				 };
+ 
+				 ReactDOM.createPortal();
+			 `,
+		},
+		{
+			code: `
+				 // Again, not something sane, but show that we consider scope
+				 // to avoid false positives.
+				 import {createPortal} from 'react-dom';
+ 
+				 function scope() {
+					 const createPortal = () => {};
+ 
+					 createPortal();
+				 }
+			 `,
+		},
+		{
+			code: `
+				 // Illustrating a limitation: catching this would be too much
+				 // work...
+				 import ReactDOM from 'react-dom';
+ 
+				 const SneakyDOM = ReactDOM;
+ 
+				 SneakyDOM.createPortal(element, container);
+			 `,
+		},
+		{
+			code: `
+				 // Regression test.
+				 let declaration;
+			 `,
+		},
+	],
+});


### PR DESCRIPTION
Fixes https://github.com/liferay/liferay-frontend-projects/issues/553

Aim of this is to aim people towards using our component in DXP. 

This feature shouldn't be added to DXP until https://github.com/liferay-frontend/liferay-portal/pull/1091 is merged