### PR TITLE
fix(eslint-config): add case for abbreviation being a key on an object

### DIFF
--- a/projects/eslint-config/plugins/liferay/lib/rules/no-abbreviations.js
+++ b/projects/eslint-config/plugins/liferay/lib/rules/no-abbreviations.js
@@ -39,7 +39,10 @@ module.exports = {
 	create(context) {
 		return {
 			Identifier(node) {
-				if (node === node.parent.property) {
+				if (
+					node === node.parent.property ||
+					node.parent.type === 'Property'
+				) {
 					return;
 				}
 

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/no-abbreviations.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/no-abbreviations.js
@@ -66,5 +66,8 @@ ruleTester.run('no-abbreviations', rule, {
 		{
 			code: `this.obj = 'this is valid'`,
 		},
+		{
+			code: `const a = {img: '/foo/bar'};`,
+		},
 	],
 });


### PR DESCRIPTION
Caught this issue while trying to get this merged to portal