### PR TITLE
feat(bs3-bs4-compat): add new package for bootstrap 3 to 4 compatibility layer

### DIFF
--- a/projects/js-themes-toolkit/README.md
+++ b/projects/js-themes-toolkit/README.md
@@ -4,6 +4,7 @@
 
 This repo contains the source for a [set of NPM packages](packages) designed to help create, update, and maintain Liferay Themes. The packages that you are most likely to interact with directly are:
 
+-   [bs3-bs4-compat](packages/bs3-bs4-compat): Bootstrap 3 to 4 Compatibility Layer for Liferay DXP. This layer is added to your theme when you run the "upgrade" task for DXP 7.4.
 -   [generator-liferay-theme](packages/generator-liferay-theme): A [Yeoman](https://yeoman.io/) generator for creating new themes, themelets, and layout templates.
 -   [liferay-theme-tasks](packages/liferay-theme-tasks): A set of [Gulp](https://gulpjs.com/) tasks for building and deploying themes.
 

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/README.md
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/README.md
@@ -9,9 +9,9 @@ With the removal of the built-in layer, we speed up all pages by default avoidin
 ## Installation
 
 ```sh
-$ npm install liferay-bs3-to-bs4-compat
+$ npm install @liferay/bs3-to-bs4-compat
 // or
-$ yarn add liferay-bs3-to-bs4-compat
+$ yarn add @liferay/bs3-to-bs4-compat
 ```
 
 ## Use
@@ -40,9 +40,9 @@ You need to import the `.scss` files into your theme. Below is an example of add
 ```diff
 @import 'clay/base';
 
-+ @import 'liferay-bs3-to-bs4-compat/scss/variables';
++ @import '@liferay/bs3-to-bs4-compat/scss/variables';
 
-+ @import 'liferay-bs3-to-bs4-compat/scss/components';
++ @import '@liferay/bs3-to-bs4-compat/scss/components';
 ```
 
 **Classic Theme**
@@ -52,11 +52,11 @@ You need to import the `.scss` files into your theme. Below is an example of add
 ```diff
 @import 'clay/atlas';
 
-+ @import 'liferay-bs3-to-bs4-compat/scss/variables';
++ @import '@liferay/bs3-to-bs4-compat/scss/variables';
 
-+ @import 'liferay-bs3-to-bs4-compat/scss/atlas_variables';
++ @import '@liferay/bs3-to-bs4-compat/scss/atlas_variables';
 
-+ @import 'liferay-bs3-to-bs4-compat/scss/components';
++ @import '@liferay/bs3-to-bs4-compat/scss/components';
 ```
 
 After making this change and deploying to your DXP bundle, you should see the compatibility layer working.

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/README.md
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/README.md
@@ -1,0 +1,62 @@
+# Liferay Bootstrap 3 to 4 Compatibility Layer
+
+With the removal of the Bootstrap 3 compatibility layer in Lifray DXP ([LPS-123359](https://issues.liferay.com/browse/LPS-123359)), code that previously relied on legacy Bootstrap 3 markup no longer behaves as expected.
+
+This built-in layer was always meant to work as a temporary band-aid that projects could use to get an upgrade done fast and out the door. Once the upgrade was completed, it was advised that the project was updated and the compat layer disabled as to speed up the site.
+
+With the removal of the built-in layer, we speed up all pages by default avoiding to load a big amount of unnecessary CSS. However, developers still relying on this might have a hard time upgrading, so the goal of this project is to provide that layer as an external package.
+
+## Installation
+
+```sh
+$ npm install liferay-bs3-to-bs4-compat
+// or
+$ yarn add liferay-bs3-to-bs4-compat
+```
+
+## Use
+
+This compatibility layer is important to have at build time because our sass variables rely on ClayCSS. In order to use this layer, you must properly import it into your theme or wherever you load ClayCSS at.
+
+### Import Order
+
+In order for sass to compile correctly, you must import them correctly so that it can get the right variables from ClayCSS.
+
+-   Clay CSS: Clay must be added first so that the BS3-BS4 layer can read sass variables that come from Clay.
+-   [`_atlas_variables.scss`](scss/_atlas_variables.scss): This file contains variables specific to the atlas theme.
+-   [`_components.scss`](scss/_components_.scss): This file imports all component specific style overrides.
+-   [`_variables.scss`](scss/_variables.scss): This file contains variables for toggling specific compat components off.
+
+_Note: all three compat files are imported into main.scss in that specific order._
+
+### Adding to a Theme
+
+You need to import the `.scss` files into your theme. Below is an example of adding it to the styled and classic themes in DXP.
+
+**Styled Theme**
+
+`modules/apps/frontend-theme/frontend-theme-styled/src/css/clay.scss`
+
+```diff
+@import 'clay/base';
+
++ @import 'liferay-bs3-to-bs4-compat/scss/variables';
+
++ @import 'liferay-bs3-to-bs4-compat/scss/components';
+```
+
+**Classic Theme**
+
+`modules/apps/frontend-theme/frontend-theme-classic/src/css/clay.scss`
+
+```diff
+@import 'clay/atlas';
+
++ @import 'liferay-bs3-to-bs4-compat/scss/variables';
+
++ @import 'liferay-bs3-to-bs4-compat/scss/atlas_variables';
+
++ @import 'liferay-bs3-to-bs4-compat/scss/components';
+```
+
+After making this change and deploying to your DXP bundle, you should see the compatibility layer working.

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/package.json
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/package.json
@@ -1,0 +1,27 @@
+{
+	"author": "Liferay Frontend Infrastructure Team <pt-frontend-infrastructure@liferay.com>",
+	"description": "Bootstrap 3 to 4 Compatibility Layer for Liferay DXP",
+	"engines": {
+		"node": ">=8.0.0"
+	},
+	"keywords": [
+		"liferay"
+	],
+	"license": "MIT",
+	"name": "liferay-bs3-to-bs4-compat",
+	"repository": {
+		"directory": "projects/js-themes-toolkit/packages/bs3-bs4-compat",
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-frontend-projects"
+	},
+	"scripts": {
+		"changelog": "npx liferay-changelog-generator",
+		"format": "liferay-workspace-scripts format",
+		"format:check": "liferay-workspace-scripts format:check",
+		"lint": "liferay-workspace-scripts lint",
+		"lint:fix": "liferay-workspace-scripts lint:fix",
+		"postversion": "liferay-workspace-scripts publish",
+		"preversion": "liferay-workspace-scripts ci"
+	},
+	"version": "1.0.0-beta.1"
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/package.json
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/package.json
@@ -8,7 +8,7 @@
 		"liferay"
 	],
 	"license": "MIT",
-	"name": "liferay-bs3-to-bs4-compat",
+	"name": "@liferay/bs3-to-bs4-compat",
 	"repository": {
 		"directory": "projects/js-themes-toolkit/packages/bs3-bs4-compat",
 		"type": "git",
@@ -16,12 +16,15 @@
 	},
 	"scripts": {
 		"changelog": "npx liferay-changelog-generator",
+		"ci": "liferay-workspace-scripts ci",
+		"build": "true",
 		"format": "liferay-workspace-scripts format",
 		"format:check": "liferay-workspace-scripts format:check",
 		"lint": "liferay-workspace-scripts lint",
 		"lint:fix": "liferay-workspace-scripts lint:fix",
 		"postversion": "liferay-workspace-scripts publish",
-		"preversion": "liferay-workspace-scripts ci"
+		"preversion": "liferay-workspace-scripts ci",
+		"test": "liferay-workspace-scripts test"
 	},
 	"version": "1.0.0-beta.1"
 }

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/_atlas_variables.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/_atlas_variables.scss
@@ -1,0 +1,35 @@
+// Map Bootstrap 4 Variables to Bootstrap 3 equivalent
+
+$btn-box-shadow: none !default;
+
+// Labels
+
+$label-text-transform: uppercase !default;
+
+// Navbar
+
+$navbar-padding-x: 0 !default;
+$navbar-padding-y: 0 !default;
+
+// Management Bar
+
+$management-bar-border-bottom-width: 0.0625rem !default; // 1px
+$management-bar-border-left-width: 0 !default;
+$management-bar-border-right-width: 0 !default;
+$management-bar-border-top-width: 0 !default;
+
+$management-bar-desktop-height: 4rem !default; // 64px
+$management-bar-desktop-link-line-height: 1.5 !default;
+$management-bar-desktop-padding-horizontal: null !default;
+$management-bar-desktop-padding-vertical: (
+	(
+			$management-bar-desktop-height -
+				$management-bar-desktop-link-line-height -
+				$management-bar-border-bottom-width -
+				$management-bar-border-top-width
+		) / 2
+) !default;
+
+// Panels
+
+$panel-title-text-transform: none !default;

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/_components.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/_components.scss
@@ -1,0 +1,40 @@
+@import 'mixins';
+
+@import 'components/alerts';
+@import 'components/basic_search';
+@import 'components/breadcrumbs';
+@import 'components/button_groups';
+@import 'components/buttons';
+@import 'components/component_animations';
+@import 'components/dropdowns';
+@import 'components/figures';
+@import 'components/form_validation';
+@import 'components/forms';
+
+@import 'components/cards';
+@import 'components/grid';
+@import 'components/icons';
+@import 'components/labels';
+@import 'components/list_groups';
+@import 'components/management_bar';
+@import 'components/modals';
+@import 'components/navs';
+
+@import 'components/nav_tabs';
+@import 'components/navbar';
+@import 'components/pager';
+@import 'components/panels';
+@import 'components/popover';
+@import 'components/progress_bars';
+@import 'components/responsive_utilities';
+@import 'components/sidebar';
+@import 'components/simple_flexbox_grid';
+@import 'components/stickers';
+@import 'components/tables';
+@import 'components/toggle_card';
+@import 'components/toggle_switch';
+@import 'components/toolbar';
+@import 'components/user_icons';
+@import 'components/utilities';
+
+@import 'components/liferay';

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/_mixins.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/_mixins.scss
@@ -1,0 +1,461 @@
+// Flex mixin
+
+@mixin break-flex-item() {
+	flex-basis: auto;
+	width: 100%;
+}
+
+@mixin stack-flex-container() {
+	flex-direction: column;
+
+	.flex-item-full {
+		flex-basis: auto;
+	}
+}
+
+// BS3 Button Size mixin
+
+@mixin button-size(
+	$padding-vertical,
+	$padding-horizontal,
+	$font-size,
+	$line-height,
+	$border-radius
+) {
+	border-radius: $border-radius;
+	font-size: $font-size;
+	line-height: $line-height;
+	padding: $padding-vertical $padding-horizontal;
+}
+
+// Gradients
+
+// Horizontal gradient, from left to right
+
+// Creates two color stops, start and end, by specifying a color and position for each color stop.
+
+@mixin gradient-horizontal(
+	$start-color: #555,
+	$end-color: #333,
+	$start-percent: 0%,
+	$end-percent: 100%
+) {
+	background-image: -o-linear-gradient(
+		left,
+		$start-color $start-percent,
+		$end-color $end-percent
+	); // Opera 12
+	background-image: -webkit-linear-gradient(
+		left,
+		$start-color $start-percent,
+		$end-color $end-percent
+	); // Safari 5.1-6, Chrome 10+
+	background-image: linear-gradient(
+		to right,
+		$start-color $start-percent,
+		$end-color $end-percent
+	); // Standard, IE10, Firefox 16+, Opera 12.10+, Safari 7+, Chrome 26+
+	background-repeat: repeat-x;
+}
+
+// Vertical gradient, from top to bottom
+
+// Creates two color stops, start and end, by specifying a color and position for each color stop.
+
+@mixin gradient-vertical(
+	$start-color: #555,
+	$end-color: #333,
+	$start-percent: 0%,
+	$end-percent: 100%
+) {
+	background-image: -o-linear-gradient(
+		top,
+		$start-color $start-percent,
+		$end-color $end-percent
+	); // Opera 12
+	background-image: -webkit-linear-gradient(
+		top,
+		$start-color $start-percent,
+		$end-color $end-percent
+	); // Safari 5.1-6, Chrome 10+
+	background-image: linear-gradient(
+		to bottom,
+		$start-color $start-percent,
+		$end-color $end-percent
+	); // Standard, IE10, Firefox 16+, Opera 12.10+, Safari 7+, Chrome 26+
+	background-repeat: repeat-x;
+}
+
+@mixin gradient-directional($start-color: #555, $end-color: #333, $deg: 45deg) {
+	background-image: -o-linear-gradient(
+		$deg,
+		$start-color,
+		$end-color
+	); // Opera 12
+	background-image: -webkit-linear-gradient(
+		$deg,
+		$start-color,
+		$end-color
+	); // Safari 5.1-6, Chrome 10+
+	background-image: linear-gradient(
+		$deg,
+		$start-color,
+		$end-color
+	); // Standard, IE10, Firefox 16+, Opera 12.10+, Safari 7+, Chrome 26+
+	background-repeat: repeat-x;
+}
+
+@mixin gradient-horizontal-three-colors(
+	$start-color: #00b3ee,
+	$mid-color: #7a43b6,
+	$color-stop: 50%,
+	$end-color: #c3325f
+) {
+	background-image: -o-linear-gradient(
+		left,
+		$start-color,
+		$mid-color $color-stop,
+		$end-color
+	);
+	background-image: -webkit-linear-gradient(
+		left,
+		$start-color,
+		$mid-color $color-stop,
+		$end-color
+	);
+	background-image: linear-gradient(
+		to right,
+		$start-color,
+		$mid-color $color-stop,
+		$end-color
+	);
+	background-repeat: no-repeat;
+}
+
+@mixin gradient-vertical-three-colors(
+	$start-color: #00b3ee,
+	$mid-color: #7a43b6,
+	$color-stop: 50%,
+	$end-color: #c3325f
+) {
+	background-image: -o-linear-gradient(
+		$start-color,
+		$mid-color $color-stop,
+		$end-color
+	);
+	background-image: -webkit-linear-gradient(
+		$start-color,
+		$mid-color $color-stop,
+		$end-color
+	);
+	background-image: linear-gradient(
+		$start-color,
+		$mid-color $color-stop,
+		$end-color
+	);
+	background-repeat: no-repeat;
+}
+
+@mixin gradient-radial($inner-color: #555, $outer-color: #333) {
+	background-image: -webkit-radial-gradient(
+		circle,
+		$inner-color,
+		$outer-color
+	);
+	background-image: radial-gradient(circle, $inner-color, $outer-color);
+	background-repeat: no-repeat;
+}
+
+@mixin gradient-striped($color: rgba(255, 255, 255, 0.15), $angle: 45deg) {
+	background-image: -o-linear-gradient(
+		$angle,
+		$color 25%,
+		transparent 25%,
+		transparent 50%,
+		$color 50%,
+		$color 75%,
+		transparent 75%,
+		transparent
+	);
+	background-image: -webkit-linear-gradient(
+		$angle,
+		$color 25%,
+		transparent 25%,
+		transparent 50%,
+		$color 50%,
+		$color 75%,
+		transparent 75%,
+		transparent
+	);
+	background-image: linear-gradient(
+		$angle,
+		$color 25%,
+		transparent 25%,
+		transparent 50%,
+		$color 50%,
+		$color 75%,
+		transparent 75%,
+		transparent
+	);
+}
+
+// Labels
+
+@mixin label-variant($color) {
+	background-color: $color;
+
+	&[href] {
+		&:hover,
+		&:focus {
+			background-color: darken($color, 10%);
+		}
+	}
+}
+
+// BS3 Navbar Vertical Align mixin
+
+@mixin navbar-vertical-align($element-height) {
+	margin-bottom: (($navbar-height - $element-height) / 2);
+	margin-top: (($navbar-height - $element-height) / 2);
+}
+
+// Progress bars
+
+@mixin progress-bar-variant($color) {
+	background-color: $color;
+
+	// Deprecated parent class requirement as of v3.2.0
+
+	.progress-striped & {
+		@include gradient-striped();
+	}
+}
+
+// _responsive-visibility.scss
+
+// More easily include all the states for responsive-utilities.less.
+// [converter] $parent hack
+
+@mixin responsive-visibility($parent) {
+	#{$parent} {
+		display: block !important;
+	}
+
+	table#{$parent} {
+		display: table !important;
+	}
+
+	tr#{$parent} {
+		display: table-row !important;
+	}
+
+	th#{$parent},
+	td#{$parent} {
+		display: table-cell !important;
+	}
+}
+
+// [converter] $parent hack
+
+@mixin responsive-invisibility($parent) {
+	#{$parent} {
+		display: none !important;
+	}
+}
+
+// BS3 Tab Focus
+// WebKit-style focus
+
+@mixin tab-focus() {
+	// Default
+
+	outline: thin dotted;
+
+	// WebKit
+
+	outline: 5px auto -webkit-focus-ring-color;
+	outline-offset: -2px;
+}
+
+// BS3 Text Overflow mixin
+
+@mixin text-overflow() {
+	@include text-truncate();
+}
+
+// Vendor Prefixes
+
+// All vendor mixins are deprecated as of v3.2.0 due to the introduction of
+// Autoprefixer in our Gruntfile. They will be removed in v4.
+
+// - Animations
+// - Backface visibility
+// - Box shadow
+// - Box sizing
+// - Content columns
+// - Hyphens
+// - Placeholder text
+// - Transformations
+// - Transitions
+// - User Select
+
+// Animations
+
+@mixin animation($animation) {
+	-o-animation: $animation;
+	-webkit-animation: $animation;
+	animation: $animation;
+}
+
+@mixin animation-name($name) {
+	-webkit-animation-name: $name;
+	animation-name: $name;
+}
+
+@mixin animation-duration($duration) {
+	-webkit-animation-duration: $duration;
+	animation-duration: $duration;
+}
+
+@mixin animation-timing-function($timing-function) {
+	-webkit-animation-timing-function: $timing-function;
+	animation-timing-function: $timing-function;
+}
+
+@mixin animation-delay($delay) {
+	-webkit-animation-delay: $delay;
+	animation-delay: $delay;
+}
+
+@mixin animation-iteration-count($iteration-count) {
+	-webkit-animation-iteration-count: $iteration-count;
+	animation-iteration-count: $iteration-count;
+}
+
+@mixin animation-direction($direction) {
+	-webkit-animation-direction: $direction;
+	animation-direction: $direction;
+}
+
+@mixin animation-fill-mode($fill-mode) {
+	-webkit-animation-fill-mode: $fill-mode;
+	animation-fill-mode: $fill-mode;
+}
+
+// Backface visibility
+// Prevent browsers from flickering when using CSS 3D transforms.
+// Default value is `visible`, but can be changed to `hidden`
+
+@mixin backface-visibility($visibility) {
+	-moz-backface-visibility: $visibility;
+	-webkit-backface-visibility: $visibility;
+	backface-visibility: $visibility;
+}
+
+// Box sizing
+
+@mixin box-sizing($boxmodel) {
+	-moz-box-sizing: $boxmodel;
+	-webkit-box-sizing: $boxmodel;
+	box-sizing: $boxmodel;
+}
+
+// CSS3 Content Columns
+
+@mixin content-columns($column-count, $column-gap: $grid-gutter-width) {
+	-moz-column-count: $column-count;
+	-moz-column-gap: $column-gap;
+	-webkit-column-count: $column-count;
+	-webkit-column-gap: $column-gap;
+	column-count: $column-count;
+	column-gap: $column-gap;
+}
+
+// Transformations
+
+@mixin scale($ratio...) {
+	transform: scale($ratio);
+}
+
+@mixin scaleX($ratio) {
+	transform: scaleX($ratio);
+}
+
+@mixin scaleY($ratio) {
+	transform: scaleY($ratio);
+}
+
+@mixin skew($x, $y) {
+	transform: skewX($x) skewY($y);
+}
+
+@mixin translate($x, $y) {
+	transform: translate($x, $y);
+}
+
+@mixin translate3d($x, $y, $z) {
+	transform: translate3d($x, $y, $z);
+}
+
+@mixin rotate($degrees) {
+	transform: rotate($degrees);
+}
+
+@mixin rotateX($degrees) {
+	transform: rotateX($degrees);
+}
+
+@mixin rotateY($degrees) {
+	transform: rotateY($degrees);
+}
+
+@mixin perspective($perspective) {
+	perspective: $perspective;
+}
+
+@mixin perspective-origin($perspective) {
+	perspective-origin: $perspective;
+}
+
+@mixin transform-origin($origin) {
+	transform-origin: $origin;
+}
+
+// Transitions
+
+@mixin transition-property($transition-property...) {
+	transition-property: $transition-property;
+}
+
+@mixin transition-delay($transition-delay) {
+	transition-delay: $transition-delay;
+}
+
+@mixin transition-duration($transition-duration...) {
+	transition-duration: $transition-duration;
+}
+
+@mixin transition-timing-function($timing-function) {
+	transition-timing-function: $timing-function;
+}
+
+@mixin transition-transform($transition...) {
+	transition: transform $transition;
+}
+
+// User icons
+
+@mixin color-user-icon($color: #999, $bg-color: #fff) {
+	background-color: $bg-color;
+	box-shadow: 0 0 0 1px $gray-300;
+	color: $color;
+}
+
+@mixin monospace($size) {
+	@include clay-monospace($size);
+}
+
+@mixin tab-focus() {
+	outline: 5px auto -webkit-focus-ring-color;
+	outline-offset: -2px;
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/_variables.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/_variables.scss
@@ -1,0 +1,263 @@
+// Compatibility layer components config
+
+$compat-alerts: true !default;
+$compat-basic_search: true !default;
+$compat-breadcrumbs: true !default;
+$compat-button_groups: true !default;
+$compat-buttons: true !default;
+$compat-cards: true !default;
+$compat-component_animations: true !default;
+$compat-dropdowns: true !default;
+$compat-figures: true !default;
+$compat-form_validation: true !default;
+$compat-forms: true !default;
+$compat-grid: true !default;
+$compat-icons: true !default;
+$compat-labels: true !default;
+$compat-liferay: true !default;
+$compat-list_groups: true !default;
+$compat-management_bar: true !default;
+$compat-modals: true !default;
+$compat-nav_tabs: true !default;
+$compat-navbar: true !default;
+$compat-navs: true !default;
+$compat-pager: true !default;
+$compat-pagination: true !default;
+$compat-panels: true !default;
+$compat-progress_bars: true !default;
+$compat-responsive_utilities: true !default;
+$compat-sidebar: true !default;
+$compat-simple_flexbox_grid: true !default;
+$compat-stickers: true !default;
+$compat-tables: true !default;
+$compat-toggle_card: true !default;
+$compat-toggle_switch: true !default;
+$compat-toolbar: true !default;
+$compat-user_icons: true !default;
+$compat-utilities: true !default;
+
+// Map Bootstrap 4 Variables to Bootstrap 3 equivalent
+
+$icon-monospaced-size: 2rem !default;
+
+$nav-link-color: $navbar-light-color !default;
+
+// Navbar
+
+$navbar-border-bottom-width: 0.0625rem !default;
+$navbar-border-left-width: 0 !default;
+$navbar-border-right-width: 0 !default;
+$navbar-border-top-width: 0 !default;
+
+$navbar-light-active-highlight: lighten(#1865fb, 22%) !default;
+$navbar-light-bg: #fff !default;
+$navbar-light-border-color: transparent !default;
+
+$navbar-dark-active-highlight: lighten(#1865fb, 22%) !default;
+$navbar-dark-bg: #31323f !default;
+$navbar-dark-border-color: transparent !default;
+
+$zindex-basic-search-close: 5 !default;
+
+// Mangagement bar
+
+$management-bar-border-bottom-width: 0.0625rem !default; // 1px
+$management-bar-border-left-width: 0.0625rem !default; // 1px
+$management-bar-border-right-width: 0.0625rem !default; // 1px
+$management-bar-border-top-width: 0.0625rem !default; // 1px
+$management-bar-border-width: $management-bar-border-top-width
+	$management-bar-border-right-width $management-bar-border-bottom-width
+	$management-bar-border-left-width !default;
+
+$management-bar-dropdown-menu-margin-top: 0 !default;
+
+$management-bar-desktop-height: null !default;
+$management-bar-height: 3.125rem !default; // 50px
+
+$management-bar-desktop-link-line-height: $line-height-base !default;
+
+$management-bar-margin-bottom: 1.25rem !default; // 20px
+
+$management-bar-desktop-padding-horizontal: null !default;
+$management-bar-desktop-padding-vertical: null !default;
+$management-bar-padding-horizontal: $nav-link-padding-x !default;
+$management-bar-padding-vertical: (
+		$management-bar-height - 1.25rem - $management-bar-border-bottom-width -
+			$management-bar-border-top-width
+	) / 2 !default;
+
+$management-bar-btn-padding-horizontal: $management-bar-padding-horizontal !default;
+$management-bar-btn-padding-vertical: (
+		$management-bar-height - $management-bar-border-bottom-width -
+			$management-bar-border-top-width - $icon-monospaced-size
+	) / 2 !default;
+
+$management-bar-toggle-height: 2.5rem + $management-bar-border-bottom-width +
+	$management-bar-border-top-width !default;
+
+$management-bar-collapse-bg: $dropdown-bg !default;
+$management-bar-collapse-border: transparent !default;
+
+$management-bar-default-bg: #fff !default;
+$management-bar-default-border: transparent !default;
+$management-bar-default-box-shadow: null !default;
+$management-bar-default-color: $secondary !default;
+
+$management-bar-default-collapse-bg: $management-bar-default-bg !default;
+$management-bar-default-collapse-border: $management-bar-default-border !default;
+
+$management-bar-default-link-color: $secondary !default;
+
+$management-bar-default-link-hover-bg: rgba(39, 40, 51, 0.03) !default;
+$management-bar-default-link-hover-color: $navbar-light-hover-color !default;
+
+$management-bar-default-link-active-bg: darken($body-bg, 6.5%) !default;
+$management-bar-default-link-active-color: $body-color !default;
+
+$management-bar-default-link-disabled-bg: transparent !default;
+$management-bar-default-link-disabled-color: $navbar-light-disabled-color !default;
+
+$management-bar-default-btn-secondary-bg: transparent !default;
+$management-bar-default-btn-secondary-border: transparent !default;
+$management-bar-default-btn-secondary-color: $management-bar-default-link-color !default;
+
+$management-bar-default-btn-secondary-hover-bg: $management-bar-default-link-hover-bg !default;
+$management-bar-default-btn-secondary-hover-border: $management-bar-default-btn-secondary-border !default;
+$management-bar-default-btn-secondary-hover-color: $body-color !default;
+
+$management-bar-default-btn-secondary-active-bg: $management-bar-default-btn-secondary-hover-bg !default;
+$management-bar-default-btn-secondary-active-border: $management-bar-default-btn-secondary-hover-border !default;
+$management-bar-default-btn-secondary-active-color: $management-bar-default-btn-secondary-hover-color !default;
+
+// Icons
+
+$help-icon-default-bg: lighten(map-get($theme-colors, secondary), 24%) !default;
+$help-icon-default-color: #fff !default;
+$help-icon-default-hover-color: $help-icon-default-color !default;
+
+// Grid
+
+$screen-lg: 1200px !default;
+
+$screen-lg-min: map-get($grid-breakpoints, xl) !default;
+$screen-md-min: map-get($grid-breakpoints, lg) !default;
+$screen-sm-min: map-get($grid-breakpoints, md) !default;
+$screen-xs-min: map-get($grid-breakpoints, sm) !default;
+
+$screen-md-max: ($screen-lg-min - 1) !default;
+$screen-sm-max: ($screen-md-min - 1) !default;
+$screen-xs-max: ($screen-sm-min - 1) !default;
+
+$grid-float-breakpoint: $screen-sm-min !default;
+
+// Pager
+
+$pager-bg: $pagination-bg !default;
+$pager-border: $pagination-border-color !default;
+$pager-border-radius: 15px !default;
+
+$pager-hover-bg: $pagination-hover-bg !default;
+
+$pager-active-bg: $pagination-active-bg !default;
+$pager-active-color: $pagination-active-color !default;
+
+$pager-disabled-color: $pagination-disabled-color !default;
+
+// Progress
+
+$progress-bar-xl-height: 52px !default;
+$progress-bar-xs-height: 8px !default;
+
+// List groups
+
+$list-group-border: #ddd !default;
+$list-group-border-radius: $border-radius-base !default;
+
+$list-group-hover-bg: #f5f5f5 !default;
+
+$list-group-link-heading-color: #333 !default;
+
+$list-group-border-width: 1px !default;
+$list-group-header-font-weight: 500 !default;
+
+$list-group-header-bg: $list-group-hover-bg !default;
+$list-group-header-color: $list-group-link-heading-color !default;
+$list-group-header-hover-color: $list-group-header-color !default;
+
+$list-group-header-open-border-color: map-get($theme-colors, primary) !default;
+$list-group-header-open-border-width: 2px !default;
+
+$list-group-header-close-border-color: $list-group-border !default;
+$list-group-header-close-border-width: 1px !default;
+
+// User icons
+
+$user-icon-xs-font-size: 8px !default;
+$user-icon-xs-size: 24px !default;
+
+$user-icon-xs-desktop-font-size: 8px !default;
+$user-icon-xs-desktop-size: 24px !default;
+
+$user-icon-sm-font-size: 12px !default;
+$user-icon-sm-size: 32px !default;
+
+$user-icon-sm-desktop-font-size: $font-size-sm !default; // 12px
+$user-icon-sm-desktop-size: 32px !default;
+
+$user-icon-font-size: $font-size-sm !default; // 14px
+$user-icon-size: 32px !default;
+
+$user-icon-lg-font-size: $font-size-sm !default;
+$user-icon-lg-size: 40px !default;
+
+$user-icon-lg-desktop-font-size: $font-size-sm !default;
+$user-icon-lg-desktop-size: 40px !default;
+
+$user-icon-xl-font-size: 16px !default;
+$user-icon-xl-size: 48px !default;
+
+$user-icon-xl-desktop-font-size: 16px !default;
+$user-icon-xl-desktop-size: 48px !default;
+
+$user-icon-xxl-font-size: 20px !default;
+$user-icon-xxl-size: 56px !default;
+
+$user-icon-xxl-desktop-font-size: 20px !default;
+$user-icon-xxl-desktop-size: 56px !default;
+
+$user-icon-border-radius: 500px !default;
+$user-icon-circle-border-radius: 500px !default;
+$user-icon-rounded-border-radius: $border-radius !default;
+$user-icon-square-border-radius: 0 !default;
+
+$user-icon-default-bg: $gray-600 !default;
+
+$user-icon-primary-bg: map-get($theme-colors, primary) !default;
+
+$user-icon-info-bg: map-get($theme-colors, info) !default;
+
+$user-icon-success-bg: map-get($theme-colors, success) !default;
+
+$user-icon-warning-bg: map-get($theme-colors, warning) !default;
+
+$user-icon-danger-bg: map-get($theme-colors, danger) !default;
+
+// Multi Step Progress
+
+$multi-step-progress-bar-active-icon: '\f111' !default;
+$multi-step-progress-bar-complete-icon: '\f00c' !default;
+$multi-step-progress-bar-icon: '\f10c' !default;
+
+$multi-step-progress-bar-color: #bbb !default;
+
+$multi-step-progress-bar-active-color: map-get($theme-colors, primary) !default;
+
+$multi-step-progress-bar-complete-color: map-get($colors, gray) !default;
+$multi-step-progress-bar-complete-icon-color: map-get(
+	$theme-colors,
+	primary
+) !default;
+
+$multi-step-progress-bar-divider-height: 1px !default;
+
+$multi-step-progress-bar-fixed-width: 100px !default;

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_alerts.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_alerts.scss
@@ -1,0 +1,29 @@
+@if $compat-alerts {
+	.alert .close .lexicon-icon {
+		display: inline-block;
+	}
+
+	.alert-dismissable {
+		padding-bottom: $alert-dismissible-padding-bottom;
+		padding-left: $alert-dismissible-padding-left;
+		padding-right: $alert-dismissible-padding-right;
+		padding-top: $alert-dismissible-padding-top;
+
+		.close {
+			position: absolute;
+		}
+	}
+
+	.alert-fluid.alert-dismissable {
+		.container,
+		.container-fluid {
+			padding-bottom: $alert-dismissible-padding-bottom;
+			padding-left: $alert-dismissible-padding-left;
+			padding-right: calc(
+				#{$alert-dismissible-padding-right} + #{$grid-gutter-width / 2}
+			);
+			padding-top: $alert-dismissible-padding-top;
+			position: relative;
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_basic_search.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_basic_search.scss
@@ -1,0 +1,185 @@
+@if $compat-basic_search {
+	.basic-search {
+		&.open {
+			z-index: 10;
+		}
+
+		.input-group-input {
+			.basic-search-slider .form-control {
+				border-bottom-right-radius: 0;
+				border-top-right-radius: 0;
+
+				&:focus {
+					z-index: 5;
+				}
+			}
+
+			.form-control {
+				@include media-breakpoint-up(md) {
+					border-bottom-left-radius: $input-border-radius;
+					border-top-left-radius: $input-border-radius;
+				}
+			}
+		}
+	}
+
+	.basic-search-transition {
+		.basic-search-slider {
+			transition: left 0.5s ease, right 0.5s ease;
+		}
+	}
+
+	// Collapse Basic Search
+
+	.basic-search-slider {
+		left: 0;
+		position: relative;
+
+		@include media-breakpoint-down($scaling-breakpoint-down) {
+			left: 101%;
+		}
+
+		.basic-search-close {
+			border-bottom-right-radius: 0;
+			border-top-right-radius: 0;
+			display: none;
+			z-index: $zindex-basic-search-close;
+
+			@include media-breakpoint-down($scaling-breakpoint-down) {
+				display: inline-block;
+			}
+		}
+
+		.basic-search.open & {
+			left: 0;
+		}
+	}
+
+	.collapse-basic-search {
+		.basic-search {
+			position: relative;
+
+			@include media-breakpoint-down($scaling-breakpoint-down) {
+				border-color: transparent;
+
+				@include border-radius($navbar-border-radius);
+
+				border-style: solid;
+				margin: 0;
+				position: absolute;
+
+				&.open {
+					background-color: $body-bg;
+				}
+			}
+
+			&.basic-search-transition,
+			&.open {
+				.input-group-input {
+					visibility: visible;
+				}
+			}
+
+			&.basic-search-transition .input-group-btn .btn:first-child,
+			&.open .input-group-btn .btn:first-child {
+				@include media-breakpoint-down($scaling-breakpoint-down) {
+					border-bottom-left-radius: 0;
+					border-top-left-radius: 0;
+				}
+			}
+
+			.input-group-btn .btn:first-child {
+				@include media-breakpoint-down($scaling-breakpoint-down) {
+					border-bottom-left-radius: $btn-border-radius;
+					border-top-left-radius: $btn-border-radius;
+				}
+			}
+
+			.input-group-input {
+				overflow: visible;
+				visibility: visible;
+
+				@include media-breakpoint-down($scaling-breakpoint-down) {
+					overflow: hidden;
+					visibility: hidden;
+				}
+			}
+		}
+	}
+
+	.collapse-basic-search {
+		flex-wrap: wrap;
+
+		&.navbar .basic-search {
+			@include media-breakpoint-down($scaling-breakpoint-down) {
+				margin-left: 0;
+				margin-right: 0;
+
+				> form {
+					width: 100%;
+				}
+			}
+		}
+
+		.basic-search {
+			max-width: 220px;
+
+			@include media-breakpoint-up(md) {
+				min-width: 220px;
+			}
+
+			@include media-breakpoint-down($scaling-breakpoint-down) {
+				max-width: none;
+			}
+
+			&.navbar-form-autofit {
+				max-width: none;
+			}
+
+			.input-group {
+				align-items: center;
+				margin-left: auto;
+			}
+
+			.input-group-input {
+				flex: 1;
+			}
+		}
+
+		.basic-search-slider {
+			display: flex;
+			flex: 1;
+
+			.form-control {
+				margin-left: -1px;
+			}
+		}
+
+		.navbar-collapse {
+			flex-basis: auto;
+
+			@include media-breakpoint-down($scaling-breakpoint-down) {
+				flex-basis: 100%;
+			}
+		}
+
+		.nav-link,
+		.navbar-toggler {
+			z-index: 1;
+		}
+	}
+
+	.basic-search-no-collapse {
+		.basic-search-slider {
+			@include media-breakpoint-down($scaling-breakpoint-down) {
+				left: 0;
+			}
+
+			.basic-search-close {
+				@include media-breakpoint-down($scaling-breakpoint-down) {
+					display: none;
+				}
+			}
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_breadcrumbs.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_breadcrumbs.scss
@@ -1,0 +1,42 @@
+@if $compat-breadcrumbs {
+	.breadcrumb > li {
+		float: left;
+
+		&.active {
+			color: $breadcrumb-active-color;
+		}
+	}
+
+	.breadcrumb > li + li::before {
+		display: inline-block; // Suppress underlining of the separator in modern browsers
+		color: $breadcrumb-divider-color;
+		content: '#{$breadcrumb-divider}';
+		padding-left: $breadcrumb-item-padding;
+		padding-right: $breadcrumb-item-padding;
+	}
+
+	.breadcrumb > li + li:hover::before {
+		text-decoration: underline;
+	}
+
+	.breadcrumb > li + li:hover::before {
+		text-decoration: none;
+	}
+
+	.breadcrumb-vertical {
+		.breadcrumb-item {
+			display: block;
+			float: none;
+			max-width: none;
+		}
+
+		.breadcrumb-item:before,
+		.breadcrumb-item + .breadcrumb-item:before {
+			color: $gray-600;
+			content: normal;
+			float: none;
+			padding-left: 0;
+			padding-right: 0;
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_button_groups.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_button_groups.scss
@@ -1,0 +1,22 @@
+.button-holder {
+	display: flex;
+	margin: 20px 0;
+
+	.btn:not(:last-child) {
+		margin-right: 12px;
+	}
+
+	&.btn-group {
+		display: inline-flex;
+	}
+}
+
+@if $compat-button_groups {
+	.btn-group {
+		flex-flow: wrap;
+
+		&.dropdown {
+			display: inline-flex;
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_buttons.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_buttons.scss
@@ -1,0 +1,140 @@
+a.btn-monospaced,
+span.btn-monospaced {
+	line-height: inherit;
+
+	.lexicon-icon {
+		font-size: 1rem;
+	}
+}
+
+.btn-unstyled.text-secondary {
+	font-size: 1rem;
+}
+
+@if $compat-buttons {
+	.btn-default {
+		@include button-variant(theme-color(secondary), theme-color(secondary));
+
+		@include clay-button-variant(map-get($btn-palette, secondary));
+	}
+
+	.btn-primary.btn-default {
+		@include button-variant(theme-color(primary), theme-color(primary));
+
+		@include clay-button-variant(map-get($btn-palette, primary));
+	}
+
+	.btn-success.btn-default {
+		@include button-variant(theme-color(success), theme-color(success));
+
+		@include clay-button-variant(map-get($btn-palette, success));
+	}
+
+	.btn-info.btn-default {
+		@include button-variant(theme-color(info), theme-color(info));
+
+		@include clay-button-variant(map-get($btn-palette, info));
+	}
+
+	.btn-warning.btn-default {
+		@include button-variant(theme-color(warning), theme-color(warning));
+
+		@include clay-button-variant(map-get($btn-palette, warning));
+	}
+
+	.btn-danger.btn-default {
+		@include button-variant(theme-color(danger), theme-color(danger));
+
+		@include clay-button-variant(map-get($btn-palette, danger));
+	}
+
+	.btn-link.btn-default {
+		background-color: transparent;
+		border-color: transparent;
+
+		@include border-radius(1px);
+
+		color: $link-color;
+		font-weight: $font-weight-normal;
+
+		@include hover {
+			background-color: transparent;
+			border-color: transparent;
+			color: $link-hover-color;
+			text-decoration: $link-hover-decoration;
+		}
+
+		&:focus,
+		&.focus {
+			border-color: transparent;
+			box-shadow: $btn-focus-box-shadow;
+			text-decoration: $link-decoration;
+		}
+
+		&:disabled,
+		&.disabled {
+			color: $btn-link-disabled-color;
+		}
+
+		&:active,
+		&.active,
+		&:not([disabled]):not(.disabled):active {
+			background-color: transparent;
+			border-color: transparent;
+			box-shadow: none;
+			color: $link-color;
+		}
+	}
+
+	.btn-link.btn-default {
+		&.btn-cancel,
+		&.close-modal {
+			@include border-radius(0.25rem);
+
+			@include button-variant(
+				theme-color(secondary),
+				theme-color(secondary)
+			);
+
+			@include clay-button-variant(map-get($btn-palette, secondary));
+
+			font-weight: 600;
+
+			@include hover {
+				text-decoration: none;
+			}
+		}
+	}
+
+	.btn-xs {
+		@extend .btn-sm;
+
+		.icon-monospaced {
+			height: 1rem;
+			line-height: 18px;
+			width: 1rem;
+		}
+	}
+
+	.btn-bottom-right {
+		bottom: 30px;
+		position: fixed;
+		right: 20px;
+	}
+
+	.btn-action,
+	.btn-action-secondary {
+		z-index: 950;
+	}
+
+	.btn-action,
+	.btn-action-secondary > .btn {
+		@include monospace(2.5rem);
+
+		overflow: hidden;
+		padding: 0;
+		text-align: center;
+		white-space: normal;
+		word-wrap: break-word;
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_cards.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_cards.scss
@@ -1,0 +1,217 @@
+@if $compat-cards {
+	// Card Simple Grid
+
+	.card-col-content {
+		display: table-cell;
+		max-width: 10px;
+		position: relative;
+		vertical-align: middle;
+		width: auto;
+		word-break: break-all \9; // IE 8, 9
+		word-wrap: break-word;
+	}
+
+	.card-col-field {
+		display: table-cell;
+		position: relative;
+		vertical-align: middle;
+		width: 1%;
+	}
+
+	.card-row {
+		&.card-row-padded {
+			display: table;
+			width: 100%;
+		}
+
+		&.card-row-padded .card-col-gutters {
+			&:first-child {
+				padding-left: 0;
+			}
+
+			&:last-child {
+				padding-right: 0;
+			}
+
+			.divider {
+				margin-left: 0;
+				margin-right: 0;
+			}
+		}
+
+		.card-col-gutters {
+			padding: 0 10px;
+
+			.divider {
+				margin-left: -10px;
+				margin-right: -10px;
+			}
+		}
+	}
+
+	.card-row-layout-fixed {
+		display: table;
+		height: 100%;
+		table-layout: fixed;
+		width: 100%;
+
+		.card-col-content {
+			word-wrap: break-word;
+		}
+
+		.card-col-field {
+			width: auto;
+			word-wrap: break-word;
+		}
+	}
+
+	.card-row-padded {
+		padding: 15px;
+	}
+
+	// Card Row Vertical Alignment
+
+	.card-row-valign-top {
+		.card-col-content,
+		.card-col-field {
+			vertical-align: top;
+		}
+
+		.clamp-container {
+			top: 0;
+		}
+
+		.clamp-horizontal .clamp-container {
+			transform: none;
+		}
+	}
+
+	.card-row-valign-bottom {
+		.card-col-content,
+		.card-col-field {
+			vertical-align: bottom;
+		}
+
+		.clamp-container {
+			bottom: 0;
+		}
+
+		.clamp-horizontal .clamp-container {
+			transform: none;
+		}
+	}
+
+	.panel-body,
+	.panel-heading {
+		> .card-row {
+			display: table;
+		}
+	}
+
+	// Checkbox and Radio Cards
+
+	.checkbox-card,
+	.radio-card {
+		margin-bottom: 0;
+		margin-top: 0;
+
+		label {
+			color: $body-color;
+			display: inline;
+			padding-left: 0;
+		}
+	}
+
+	.checkbox-card input[type='checkbox'],
+	.radio-card input[type='radio'] {
+		margin-left: 0;
+		margin-top: 0;
+		z-index: 1;
+	}
+
+	.checkbox-bottom-left,
+	.checkbox-middle-left,
+	.checkbox-top-left,
+	.radio-bottom-left,
+	.radio-middle-left,
+	.radio-top-left {
+		.card-horizontal {
+			.card.flex-container {
+				padding-left: $checkbox-left-card-padding;
+			}
+
+			> .card-row {
+				padding-left: $checkbox-left-card-padding;
+			}
+		}
+	}
+
+	.checkbox-bottom-right,
+	.checkbox-middle-right,
+	.checkbox-top-right,
+	.radio-bottom-right,
+	.radio-middle-right,
+	.radio-top-right {
+		.card-horizontal {
+			.card.flex-container {
+				padding-right: $checkbox-right-card-padding;
+			}
+
+			> .card-row {
+				padding-right: $checkbox-right-card-padding;
+			}
+		}
+	}
+
+	.checkbox-bottom-left input[type='checkbox'],
+	.checkbox-bottom-left label > input[type='checkbox'],
+	.radio-bottom-left input[type='radio'],
+	.radio-bottom-left label > input[type='radio'] {
+		bottom: $checkbox-position;
+		left: $checkbox-position;
+		transform: none;
+	}
+
+	.checkbox-bottom-right input[type='checkbox'],
+	.checkbox-bottom-right label > input[type='checkbox'],
+	.radio-bottom-right input[type='radio'],
+	.radio-bottom-right label > input[type='radio'] {
+		bottom: $checkbox-position;
+		right: $checkbox-position;
+		transform: none;
+	}
+
+	.checkbox-middle-left input[type='checkbox'],
+	.checkbox-middle-left label > input[type='checkbox'],
+	.radio-middle-left input[type='radio'],
+	.radio-middle-left label > input[type='radio'] {
+		left: $checkbox-position;
+		margin-top: 0;
+		top: 50%;
+		transform: translateY(-50%);
+	}
+
+	.checkbox-middle-right input[type='checkbox'],
+	.checkbox-middle-right label > input[type='checkbox'],
+	.radio-middle-right input[type='radio'],
+	.radio-middle-right label > input[type='radio'] {
+		margin-top: 0;
+		right: $checkbox-position;
+		top: 50%;
+		transform: translateY(-50%);
+	}
+
+	.checkbox-top-left label > input[type='checkbox'],
+	.radio-top-left label > input[type='radio'] {
+		left: $checkbox-position;
+		top: $checkbox-position;
+		transform: none;
+	}
+
+	.checkbox-top-right label > input[type='checkbox'],
+	.radio-top-right label > input[type='radio'] {
+		right: $checkbox-position;
+		top: $checkbox-position;
+		transform: none;
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_component_animations.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_component_animations.scss
@@ -1,0 +1,17 @@
+@if $compat-component_animations {
+	.collapse.in {
+		display: block;
+	}
+
+	tr.collapse.in {
+		display: table-row;
+	}
+
+	tbody.collapse.in {
+		display: table-row-group;
+	}
+
+	.fade.in {
+		opacity: 1;
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_dropdowns.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_dropdowns.scss
@@ -1,0 +1,98 @@
+.dropdown.open > .dropdown-menu,
+.overlay-content .open > .dropdown-menu {
+	display: block;
+}
+
+@if $compat-dropdowns {
+	// Moved .caret to .dropdown-toggle:after in BS4
+
+	.caret {
+		border-top: $caret-width dashed;
+		display: inline-block;
+		height: 0;
+		margin-left: 2px;
+		vertical-align: middle;
+		width: 0;
+		border-top: $caret-width solid \9; // IE8
+		border-left: $caret-width solid transparent;
+		border-right: $caret-width solid transparent;
+	}
+
+	.dropdown-menu {
+		border: 1px solid $dropdown-border-color;
+	}
+
+	// Moved .dropdown-menu > li > a to .dropdown-item in BS4
+
+	.dropdown-menu > li > a,
+	.dropdown-menu .link-list > li > a {
+		@extend .dropdown-item;
+	}
+
+	.dropdown-menu > li.disabled > a,
+	.dropdown-menu .link-list > .disabled > a {
+		$disabled: setter(map-get($dropdown-item-base, disabled), ());
+		$disabled: map-merge(
+			$disabled,
+			(
+				background-color:
+					setter(
+						map-get($dropdown-item-base, disabled-bg),
+						map-get($disabled, background-color)
+					),
+				border-color:
+					setter(
+						map-get($dropdown-item-base, disabled-border-color),
+						map-get($disabled, border-color)
+					),
+				box-shadow:
+					setter(
+						map-get($dropdown-item-base, disabled-box-shadow),
+						map-get($disabled, box-shadow)
+					),
+				color:
+					setter(map-get($dropdown-item-base, disabled-color), map-get($disabled, color)),
+				cursor:
+					setter(
+						map-get($dropdown-item-base, disabled-cursor),
+						map-get($disabled, cursor)
+					),
+				opacity:
+					setter(
+						map-get($dropdown-item-base, disabled-opacity),
+						map-get($disabled, opacity)
+					),
+				outline:
+					setter(
+						map-get($dropdown-item-base, disabled-outline),
+						map-get($disabled, outline)
+					),
+				pointer-events:
+					setter(
+						map-get($dropdown-item-base, disabled-pointer-events),
+						map-get($disabled, pointer-events)
+					),
+				text-decoration:
+					setter(
+						map-get($dropdown-item-base, disabled-text-decoration),
+						map-get($disabled, text-decoration)
+					),
+			)
+		);
+		@include clay-css($disabled);
+	}
+
+	.dropdown-toggle:after {
+		border-width: 0;
+		content: normal;
+	}
+
+	.dropup .dropdown-toggle:after {
+		border-width: 0;
+		content: normal;
+	}
+
+	.dropdown > .dropdown-menu {
+		position: absolute;
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_figures.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_figures.scss
@@ -1,0 +1,5 @@
+@if $compat-figures {
+	.figure {
+		display: block;
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_form_validation.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_form_validation.scss
@@ -1,0 +1,54 @@
+.help-block {
+	color: lighten($body-color, 25%); // lighten the text some for contrast
+	display: block; // account for any element using help-block
+	font-size: 0.875rem;
+	margin-bottom: 10px;
+	margin-top: 5px;
+}
+
+.has-error {
+	.cke {
+		border-color: $form-feedback-invalid-color;
+	}
+
+	.help-block {
+		color: $form-feedback-invalid-color;
+	}
+}
+
+.has-warning .help-block {
+	color: $form-feedback-warning-color;
+}
+
+.has-success .help-block {
+	color: $form-feedback-valid-color;
+}
+
+@if $compat-form_validation {
+	.has-feedback {
+		position: relative;
+
+		label,
+		.form-control {
+			+ .form-control-feedback {
+				position: absolute;
+				top: (
+					$line-height-base + 5
+				); // Height of the `label` and its margin
+				right: 0;
+				z-index: 2; // Ensure icon is above input groups
+				display: block;
+				height: $input-height;
+				line-height: $input-height;
+				margin-top: 0;
+				pointer-events: none;
+				text-align: center;
+				width: $input-height;
+			}
+
+			&.sr-only ~ .form-control-feedback {
+				top: 0;
+			}
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_forms.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_forms.scss
@@ -1,0 +1,291 @@
+@if $compat-forms {
+	label {
+		max-width: 100%;
+	}
+
+	// Indent the labels to position radios/checkboxes as hanging controls.
+
+	.radio,
+	.checkbox {
+		display: block;
+		margin-bottom: 10px;
+		margin-top: 10px;
+		position: relative;
+
+		label {
+			min-height: 24px; // Ensure the input doesn't jump when there is no text
+			cursor: pointer;
+			font-weight: normal;
+			margin-bottom: 0;
+			padding-left: 20px;
+		}
+	}
+
+	.radio input[type='radio'],
+	.radio-inline input[type='radio'],
+	.checkbox input[type='checkbox'],
+	.checkbox-inline input[type='checkbox'] {
+		margin-left: -20px;
+		margin-top: 4px \9;
+		position: absolute;
+	}
+
+	.radio + .radio,
+	.checkbox + .checkbox {
+		margin-top: -5px; // Move up sibling radios or checkboxes for tighter spacing
+	}
+
+	// Radios and checkboxes on same line
+
+	.radio-inline,
+	.checkbox-inline {
+		cursor: pointer;
+		display: inline-block;
+		font-weight: normal;
+		margin-bottom: 0;
+		padding-left: 20px;
+		position: relative;
+		vertical-align: middle;
+	}
+
+	.radio-inline + .radio-inline,
+	.checkbox-inline + .checkbox-inline {
+		margin-top: 0;
+		margin-left: 10px; // space out consecutive inline controls
+	}
+
+	@if (variable-exists(atlas-theme)) {
+		// Checkbox and Radio Styles
+
+		.checkbox,
+		.radio {
+			label {
+				font-weight: $input-label-font-weight;
+				padding-left: 25px;
+
+				@media (-webkit-min-device-pixel-ratio: 0) {
+					padding-left: 20px;
+				}
+			}
+		}
+
+		.checkbox input[type='checkbox'],
+		.checkbox-inline input[type='checkbox'] {
+			height: 20px;
+			margin-left: -25px;
+			margin-top: 0;
+			top: 50%;
+			transform: translateY(-50%);
+			width: 20px;
+
+			@media (-webkit-min-device-pixel-ratio: 0) {
+				height: 14px;
+				margin-left: -20px;
+				width: 14px;
+			}
+		}
+
+		.radio input[type='radio'],
+		.radio-inline input[type='radio'] {
+			height: 20px;
+			margin-left: -25px;
+			margin-top: 0;
+			top: 50%;
+			transform: translateY(-50%);
+			width: 20px;
+
+			@media (-webkit-min-device-pixel-ratio: 0) {
+				height: 15px;
+				margin-left: -20px;
+				width: 14px;
+			}
+		}
+
+		.checkbox-card,
+		.radio-card {
+			label {
+				padding-left: 0;
+			}
+		}
+
+		.checkbox-card input[type='checkbox'],
+		.radio-card input[type='radio'] {
+			margin-left: 0;
+		}
+	}
+
+	@if (variable-exists(atlas-theme)) {
+		.input-group-lg > .form-control {
+			@extend .input-lg;
+		}
+
+		.input-group-sm > .form-control {
+			@extend .input-sm;
+		}
+	}
+
+	.form-horizontal > .form-group {
+		@extend .row;
+	}
+
+	.form-inline label {
+		display: inline-block;
+	}
+
+	.input-lg {
+		@extend .form-control-lg;
+	}
+
+	.input-sm {
+		@extend .form-control-sm;
+	}
+
+	fieldset {
+		width: 100%;
+	}
+
+	// ---------- Input group ----------
+
+	.input-group .form-validator-stack {
+		order: 10;
+		width: 100%;
+	}
+
+	.input-group-addon {
+		align-items: center;
+		background-color: $input-group-addon-bg;
+		border-color: $input-group-addon-border-color;
+
+		@include border-radius($input-border-radius);
+
+		border-style: solid;
+		border-width: $input-border-width;
+		color: $input-group-addon-color;
+		display: flex;
+		font-size: $font-size-base;
+		font-weight: $input-group-addon-font-weight;
+		height: $input-height;
+		justify-content: center;
+		line-height: $input-line-height;
+		margin-bottom: 0;
+		min-width: $input-group-addon-min-width;
+		padding-bottom: 0;
+		padding-left: setter($input-group-addon-padding-x, $input-padding-x);
+		padding-right: setter($input-group-addon-padding-x, $input-padding-x);
+		padding-top: 0;
+		text-align: center;
+		white-space: nowrap;
+
+		@include clay-scale-component {
+			height: $input-height-mobile;
+		}
+
+		.custom-control,
+		.form-check {
+			margin-bottom: 0;
+		}
+
+		input[type='radio'],
+		input[type='checkbox'] {
+			margin-top: 0;
+		}
+
+		label {
+			color: $input-group-addon-color;
+		}
+	}
+
+	.input-group-btn {
+		display: flex;
+
+		.btn + .btn {
+			margin-left: -$btn-border-width;
+		}
+	}
+
+	.input-group-addon:first-child,
+	.input-group-btn:first-child > .btn,
+	.input-group-btn:first-child > .btn-group > .btn,
+	.input-group-btn:first-child > .dropdown-toggle,
+	.input-group-btn:last-child > .btn:not(:last-child):not(.dropdown-toggle),
+	.input-group-btn:last-child > .btn-group:not(:last-child) > .btn {
+		@include border-right-radius(0);
+	}
+
+	.input-group-addon:first-child {
+		border-right: 0;
+	}
+
+	.input-group-addon:last-child,
+	.input-group-btn:last-child > .btn,
+	.input-group-btn:last-child > .btn-group > .btn,
+	.input-group-btn:last-child > .dropdown-toggle,
+	.input-group-btn:first-child > .btn:not(:first-child),
+	.input-group-btn:first-child > .btn-group:not(:first-child) > .btn {
+		@include border-left-radius(0);
+	}
+
+	.input-group-addon:last-child {
+		border-left: 0;
+	}
+
+	.form-control {
+		+ .input-group-btn,
+		+ .input-group-input {
+			margin-left: -$input-border-right-width;
+		}
+
+		&[type='file'] {
+			background: transparent;
+			border-color: transparent;
+			padding: 0;
+		}
+	}
+
+	.input-group-input {
+		+ .input-group-btn {
+			margin-left: -$input-border-right-width;
+		}
+	}
+
+	.input-group-insert {
+		@include border-radius(0);
+
+		margin-left: -$input-border-right-width;
+
+		+ .input-group-addon,
+		+ .input-group-btn,
+		+ .input-group-input,
+		+ .form-control {
+			margin-left: -$input-border-right-width;
+		}
+	}
+
+	.input-group-constrain {
+		align-self: flex-start;
+		max-width: 9.375rem;
+		overflow-x: auto;
+		overflow-y: hidden;
+		padding-right: 0.125rem;
+
+		@include media-breakpoint-up(sm) {
+			max-width: 18.75rem;
+		}
+	}
+
+	.input-group-addon .input-group-constrain {
+		border-bottom-width: 0;
+		display: block;
+		line-height: $input-height-inner;
+		margin-left: -(setter($input-group-addon-padding-x, $input-padding-x));
+		margin-right: -(setter($input-group-addon-padding-x, $input-padding-x));
+		padding-left: setter($input-group-addon-padding-x, $input-padding-x);
+		padding-right: setter($input-group-addon-padding-x, $input-padding-x);
+	}
+
+	.form-group-item {
+		> .form-group {
+			margin-bottom: 0;
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_grid.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_grid.scss
@@ -1,0 +1,43 @@
+@if $compat-grid {
+	// Renamed .col-xs-* to .col-*
+
+	@for $i from 1 through $grid-columns {
+		.col-xs-#{$i} {
+			@extend .col-#{$i};
+		}
+	}
+
+	[class*='-offset-'] {
+		@extend .mx-auto;
+	}
+
+	.container-fluid-1280 {
+		@include clearfix();
+
+		margin-left: auto;
+		margin-right: auto;
+		max-width: 1280px;
+		padding-left: $grid-gutter-width / 2;
+		padding-right: $grid-gutter-width / 2;
+		width: 100%;
+	}
+
+	// Image
+	// Renamed .img-responsive to .img-fluid
+
+	.img-responsive {
+		@include img-fluid();
+	}
+
+	// Renamed .img-circle to .rounded-circle
+
+	.img-circle {
+		@extend .rounded-circle;
+	}
+
+	// Renamed .img-rounded to .rounded
+
+	.img-rounded {
+		@extend .rounded;
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_icons.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_icons.scss
@@ -1,0 +1,50 @@
+@if $compat-icons {
+	.icon-monospaced {
+		&,
+		&[class^='icon-'],
+		&[class*=' icon-'] {
+			color: inherit;
+			display: inline-block;
+			height: $icon-monospaced-size;
+			line-height: 34px;
+			text-align: center;
+			width: $icon-monospaced-size;
+		}
+	}
+
+	.icon-monospaced.lexicon-icon {
+		padding: 8px;
+	}
+
+	.btn-monospaced > .icon-monospaced:not(.lexicon-icon) {
+		padding: 0;
+	}
+
+	.help-icon {
+		border-radius: 100px;
+		display: inline-block;
+
+		@include monospace($icon-monospaced-size);
+
+		text-align: center;
+
+		&:hover,
+		&:focus {
+			text-decoration: none;
+		}
+
+		&.icon-monospaced {
+			vertical-align: baseline;
+		}
+	}
+
+	.help-icon-default {
+		background-color: $help-icon-default-bg;
+		color: $help-icon-default-color;
+
+		&:focus,
+		&:hover {
+			color: $help-icon-default-hover-color;
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_labels.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_labels.scss
@@ -1,0 +1,27 @@
+@if $compat-labels {
+	.label {
+		&.approved {
+			@extend .label-success;
+		}
+
+		&.denied {
+			@extend .label-danger;
+		}
+
+		&.draft {
+			@extend .label-secondary;
+		}
+
+		&.expired {
+			@extend .label-warning;
+		}
+
+		&.pending {
+			@extend .label-info;
+		}
+
+		&.scheduled {
+			@extend .label-primary;
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_liferay.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_liferay.scss
@@ -1,0 +1,166 @@
+@if $compat-liferay {
+	#navigationCollapse {
+		padding-left: $navbar-padding-x;
+		padding-right: $navbar-padding-x;
+
+		@include media-breakpoint-up(md) {
+			display: block;
+		}
+	}
+
+	#banner .row:first-child {
+		display: block;
+	}
+
+	.product-menu.sidebar {
+		.sidebar-header {
+			padding-bottom: 0.7rem;
+			padding-top: 0.7rem;
+		}
+	}
+
+	.product-menu.sidebar .sidebar-body,
+	.lfr-has-simulation-panel .lfr-simulation-device {
+		top: 3.5rem;
+	}
+
+	.product-menu.sidebar .lfr-applications-menu .sidebar-body {
+		top: 0;
+	}
+
+	.product-menu .add-application-panel .panel-body {
+		padding-bottom: 0.01rem;
+	}
+
+	.lfr-page-layouts.row .list-unstyled {
+		display: flex;
+		flex-wrap: wrap;
+	}
+
+	.fade.in {
+		opacity: 1;
+	}
+
+	.lfr-add-panel .input-group.search-bar {
+		margin: 0;
+		padding: 10px;
+
+		.form-control {
+			width: 100%;
+		}
+
+		.input-group-btn {
+			font-size: 1rem;
+			margin-top: -11px;
+		}
+	}
+
+	.input-group.search-bar {
+		.search-field {
+			display: flex;
+
+			&:first-child {
+				flex-grow: 1;
+			}
+
+			.btn {
+				margin-top: 0;
+			}
+
+			.form-group {
+				margin-bottom: 0;
+			}
+
+			.search-bar-input {
+				@include border-right-radius(0);
+			}
+
+			~ .search-field {
+				margin-left: -$input-border-right-width;
+			}
+		}
+
+		.search-select {
+			@include border-radius(0);
+
+			width: 100%;
+		}
+	}
+
+	// ---------- Modals ----------
+
+	.dialog-with-footer .button-holder.dialog-footer {
+		background-color: $modal-content-bg;
+	}
+
+	// ---------- Friendly URL ----------
+
+	.lfr-friendly-url-input-group.input-group {
+		.input-group-addon {
+			background-color: #e8e8ec;
+		}
+
+		.language-value {
+			border-radius: 0 0.25rem 0.25rem 0;
+			width: auto;
+		}
+	}
+
+	// ---------- Forms builder ----------
+
+	#settings .lfr-ddm-form-page {
+		margin-top: 0;
+	}
+
+	.autosave-bar .toolbar {
+		align-items: center;
+	}
+
+	.form-builder-sidebar {
+		.tab-content .tab-pane {
+			padding: 24px;
+			position: static;
+		}
+
+		.input-group-container {
+			display: flex;
+
+			.input-group-addon {
+				background-color: transparent;
+				border-width: 0;
+			}
+		}
+	}
+
+	.form-builder-page-header {
+		.form-control {
+			background-color: transparent;
+		}
+	}
+
+	.form-builder-field {
+		.input-group .form-control {
+			z-index: 0;
+		}
+	}
+
+	.help-icon.icon-monospaced {
+		line-height: 2;
+	}
+
+	.layout-row-container-row
+		.layout-builder-move-cut-button.layout-builder-move-cut-row-button {
+		right: 30px;
+		top: -22px;
+	}
+
+	// ---------- Portlet forms ----------
+
+	.portal-popup,
+	.portlet-forms-admin {
+		.asset-icon .sticker .lexicon-icon {
+			height: 100%;
+			width: 1em;
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_list_groups.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_list_groups.scss
@@ -1,0 +1,152 @@
+@if $compat-list_groups {
+	.list-group-heading {
+		background-color: $list-group-header-bg;
+		border-color: $list-group-border;
+		border-style: solid;
+		border-width: $list-group-border-width;
+		color: $list-group-header-color;
+		display: block;
+		font-weight: $list-group-header-font-weight;
+		margin-bottom: -1px;
+		overflow: hidden;
+		padding: 10px 15px;
+		position: relative;
+		word-wrap: break-word;
+
+		@if (variable-exists(atlas-theme)) {
+			margin-bottom: 0;
+
+			&:after {
+				background-color: $list-group-header-open-border-color;
+				bottom: 0;
+				content: '';
+				display: block;
+				height: $list-group-header-open-border-width;
+				left: 0;
+				position: absolute;
+				right: 0;
+			}
+
+			&:after:focus {
+				z-index: -1;
+			}
+
+			&.collapsed {
+				font-weight: 300;
+
+				&:after {
+					background-color: $list-group-header-close-border-color;
+					height: $list-group-header-close-border-width;
+				}
+			}
+		}
+
+		&:focus {
+			background-color: $list-group-header-bg;
+			color: $list-group-header-hover-color;
+			text-decoration: none;
+			z-index: 1;
+		}
+
+		&:hover {
+			background-color: $list-group-header-bg;
+			color: $list-group-header-hover-color;
+			text-decoration: none;
+		}
+
+		&:first-child {
+			border-top-left-radius: $list-group-border-radius;
+			border-top-right-radius: $list-group-border-radius;
+		}
+
+		&:last-child {
+			border-bottom-left-radius: $list-group-border-radius;
+			border-bottom-right-radius: $list-group-border-radius;
+			margin-bottom: 0;
+		}
+	}
+
+	button.list-group-heading {
+		text-align: left;
+		width: 100%;
+	}
+
+	// Tabular List Group
+
+	.list-group-item-field {
+		display: table-cell;
+		padding: $table-cell-padding;
+		position: relative;
+		text-align: center;
+		vertical-align: top;
+		width: 1%;
+		word-wrap: break-word;
+
+		> .checkbox,
+		> .radio {
+			margin-bottom: 0;
+			margin-top: 0;
+		}
+	}
+
+	.list-group-item-content {
+		display: table-cell;
+		max-width: 100px;
+		min-width: 100px;
+		padding: $table-cell-padding;
+		position: relative;
+		vertical-align: top;
+		word-wrap: break-word;
+
+		&.clamp-horizontal {
+			.clamp-container {
+				transform: none;
+			}
+		}
+
+		&.clamp-all {
+			.clamp-container {
+				padding-top: 1em;
+			}
+		}
+
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6 {
+			margin: 0.5em 0;
+
+			&:first-child {
+				margin-top: 0;
+			}
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+	}
+
+	.tabular-list-group {
+		display: table;
+		margin-bottom: 20px;
+		padding: 0;
+		width: 100%;
+	}
+
+	.tabular-list-group-unstyled {
+		list-style: none;
+		padding-left: 0;
+
+		.list-group-item {
+			border-width: 0;
+			padding: 0;
+		}
+
+		.list-group-item-content,
+		.list-group-item-field {
+			padding: 0;
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_management_bar.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_management_bar.scss
@@ -1,0 +1,572 @@
+@if $compat-management_bar {
+	.management-bar {
+		@include clearfix;
+
+		margin-bottom: $management-bar-margin-bottom;
+		min-height: $management-bar-height;
+		position: relative;
+
+		& + .subnav-tbar-primary {
+			margin-bottom: $management-bar-margin-bottom;
+			margin-top: -$management-bar-margin-bottom;
+		}
+
+		.add-menu {
+			z-index: inherit;
+		}
+
+		.btn-action,
+		.btn-action-secondary > .btn {
+			color: #fff;
+			height: 2.1rem;
+			line-height: 2.1rem;
+			width: 2.1rem;
+		}
+
+		.checkbox,
+		.radio {
+			margin-bottom: 0;
+			margin-top: 0;
+
+			label {
+				display: block;
+			}
+		}
+
+		.input-checkbox-wrapper {
+			position: static;
+		}
+
+		@if (variable-exists(atlas-theme)) {
+			.btn-link {
+				color: $nav-link-color;
+			}
+		}
+	}
+
+	.management-bar .management-bar-nav > li > .btn,
+	.management-bar .management-bar-nav > .dropdown > .btn,
+	.management-bar-header > .btn,
+	.management-bar-header-right > .btn,
+	.management-bar-header > .dropdown,
+	.management-bar-header-right > .dropdown {
+		margin: $management-bar-btn-padding-vertical
+			0
+			$management-bar-btn-padding-vertical
+			$management-bar-btn-padding-horizontal;
+		padding: 0;
+
+		@if (variable-exists(atlas-theme)) {
+			@include media-breakpoint-up(md) {
+				margin: 13px 0 13px 15px;
+			}
+		}
+	}
+
+	.management-bar-header > .dropdown,
+	.management-bar-header-right > .dropdown {
+		float: left;
+
+		> a {
+			padding: 0;
+		}
+	}
+
+	// management bar headers
+
+	.container,
+	.container-fluid {
+		> .management-bar-header,
+		> .management-bar-collapse {
+			margin-left: -$management-bar-padding-horizontal;
+			margin-right: -$management-bar-padding-horizontal;
+
+			@include media-breakpoint-up(md) {
+				margin-left: 0;
+				margin-right: 0;
+			}
+		}
+	}
+
+	.container-fluid-1280 .management-bar-header-right {
+		margin-right: 0;
+		position: relative;
+	}
+
+	.management-bar-header > .checkbox,
+	.management-bar-header > .radio,
+	.management-bar-header-right > .checkbox,
+	.management-bar-header-right > .radio,
+	.management-bar-nav > li > .checkbox,
+	.management-bar-nav > li > .radio {
+		float: left;
+		padding-bottom: (
+			(
+					$management-bar-height -
+						1.5rem -
+						$management-bar-border-bottom-width -
+						$management-bar-border-top-width
+				) /
+				2
+		);
+		padding-left: $management-bar-padding-horizontal;
+		padding-right: 0;
+		padding-top: (
+			(
+					$management-bar-height -
+						1.5rem -
+						$management-bar-border-bottom-width -
+						$management-bar-border-top-width
+				) /
+				2
+		);
+
+		@if (variable-exists(atlas-theme)) {
+			@include media-breakpoint-up(md) {
+				padding-bottom: 18px;
+				padding-top: 18px;
+			}
+		}
+	}
+
+	.management-bar-nav > li {
+		> .basic-search,
+		> .form {
+			padding-left: 20px;
+			padding-top: 12px;
+
+			.input-group-btn .btn-secondary {
+				background-color: #f1f2f5;
+				border-color: #e7e7ed;
+			}
+
+			.form-control {
+				border-right-color: transparent;
+				width: 100%;
+			}
+		}
+	}
+
+	.management-bar-nav .basic-search-slider {
+		left: inherit;
+
+		.basic-search-close {
+			display: none;
+		}
+	}
+
+	.management-bar-header {
+		@include clearfix;
+
+		float: left;
+	}
+
+	.management-bar-header-right {
+		float: right;
+		margin-right: $management-bar-padding-horizontal;
+
+		> a,
+		> span {
+			display: block;
+			float: left;
+			padding: $management-bar-padding-vertical
+				$management-bar-padding-horizontal;
+
+			@if (variable-exists(atlas-theme)) {
+				@include media-breakpoint-up(md) {
+					padding-bottom: $management-bar-desktop-padding-vertical;
+					padding-top: $management-bar-desktop-padding-vertical;
+				}
+			}
+		}
+
+		.btn-secondary:not([disabled]):not(.disabled).active {
+			border-color: transparent;
+		}
+	}
+
+	.management-bar-header-item {
+		float: left;
+		height: $management-bar-height;
+		padding: $management-bar-padding-vertical
+			$management-bar-padding-horizontal;
+
+		&:hover,
+		&:focus {
+			text-decoration: none;
+		}
+
+		> img {
+			display: block;
+		}
+
+		.management-bar > .container &,
+		.management-bar > .container-fluid & {
+			@include media-breakpoint-up(md) {
+				margin-left: -$management-bar-padding-horizontal;
+			}
+		}
+	}
+
+	.management-bar-item-title {
+		display: inline-block;
+		float: left;
+		margin-right: 5px;
+		max-width: 100%;
+
+		@include text-truncate;
+
+		@include media-breakpoint-up(md) {
+			max-width: 180px;
+		}
+	}
+
+	.management-bar-toggle {
+		background-color: transparent;
+		background-image: none;
+		border: 1px solid transparent;
+		border-radius: $border-radius;
+		float: right;
+		margin-right: $management-bar-padding-horizontal;
+		padding: 9px 10px;
+		position: relative;
+
+		@include media-breakpoint-up(md) {
+			display: none;
+		}
+
+		&:focus {
+			outline: 0;
+		}
+	}
+
+	.management-bar-toggle-link {
+		border-radius: 0;
+		border-width: 0;
+
+		&.management-bar-toggle {
+			margin: 0;
+			padding: $management-bar-padding-vertical
+				$management-bar-padding-horizontal;
+		}
+
+		&:focus,
+		&:hover {
+			//background-color: $nav-link-hover-bg;
+			text-decoration: none;
+		}
+	}
+
+	.management-bar-toggle-left {
+		float: left;
+
+		//margin: floor(($navbar-height - $input-height) / 2) $navbar-padding-x;
+		padding: 0.375rem 10px;
+	}
+
+	// management bar collapse
+
+	.management-bar-collapse {
+		-webkit-overflow-scrolling: touch;
+		border-top: 1px solid transparent;
+
+		@include clearfix;
+
+		overflow-x: visible;
+		padding-left: $management-bar-padding-horizontal;
+		padding-right: $management-bar-padding-horizontal;
+
+		@include media-breakpoint-down(sm) {
+			background-color: $management-bar-collapse-bg;
+			border-color: $management-bar-collapse-border;
+			border-style: solid;
+			border-width: $management-bar-border-width;
+
+			@if (variable-exists(atlas-theme)) {
+				border-width: 1px 0;
+				box-shadow: 0 2px 3px -2px rgba(0, 0, 0, 0.7);
+			}
+
+			clear: both;
+			left: -$management-bar-border-left-width;
+			position: absolute;
+			right: -$management-bar-border-right-width;
+			top: 100%;
+			z-index: 1001;
+		}
+
+		@include media-breakpoint-up(md) {
+			border-top-width: 0;
+			box-shadow: none;
+			clear: none;
+			float: left;
+			margin-top: 0;
+			padding-left: 0;
+			padding-right: 0;
+			position: static;
+			width: auto;
+		}
+
+		&.collapse {
+			@include media-breakpoint-up(md) {
+				display: block !important;
+				height: auto !important;
+				overflow: visible !important;
+				padding-bottom: 0;
+			}
+		}
+
+		&.in {
+			overflow-y: auto;
+
+			@include media-breakpoint-up(md) {
+				overflow-y: visible;
+			}
+		}
+
+		.management-bar-nav > .dropdown {
+			> .dropdown-toggle {
+				display: flex;
+			}
+
+			> .dropdown-menu {
+				@include media-breakpoint-down($scaling-breakpoint-down) {
+					position: relative !important;
+					transform: none !important;
+				}
+			}
+		}
+	}
+
+	.management-bar-nav {
+		margin: ($management-bar-padding-vertical / 2)
+			(-$management-bar-padding-horizontal);
+
+		@include media-breakpoint-up(md) {
+			float: left;
+			margin: 0;
+		}
+
+		> li {
+			@include media-breakpoint-up(md) {
+				float: left;
+			}
+
+			> a,
+			> span {
+				display: block;
+				padding: $management-bar-padding-vertical
+					$management-bar-padding-horizontal;
+
+				@if (variable-exists(atlas-theme)) {
+					@include media-breakpoint-up(md) {
+						padding-bottom: 19.5px;
+						padding-top: 19.5px;
+					}
+				}
+			}
+
+			> .dropdown-menu {
+				@include border-top-radius(0);
+
+				margin-top: $management-bar-dropdown-menu-margin-top;
+			}
+		}
+
+		.open .dropdown-menu {
+			@include media-breakpoint-down(sm) {
+				background-color: transparent;
+				border-width: 0;
+				box-shadow: none;
+				float: none;
+				margin-top: 0;
+				max-width: none;
+				position: static;
+				width: auto;
+			}
+
+			> li > a,
+			.dropdown-header {
+				@include media-breakpoint-down(sm) {
+					padding: 5px 15px 5px 25px;
+				}
+			}
+
+			> li > a {
+				&:hover,
+				&:focus {
+					@include media-breakpoint-down(sm) {
+						background-image: none;
+					}
+				}
+			}
+		}
+	}
+
+	.management-bar-no-collapse {
+		.management-bar-nav {
+			float: left;
+			margin: 0;
+
+			> li {
+				float: left;
+				margin-left: -1px;
+
+				&:first-child {
+					margin-left: 0;
+				}
+			}
+
+			.dropdown-menu {
+				background-color: $dropdown-bg;
+				border-color: $dropdown-border-color;
+				border-style: $dropdown-border-style;
+				border-width: $dropdown-border-width;
+				box-shadow: $dropdown-box-shadow;
+				position: absolute;
+			}
+		}
+
+		.management-bar-nav-right {
+			float: right;
+			margin-right: $management-bar-padding-horizontal;
+		}
+	}
+
+	.management-bar-no-collapse .container-fluid-1280 {
+		.management-bar-nav-right {
+			margin-right: 0;
+		}
+	}
+
+	// Management Bar Skins
+
+	.management-bar-default {
+		.management-bar-collapse {
+			border-color: $management-bar-default-border;
+
+			@include media-breakpoint-down(sm) {
+				background-color: $management-bar-default-collapse-bg;
+				border-color: $management-bar-default-collapse-border;
+			}
+		}
+
+		.management-bar-toggle-left {
+			color: $management-bar-default-link-active-color;
+		}
+	}
+
+	.management-bar-default {
+		background-color: $management-bar-default-bg;
+		border-color: $management-bar-default-border;
+		box-shadow: $management-bar-default-box-shadow;
+
+		a,
+		.management-bar-text,
+		.management-bar-nav > li > a,
+		.management-bar-nav > .dropdown > a {
+			color: $management-bar-default-link-color;
+		}
+
+		.management-bar-nav {
+			> li > a:hover,
+			> .dropdown > a:hover {
+				background-color: $management-bar-default-link-hover-bg;
+				color: $management-bar-default-link-hover-color;
+			}
+
+			> li > a:focus,
+			> .dropdown > a:focus,
+			.open > a,
+			.open > a:focus,
+			.open > a:hover {
+				background-color: $management-bar-default-link-active-bg;
+				color: $management-bar-default-link-active-color;
+			}
+
+			> .disabled > a {
+				&,
+				&:focus,
+				&:hover {
+					background-color: $management-bar-default-link-disabled-bg;
+					color: $management-bar-default-link-disabled-color;
+				}
+			}
+		}
+	}
+
+	// Management Bar Default Btn Default
+
+	.management-bar-default {
+		.btn-secondary,
+		.nav > li > .btn-secondary {
+			background-color: $management-bar-default-btn-secondary-bg;
+			border-color: $management-bar-default-btn-secondary-border;
+			color: $management-bar-default-btn-secondary-color;
+
+			&:focus,
+			&:hover {
+				background-color: $management-bar-default-btn-secondary-hover-bg;
+				border-color: $management-bar-default-btn-secondary-hover-border;
+				color: $management-bar-default-btn-secondary-hover-color;
+			}
+
+			&:active,
+			&.active {
+				background-color: $management-bar-default-btn-secondary-active-bg;
+				border-color: $management-bar-default-btn-secondary-active-border;
+				color: $management-bar-default-btn-secondary-active-color;
+			}
+		}
+
+		@if (variable-exists(atlas-theme)) {
+			.dropdown.open .btn-secondary {
+				&,
+				&:focus {
+					background-color: $management-bar-default-btn-secondary-active-bg;
+					border-color: $management-bar-default-btn-secondary-active-border;
+					color: $management-bar-default-btn-secondary-active-color;
+				}
+			}
+		}
+	}
+
+	.management-bar-nav {
+		display: block;
+
+		> li {
+			@include media-breakpoint-down(sm) {
+				display: block;
+			}
+		}
+
+		.dropdown-menu {
+			@include media-breakpoint-down(sm) {
+				background-color: transparent;
+				border-width: 0;
+				box-shadow: none;
+				max-width: none;
+				position: relative;
+				width: 100%;
+			}
+		}
+	}
+
+	.management-bar-header .form-inline input[type='checkbox'] {
+		margin-left: -1.25rem;
+	}
+
+	@if (variable-exists(atlas-theme)) {
+		@include media-breakpoint-up(md) {
+			.management-bar-nav > li > .dropdown-toggle {
+				padding-bottom: $management-bar-desktop-padding-vertical;
+				padding-top: $management-bar-desktop-padding-vertical;
+			}
+		}
+	}
+
+	.management-bar-secondary-bar {
+		background-color: #f0f5ff;
+		border-bottom: 1px solid $primary;
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_modals.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_modals.scss
@@ -1,0 +1,68 @@
+@if $compat-modals {
+	.modal-header {
+		.btn-toolbar {
+			@extend .order-2;
+		}
+
+		.btn-toolbar + .modal-title {
+			@extend .order-1;
+		}
+	}
+
+	.modal-footer > .btn-toolbar {
+		& > :not(:first-child) {
+			margin-left: 0.25rem;
+		}
+
+		& > :not(:last-child) {
+			margin-right: 0.25rem;
+		}
+	}
+
+	// LPS-109615
+
+	.modal-content .modal-footer .btn-toolbar {
+		margin-left: auto;
+	}
+
+	// LPS-113239
+
+	.modal-md {
+		max-width: $modal-md;
+	}
+
+	// LPS-97981
+
+	@include media-breakpoint-up(sm) {
+		.modal-dialog {
+			&.modal-lg,
+			&.modal-md,
+			&.modal-sm,
+			&.modal-xl {
+				max-width: $modal-md;
+				position: relative;
+			}
+		}
+
+		.modal-dialog.modal-sm {
+			max-width: $modal-sm;
+		}
+	}
+
+	.modal-dialog {
+		&.modal-lg,
+		&.modal-xl {
+			@include media-breakpoint-up(lg) {
+				max-width: $modal-lg;
+			}
+		}
+	}
+
+	.modal-dialog {
+		&.modal-xl {
+			@include media-breakpoint-up(xl) {
+				max-width: $modal-xl;
+			}
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_nav_tabs.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_nav_tabs.scss
@@ -1,0 +1,96 @@
+@if $compat-nav_tabs {
+	.nav-tabs {
+		flex-direction: row;
+	}
+
+	.nav-tabs > li {
+		margin-bottom: -$nav-tabs-border-width;
+
+		> a {
+			border: $nav-tabs-border-width solid transparent;
+
+			@include border-top-radius($border-radius);
+
+			@include hover-focus {
+				border-color: $nav-tabs-link-hover-border-color
+					$nav-tabs-link-hover-border-color $nav-tabs-border-color;
+			}
+		}
+	}
+
+	.nav-tabs > li > a.active,
+	.nav-tabs > .active > a {
+		background-color: $nav-tabs-link-active-bg;
+		border-color: $nav-tabs-link-active-border-color
+			$nav-tabs-link-active-border-color
+			$nav-tabs-link-active-bg;
+		color: $nav-tabs-link-active-color;
+
+		@include hover-focus {
+			border-color: $nav-tabs-link-active-border-color
+				$nav-tabs-link-active-border-color $nav-tabs-link-active-bg;
+		}
+	}
+
+	.nav-tabs-default {
+		font-size: $nav-underline-font-size;
+
+		> li > a {
+			color: $nav-underline-link-color;
+			padding: $nav-underline-link-padding-y
+				$nav-underline-link-padding-x;
+
+			@include hover-focus {
+				color: $nav-underline-link-hover-color;
+			}
+
+			&:after {
+				bottom: $nav-underline-link-highlight-bottom;
+				content: $nav-underline-link-highlight-content;
+				display: block;
+				height: $nav-underline-link-highlight-height;
+				left: $nav-underline-link-highlight-left;
+				position: absolute;
+				right: $nav-underline-link-highlight-right;
+				top: $nav-underline-link-highlight-top;
+				width: auto;
+			}
+		}
+
+		> .active > a:after {
+			background-color: $nav-underline-link-active-highlight;
+		}
+
+		> .active > a,
+		> .show > a {
+			background-color: transparent;
+			color: $nav-underline-link-active-color;
+
+			&:after {
+				@if not(
+					$nav-underline-link-active-content ==
+						$nav-underline-link-highlight-content
+				)
+				{
+					content: $nav-underline-link-active-content;
+				}
+
+				@if not(
+					$nav-underline-link-active-highlight-height ==
+						$nav-underline-link-highlight-height
+				)
+				{
+					height: $nav-underline-link-active-highlight-height;
+				}
+			}
+		}
+
+		> .disabled > a {
+			color: $nav-underline-link-disabled-color;
+
+			&:after {
+				background-color: $nav-underline-link-disabled-highlight;
+			}
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_navbar.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_navbar.scss
@@ -1,0 +1,257 @@
+@if $compat-navbar {
+	.navbar-toggle {
+		background-color: transparent;
+		background-image: none;
+		border: 1px solid transparent;
+		border-radius: $border-radius;
+		float: right;
+
+		// TODO: can't mix rem and px
+
+		//margin-bottom: (($navbar-height - 34px) / 2);
+		margin-right: $navbar-padding-x;
+
+		// TODO: can't mix rem and px
+
+		//margin-top: (($navbar-height - 34px) / 2);
+		padding: 9px 10px;
+		position: relative;
+		z-index: 1;
+
+		@include media-breakpoint-up(md) {
+			display: none;
+		}
+
+		&:focus {
+			outline: 0;
+		}
+
+		.icon-bar {
+			background-color: $body-color;
+			border-radius: 1px;
+			display: block;
+			height: 2px;
+			width: 22px;
+		}
+
+		.icon-bar + .icon-bar {
+			margin-top: 4px;
+		}
+	}
+
+	.navbar-toggle-left {
+		float: left;
+	}
+
+	.navbar-toggle-page-name {
+		border-width: 0;
+		padding: 13px 16px;
+	}
+
+	.navbar-header-right {
+		margin-left: auto;
+	}
+
+	.taglib-search-toggle-advanced-wrapper {
+		left: auto;
+		position: absolute;
+		right: 0;
+		z-index: $zindex-dropdown;
+	}
+
+	.navbar {
+		&.collapse-basic-search {
+			.basic-search {
+				@include media-breakpoint-down($scaling-breakpoint-down) {
+					border-width: $navbar-border-top-width
+						$navbar-border-right-width $navbar-border-bottom-width
+						$navbar-border-left-width;
+					left: -$navbar-border-left-width;
+					right: -$navbar-border-right-width;
+					top: -$navbar-border-top-width;
+				}
+			}
+		}
+	}
+
+	.navbar-collapse {
+		.nav-tabs {
+			@include media-breakpoint-down($scaling-breakpoint-down) {
+				flex-direction: column;
+			}
+		}
+
+		.navbar-nav {
+			flex-direction: row;
+
+			@include media-breakpoint-down($scaling-breakpoint-down) {
+				flex: 1;
+				flex-direction: column;
+			}
+		}
+	}
+
+	.navbar-no-collapse {
+		.navbar-nav {
+			flex-direction: row;
+		}
+	}
+
+	.navbar-default,
+	.navbar-inverse {
+		border-style: solid;
+		border-width: $navbar-border-top-width
+			$navbar-border-right-width
+			$navbar-border-bottom-width
+			$navbar-border-left-width;
+
+		.container-fluid-1280 {
+			@include media-breakpoint-up(md) {
+				display: flex;
+			}
+		}
+
+		.basic-search {
+			padding: 3.5px 16px;
+
+			@include media-breakpoint-up(md) {
+				padding: 10px 0 7px;
+			}
+		}
+
+		.navbar-collapse {
+			@include media-breakpoint-up(md) {
+				display: block;
+			}
+
+			+ .form {
+				margin-left: auto;
+			}
+		}
+
+		.navbar-nav {
+			@include media-breakpoint-up(md) {
+				flex-direction: row;
+			}
+
+			> li > a {
+				padding-bottom: 11.5px;
+				padding-top: 11.5px;
+
+				@include media-breakpoint-up(md) {
+					padding: 18px 16px;
+				}
+			}
+		}
+	}
+
+	.navbar-default {
+		background-color: $navbar-light-bg;
+		border-color: $navbar-light-border-color;
+
+		.navbar-nav > li > a {
+			color: $navbar-light-color;
+
+			&:focus,
+			&:hover {
+				color: $navbar-light-hover-color;
+			}
+		}
+
+		.navbar-nav > .active > a,
+		.navbar-toggle-page-name {
+			&,
+			&:hover {
+				color: $navbar-light-active-color;
+			}
+
+			&:after {
+				background-color: $navbar-light-active-highlight;
+				bottom: -$navbar-border-bottom-width;
+				content: '';
+				display: block;
+				height: 2px;
+				left: 16px;
+				position: absolute;
+				right: 16px;
+			}
+		}
+
+		.navbar-nav > .active > a:after {
+			@include media-breakpoint-down($scaling-breakpoint-down) {
+				content: normal;
+			}
+		}
+	}
+
+	.navbar-inverse {
+		background-color: $navbar-dark-bg;
+		border-color: $navbar-dark-border-color;
+
+		.navbar-nav > li > a {
+			color: $navbar-dark-color;
+
+			&:focus,
+			&:hover {
+				color: $navbar-dark-hover-color;
+			}
+		}
+
+		.navbar-nav > .active > a,
+		.navbar-toggle-page-name {
+			&,
+			&:hover {
+				color: $navbar-dark-active-color;
+			}
+
+			&:after {
+				background-color: $navbar-dark-active-highlight;
+				bottom: -$navbar-border-bottom-width;
+				content: '';
+				display: block;
+				height: 2px;
+				left: 16px;
+				position: absolute;
+				right: 16px;
+			}
+		}
+
+		.navbar-nav > .active > a:after {
+			@include media-breakpoint-down($scaling-breakpoint-down) {
+				content: normal;
+			}
+		}
+	}
+
+	.navbar-form {
+		.form-group {
+			@include media-breakpoint-up(md) {
+				display: inline-block;
+				margin-bottom: 0;
+				vertical-align: middle;
+			}
+		}
+	}
+
+	.navbar-header {
+		@include clearfix;
+
+		@include media-breakpoint-up(md) {
+			float: left;
+		}
+	}
+
+	@include media-breakpoint-up(md) {
+		.navbar-left {
+			float: left !important;
+		}
+
+		.navbar-right {
+			float: right !important;
+
+			~ .navbar-right {
+				margin-right: 0;
+			}
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_navs.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_navs.scss
@@ -1,0 +1,67 @@
+@if $compat-navs {
+	.nav {
+		flex-direction: column;
+
+		> li {
+			position: relative;
+		}
+
+		> li > a {
+			display: block;
+			padding: $nav-link-padding-y $nav-link-padding-x;
+
+			@include hover-focus {
+				text-decoration: none;
+			}
+		}
+
+		.disabled > a {
+			color: $nav-link-disabled-color;
+		}
+	}
+
+	.nav-justified {
+		flex-direction: row;
+
+		> li {
+			flex: 1;
+			text-align: center;
+		}
+	}
+
+	.nav-stacked {
+		@extend .flex-column;
+	}
+
+	.nav.nav-pills {
+		flex-direction: row;
+	}
+
+	.nav-pills > li > a {
+		@include border-radius($nav-pills-border-radius);
+	}
+
+	.nav-pills > li.active > a {
+		background-color: $nav-pills-link-active-bg;
+		color: $nav-pills-link-active-color;
+	}
+
+	.nav-tabs,
+	.nav-underline {
+		flex-direction: row;
+	}
+
+	.nav-underline {
+		.tab {
+			@extend .nav-item;
+
+			a {
+				@extend .nav-link;
+			}
+
+			&.active a {
+				@extend .active;
+			}
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_pager.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_pager.scss
@@ -1,0 +1,53 @@
+@if $compat-pager {
+	.pager {
+		list-style: none;
+		margin: map-get($spacers, 4) 0;
+		padding-left: 0;
+		text-align: center;
+
+		@include clearfix;
+
+		li {
+			display: inline;
+			> a,
+			> span {
+				background-color: $pager-bg;
+				border: 1px solid $pager-border;
+				border-radius: $pager-border-radius;
+				display: inline-block;
+				padding: 5px 14px;
+			}
+
+			> a:hover,
+			> a:focus {
+				background-color: $pager-hover-bg;
+				text-decoration: none;
+			}
+		}
+
+		.next {
+			> a,
+			> span {
+				float: right;
+			}
+		}
+
+		.previous {
+			> a,
+			> span {
+				float: left;
+			}
+		}
+
+		.disabled {
+			> a,
+			> a:hover,
+			> a:focus,
+			> span {
+				background-color: $pager-bg;
+				color: $pager-disabled-color;
+				cursor: not-allowed;
+			}
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_panels.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_panels.scss
@@ -1,0 +1,69 @@
+@if $compat-panels {
+	.panel {
+		position: inherit;
+	}
+
+	.panel-heading {
+		position: relative;
+	}
+
+	.panel-title {
+		&.h4 {
+			font-size: $panel-title-font-size;
+			margin-bottom: 0;
+		}
+
+		.collapse-icon {
+			color: inherit;
+			display: block;
+			padding: $panel-header-padding-y $panel-header-padding-x;
+			text-decoration: $panel-header-link-text-decoration;
+
+			&:hover,
+			&:focus {
+				color: inherit;
+				text-decoration: $panel-header-link-text-decoration;
+			}
+
+			.collapse-icon {
+				padding-left: $collapse-icon-padding-left;
+				padding-right: $collapse-icon-padding-right;
+			}
+		}
+	}
+
+	.panel-group {
+		background-color: transparent;
+	}
+
+	.panel-default {
+		border-color: map-get($panel-secondary, border-color);
+		box-shadow: $panel-box-shadow;
+		color: map-get($panel-secondary, color);
+
+		.panel-heading {
+			background-color: map-get($panel-secondary, header-bg);
+			border-color: map-get($panel-secondary, header-border-color);
+			color: map-get($panel-secondary, header-color);
+
+			.panel-group & {
+				+ .panel-collapse > .panel-body {
+					border-color: map-get(
+						$panel-secondary,
+						header-border-color
+					);
+				}
+			}
+		}
+
+		.panel-footer {
+			background-color: map-get($panel-secondary, footer-bg);
+			border-color: map-get($panel-secondary, footer-border-color);
+			color: map-get($panel-secondary, footer-color);
+		}
+	}
+
+	.main-content-card .panel-group {
+		@extend .panel-group-fluid;
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_popover.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_popover.scss
@@ -1,0 +1,47 @@
+.popover-title {
+	@extend .popover-header;
+}
+
+.popover-content {
+	@extend .popover-body;
+}
+
+.popover {
+	&.top {
+		@extend .bs-popover-top;
+
+		margin-bottom: $popover-arrow-height;
+	}
+
+	&.bottom {
+		@extend .bs-popover-bottom;
+
+		margin-top: $popover-arrow-height;
+	}
+
+	&.left {
+		@extend .bs-popover-left;
+
+		margin-right: $popover-arrow-width;
+	}
+
+	&.right {
+		@extend .bs-popover-right;
+
+		margin-left: $popover-arrow-width;
+	}
+
+	&.top,
+	&.bottom {
+		.arrow {
+			left: calc(50% - (#{$popover-arrow-width} / 2));
+		}
+	}
+
+	&.left,
+	&.right {
+		.arrow {
+			top: calc(50% - (#{$popover-arrow-height} / 2));
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_progress_bars.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_progress_bars.scss
@@ -1,0 +1,161 @@
+@if $compat-progress_bars {
+	.progress-bar.active {
+		@extend .progress-bar-animated;
+	}
+
+	.progress-bar {
+		.progress-xs & {
+			height: $progress-bar-xs-height;
+		}
+
+		.progress-lg & {
+			height: $progress-height-lg;
+		}
+
+		.progress-xl & {
+			height: $progress-bar-xl-height;
+		}
+	}
+
+	.progress-bar-danger {
+		background-color: $progress-bar-danger-bg;
+	}
+
+	.progress-bar-info {
+		background-color: $progress-bar-info-bg;
+	}
+
+	.progress-bar-success {
+		background-color: $progress-bar-success-bg;
+	}
+
+	.progress-bar-warning {
+		background-color: $progress-bar-warning-bg;
+	}
+
+	// Multi Step Progress Bar
+
+	.multi-step-progress-bar {
+		display: table;
+		list-style: none;
+		margin-bottom: 0;
+		padding-left: 0;
+		position: relative;
+		width: 100%;
+
+		> li {
+			color: $multi-step-progress-bar-color;
+			display: table-cell;
+			vertical-align: bottom;
+			width: 1%;
+		}
+
+		> .active {
+			color: $multi-step-progress-bar-active-color;
+
+			.divider {
+				background-color: $multi-step-progress-bar-active-color;
+				color: $multi-step-progress-bar-active-color;
+			}
+		}
+
+		> .complete {
+			color: $multi-step-progress-bar-complete-color;
+
+			.divider {
+				background-color: $multi-step-progress-bar-complete-color;
+				color: $multi-step-progress-bar-complete-icon-color;
+
+				@if (variable-exists(atlas-theme)) {
+					margin-left: 18px;
+				} @else {
+					margin-left: 15px;
+				}
+			}
+		}
+
+		.divider {
+			background-color: $multi-step-progress-bar-color;
+			color: $multi-step-progress-bar-color;
+			height: $multi-step-progress-bar-divider-height;
+
+			@if (variable-exists(atlas-theme)) {
+				margin: 20px 0 20px 12px;
+			} @else {
+				margin: 10px 0 10px 12px;
+			}
+
+			position: relative;
+
+			.lexicon-icon {
+				font-size: 12px;
+				left: -12px;
+				position: absolute;
+				top: -2px;
+
+				&.lexicon-icon-check {
+					left: -16px;
+				}
+			}
+		}
+
+		.progress-bar-step,
+		.progress-bar-title {
+			@if (variable-exists(atlas-theme)) {
+				font-weight: 500;
+			}
+
+			margin-right: 10px;
+		}
+	}
+
+	.multi-step-progress-bar-collapse {
+		@include media-breakpoint-down(sm) {
+			padding-top: 20px;
+		}
+
+		> li {
+			@include media-breakpoint-down(sm) {
+				width: auto;
+			}
+
+			&:last-child {
+				@include media-breakpoint-down(sm) {
+					width: 1%;
+				}
+
+				.divider {
+					@include media-breakpoint-down(sm) {
+						width: 0;
+					}
+				}
+			}
+		}
+
+		> .active {
+			.progress-bar-title {
+				@include media-breakpoint-down(sm) {
+					display: block;
+					left: 0;
+					position: absolute;
+					right: 0;
+					text-align: center;
+					top: 0;
+				}
+			}
+		}
+
+		.progress-bar-title {
+			@include media-breakpoint-down(sm) {
+				display: none;
+			}
+		}
+	}
+
+	.multi-step-progress-bar-fixed {
+		> li {
+			display: inline-block;
+			width: $multi-step-progress-bar-fixed-width;
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_responsive_utilities.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_responsive_utilities.scss
@@ -1,0 +1,125 @@
+@if $compat-responsive_utilities {
+	@include responsive-invisibility('.visible-lg');
+	@include responsive-invisibility('.visible-md');
+	@include responsive-invisibility('.visible-sm');
+	@include responsive-invisibility('.visible-xs');
+
+	.visible-xs-block,
+	.visible-xs-inline,
+	.visible-xs-inline-block,
+	.visible-sm-block,
+	.visible-sm-inline,
+	.visible-sm-inline-block,
+	.visible-md-block,
+	.visible-md-inline,
+	.visible-md-inline-block,
+	.visible-lg-block,
+	.visible-lg-inline,
+	.visible-lg-inline-block {
+		display: none !important;
+	}
+
+	@media (max-width: $screen-xs-max) {
+		@include responsive-visibility('.visible-xs');
+	}
+
+	.visible-xs-block {
+		@media (max-width: $screen-xs-max) {
+			display: block !important;
+		}
+	}
+
+	.visible-xs-inline {
+		@media (max-width: $screen-xs-max) {
+			display: inline !important;
+		}
+	}
+
+	.visible-xs-inline-block {
+		@media (max-width: $screen-xs-max) {
+			display: inline-block !important;
+		}
+	}
+
+	@media (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
+		@include responsive-visibility('.visible-sm');
+	}
+
+	.visible-sm-block {
+		@media (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
+			display: block !important;
+		}
+	}
+
+	.visible-sm-inline {
+		@media (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
+			display: inline !important;
+		}
+	}
+
+	.visible-sm-inline-block {
+		@media (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
+			display: inline-block !important;
+		}
+	}
+
+	@media (min-width: $screen-md-min) and (max-width: $screen-md-max) {
+		@include responsive-visibility('.visible-md');
+	}
+
+	.visible-md-block {
+		@media (min-width: $screen-md-min) and (max-width: $screen-md-max) {
+			display: block !important;
+		}
+	}
+
+	.visible-md-inline {
+		@media (min-width: $screen-md-min) and (max-width: $screen-md-max) {
+			display: inline !important;
+		}
+	}
+
+	.visible-md-inline-block {
+		@media (min-width: $screen-md-min) and (max-width: $screen-md-max) {
+			display: inline-block !important;
+		}
+	}
+
+	@media (min-width: $screen-lg-min) {
+		@include responsive-visibility('.visible-lg');
+	}
+
+	.visible-lg-block {
+		@media (min-width: $screen-lg-min) {
+			display: block !important;
+		}
+	}
+
+	.visible-lg-inline {
+		@media (min-width: $screen-lg-min) {
+			display: inline !important;
+		}
+	}
+
+	.visible-lg-inline-block {
+		@media (min-width: $screen-lg-min) {
+			display: inline-block !important;
+		}
+	}
+
+	@media (max-width: $screen-xs-max) {
+		@include responsive-invisibility('.hidden-xs');
+	}
+
+	@media (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
+		@include responsive-invisibility('.hidden-sm');
+	}
+
+	@media (min-width: $screen-md-min) and (max-width: $screen-md-max) {
+		@include responsive-invisibility('.hidden-md');
+	}
+
+	@media (min-width: $screen-lg-min) {
+		@include responsive-invisibility('.hidden-lg');
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_sidebar.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_sidebar.scss
@@ -1,0 +1,28 @@
+@if $compat-sidebar {
+	.sidebar-default {
+		background-color: #fff;
+	}
+
+	.sidebar-actions,
+	.sidebar-header-actions {
+		float: right;
+
+		@include list-unstyled();
+
+		margin-bottom: 0;
+		margin-right: -9px;
+
+		> li {
+			display: inline-block;
+		}
+	}
+
+	.sidebar-block.tabular-list-group-unstyled {
+		margin-right: -9px;
+	}
+
+	.sidebar-section-flex {
+		@extend %autofit-row;
+		@extend %autofit-row-center;
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_simple_flexbox_grid.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_simple_flexbox_grid.scss
@@ -1,0 +1,142 @@
+@if $compat-simple_flexbox_grid {
+	.flex-container {
+		display: flex;
+		flex-flow: row wrap;
+	}
+
+	.flex-container-stacked {
+		flex-direction: column;
+	}
+
+	.flex-row-vertical {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.flex-item-expand {
+		flex: 1;
+		flex-wrap: wrap;
+		min-width: 0;
+	}
+
+	.flex-item-full {
+		flex: 1 100%;
+		flex-wrap: wrap;
+
+		+ .flex-item-expand {
+			flex-basis: auto;
+		}
+	}
+
+	.flex-item-bottom {
+		align-self: flex-end;
+	}
+
+	.flex-item-center {
+		align-self: center;
+	}
+
+	.flex-item-top {
+		align-self: flex-start;
+	}
+
+	// Stacking Flex Container
+
+	.flex-container-stacked-xxs {
+		@media (max-width: 479px) {
+			@include stack-flex-container;
+		}
+	}
+
+	.flex-container-stacked-xs {
+		@media (max-width: $screen-xs-max) {
+			@include stack-flex-container;
+		}
+	}
+
+	.flex-container-stacked-sm {
+		@media (max-width: $screen-sm-max) {
+			@include stack-flex-container;
+		}
+	}
+
+	.flex-container-stacked-md {
+		@media (max-width: $screen-md-max) {
+			@include stack-flex-container;
+		}
+	}
+
+	.flex-container-stacked-lg {
+		@media (min-width: $screen-lg-min) {
+			@include stack-flex-container;
+		}
+	}
+
+	.flex-container-stacked-xs-only {
+		@media (min-width: $screen-xs-min) and (max-width: $screen-xs-max) {
+			@include stack-flex-container;
+		}
+	}
+
+	.flex-container-stacked-sm-only {
+		@media (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
+			@include stack-flex-container;
+		}
+	}
+
+	.flex-container-stacked-md-only {
+		@media (min-width: $screen-md-min) and (max-width: $screen-md-max) {
+			@include stack-flex-container;
+		}
+	}
+
+	// Flex Item Break
+
+	.flex-item-break-xxs {
+		@media (max-width: 479px) {
+			@include break-flex-item;
+		}
+	}
+
+	.flex-item-break-xs {
+		@media (max-width: $screen-xs-max) {
+			@include break-flex-item;
+		}
+	}
+
+	.flex-item-break-sm {
+		@media (max-width: $screen-sm-max) {
+			@include break-flex-item;
+		}
+	}
+
+	.flex-item-break-md {
+		@media (max-width: $screen-md-max) {
+			@include break-flex-item;
+		}
+	}
+
+	.flex-item-break-lg {
+		@media (min-width: $screen-lg) {
+			@include break-flex-item;
+		}
+	}
+
+	.flex-item-break-xs-only {
+		@media (min-width: $screen-xs-min) and (max-width: $screen-xs-max) {
+			@include break-flex-item;
+		}
+	}
+
+	.flex-item-break-sm-only {
+		@media (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
+			@include break-flex-item;
+		}
+	}
+
+	.flex-item-break-md-only {
+		@media (min-width: $screen-md-min) and (max-width: $screen-md-max) {
+			@include break-flex-item;
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_stickers.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_stickers.scss
@@ -1,0 +1,29 @@
+@if $compat-stickers {
+	.sticker-default {
+		@extend .sticker-secondary;
+	}
+
+	// Sticker Positions
+
+	.sticker-bottom {
+		bottom: $sticker-inside-offset;
+		left: $sticker-inside-offset;
+		position: absolute;
+		right: auto;
+		top: auto;
+	}
+
+	.sticker-right {
+		left: auto;
+		position: absolute;
+		right: $sticker-inside-offset;
+		top: $sticker-inside-offset;
+	}
+
+	.sticker-document {
+		.lexicon-icon {
+			height: 1.25em;
+			width: auto;
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_tables.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_tables.scss
@@ -1,0 +1,70 @@
+@if $compat-tables {
+	div.splitter,
+	.table.table-autofit .splitter td,
+	.table.table-autofit .splitter th {
+		background-color: $table-divider-bg;
+		color: $table-divider-color;
+		font-size: $table-divider-font-size;
+		font-weight: $table-divider-font-weight;
+		padding: $table-divider-padding;
+		text-transform: $table-divider-text-transform;
+	}
+
+	.table .splitter {
+		box-shadow: none;
+		padding: 0;
+	}
+
+	.table > thead > tr,
+	.table > tbody > tr,
+	.table > tfoot > tr {
+		&.active > th,
+		&.active > td,
+		th.active,
+		td.active {
+			background-color: $table-active-bg;
+		}
+
+		&.success > th,
+		&.success > td,
+		th.success,
+		td.success {
+			background-color: map-get($theme-colors, success);
+		}
+
+		&.info > th,
+		&.info > td,
+		th.info,
+		td.info {
+			background-color: map-get($theme-colors, info);
+		}
+
+		&.warning > th,
+		&.warning > td,
+		th.warning,
+		td.warning {
+			background-color: map-get($theme-colors, warning);
+		}
+
+		&.danger > th,
+		&.danger > td,
+		th.danger,
+		td.danger {
+			background-color: map-get($theme-colors, danger);
+		}
+	}
+
+	.table-cell-content {
+		@extend %table-cell-expand;
+	}
+
+	.table-cell-field {
+		@extend %table-cell-contract;
+	}
+
+	.table-autofit {
+		.table-cell-content {
+			width: auto;
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_toggle_card.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_toggle_card.scss
@@ -1,0 +1,94 @@
+@if $compat-toggle_card {
+	.toggle-card-check {
+		float: left;
+		line-height: normal;
+		position: relative;
+		user-select: none;
+	}
+
+	.toggle-card-container {
+		background-color: transparent;
+		border: 1px solid $gray-600;
+
+		@include border-radius(4px);
+		@include box-shadow(none);
+
+		color: $body-color;
+		height: 104px;
+		padding: 12px;
+		text-align: center;
+		width: 92px;
+	}
+
+	.toggle-card-icon {
+		align-items: center;
+		display: flex;
+
+		@include border-radius(4px);
+
+		font-size: 16px;
+		height: 32px;
+		justify-content: center;
+		margin-left: auto;
+		margin-right: auto;
+		width: 32px;
+
+		.lexicon-icon {
+			margin-top: 0;
+		}
+	}
+
+	.toggle-card-label {
+		height: 58px;
+		line-height: 16px;
+		overflow: hidden;
+		padding-top: 12px;
+	}
+
+	.toggle-card .toggle-check {
+		height: auto;
+		width: auto;
+	}
+
+	.toggle-card-check {
+		height: 104px;
+		margin: 0;
+		opacity: 0;
+		position: absolute;
+		width: 92px;
+
+		&:empty ~ .toggle-card-container {
+			.toggle-card-off {
+				display: block;
+			}
+
+			.toggle-card-on {
+				display: none;
+			}
+
+			.toggle-card-icon {
+				background-color: transparent;
+			}
+		}
+
+		&:checked ~ .toggle-card-container {
+			background-color: $body-bg;
+			border: 1px solid $link-color;
+			color: $link-color;
+			padding: 12px;
+
+			.toggle-card-off {
+				display: none;
+			}
+
+			.toggle-card-on {
+				display: block;
+			}
+		}
+
+		&[disabled] ~ .toggle-card-container {
+			cursor: not-allowed;
+			opacity: 0.4;
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_toggle_switch.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_toggle_switch.scss
@@ -1,0 +1,5 @@
+@if $compat-toggle_switch {
+	label:not(.toggle-switch) .toggle-switch {
+		@extend .toggle-switch-check;
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_toolbar.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_toolbar.scss
@@ -1,0 +1,7 @@
+@if $compat-toolbar {
+	.toolbar {
+		display: flex;
+
+		@extend .justify-content-between;
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_user_icons.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_user_icons.scss
@@ -1,0 +1,152 @@
+@if $compat-user_icons {
+	.user-icon img {
+		vertical-align: baseline;
+	}
+
+	.user-icon {
+		border-radius: $user-icon-border-radius;
+
+		font-size: $user-icon-font-size;
+
+		@if (variable-exists(user-icon-font-weight)) {
+			font-weight: $user-icon-font-weight;
+		}
+
+		@include monospace($user-icon-size);
+
+		overflow: hidden;
+		text-align: center;
+
+		@media (min-width: $grid-float-breakpoint) {
+			@if (variable-exists(user-icon-desktop-font-size)) {
+				font-size: $user-icon-desktop-font-size;
+			}
+
+			@if (variable-exists(user-icon-desktop-size)) {
+				@include monospace($user-icon-desktop-size);
+			}
+		}
+	}
+
+	// User Icon Sizes
+
+	.user-icon-xs {
+		font-size: $user-icon-xs-font-size;
+
+		@include monospace($user-icon-xs-size);
+
+		@media (min-width: $grid-float-breakpoint) {
+			font-size: $user-icon-xs-desktop-font-size;
+
+			@include monospace($user-icon-xs-desktop-size);
+		}
+	}
+
+	.user-icon-sm {
+		font-size: $user-icon-sm-font-size;
+
+		@include monospace($user-icon-sm-size);
+
+		@media (min-width: $grid-float-breakpoint) {
+			font-size: $user-icon-sm-desktop-font-size;
+
+			@include monospace($user-icon-sm-desktop-size);
+		}
+	}
+
+	.user-icon-lg {
+		font-size: $user-icon-lg-font-size;
+
+		@include monospace($user-icon-lg-size);
+
+		@media (min-width: $grid-float-breakpoint) {
+			font-size: $user-icon-lg-desktop-font-size;
+
+			@include monospace($user-icon-lg-desktop-size);
+		}
+	}
+
+	.user-icon-xl {
+		font-size: $user-icon-xl-font-size;
+
+		@include monospace($user-icon-xl-size);
+
+		@media (min-width: $grid-float-breakpoint) {
+			font-size: $user-icon-xl-desktop-font-size;
+
+			@include monospace($user-icon-xl-desktop-size);
+		}
+	}
+
+	.user-icon-xxl {
+		font-size: $user-icon-xxl-font-size;
+
+		@include monospace($user-icon-xxl-size);
+
+		@media (min-width: $grid-float-breakpoint) {
+			font-size: $user-icon-xxl-desktop-font-size;
+
+			@include monospace($user-icon-xxl-desktop-size);
+		}
+	}
+
+	// User Icon States
+
+	.user-icon-default {
+		@include color-user-icon($user-icon-default-bg);
+	}
+
+	.user-icon-primary {
+		@include color-user-icon($user-icon-primary-bg);
+	}
+
+	.user-icon-info {
+		@include color-user-icon($user-icon-info-bg);
+	}
+
+	.user-icon-success {
+		@include color-user-icon($user-icon-success-bg);
+	}
+
+	.user-icon-warning {
+		@include color-user-icon($user-icon-warning-bg);
+	}
+
+	.user-icon-danger {
+		@include color-user-icon($user-icon-danger-bg);
+	}
+
+	// User Icon Helpers
+
+	.user-icon-circle {
+		&.user-icon,
+		.user-icon {
+			@if not($user-icon-border-radius == $user-icon-circle-border-radius)
+			{
+				border-radius: $user-icon-circle-border-radius;
+			}
+		}
+	}
+
+	.user-icon-rounded {
+		&.user-icon,
+		.user-icon {
+			@if not(
+				$user-icon-border-radius == $user-icon-rounded-border-radius
+			)
+			{
+				border-radius: $user-icon-rounded-border-radius;
+			}
+		}
+	}
+
+	.user-icon-square {
+		&.user-icon,
+		.user-icon {
+			@if not($user-icon-border-radius == $user-icon-square-border-radius)
+			{
+				border-radius: $user-icon-square-border-radius;
+			}
+		}
+	}
+}

--- a/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_utilities.scss
+++ b/projects/js-themes-toolkit/packages/bs3-bs4-compat/scss/components/_utilities.scss
@@ -1,0 +1,30 @@
+.hide {
+	@extend .d-none;
+}
+
+@if $compat-utilities {
+	.pull-left {
+		@extend .float-left;
+	}
+
+	.pull-right {
+		@extend .float-right;
+	}
+
+	.truncate-text {
+		display: block;
+
+		@include text-truncate();
+
+		word-break: normal \9; // IE 8, 9
+		word-wrap: normal;
+	}
+
+	.flex-col {
+		@extend %autofit-col;
+	}
+
+	.flex-col-expand {
+		@extend %autofit-col-expand;
+	}
+}


### PR DESCRIPTION
Not totally sure if this is the right place to put this package, but at least we can review it hear and decide where to put it later.

This is to help address https://issues.liferay.com/browse/LPS-125918

I yanked out the compat layer we previously had in 7.3 and now locate all that scss in this package. I don't think we can provide a 100% solution for this, but this compat layer has always been meant as a bandaid and not a permanent fix. By providing this, we at least give a place for customers to look at css they might need or they can add the entire layer by following the README directions.

Below is two screen shots comparing 7.3 (has compatibility layer) and 7.4 + this package. They are not identical but I think they are similar enough (not a css guy for the record). I don't actually think we can get a 100% replica without writing and maintaining more code, which I don't think we want to do since this is just a temporary solution for customers.

Let me know what you think! cc @pat270 @marcoscv-work

PS these screenshots are based on the markup from [here](https://liferay.github.io/lexiconcss/content/test-assorted/)

**7.3**
![with-compat-7 3](https://user-images.githubusercontent.com/6843530/122473741-1bd60200-cf77-11eb-91d3-957e473684ef.png)


**7.4 + this package**
![7 4-bs3-compat](https://user-images.githubusercontent.com/6843530/122473779-298b8780-cf77-11eb-940a-57f6d27976ed.png)