### PR TITLE
feat(eslint-config): Add lint to catch common AUI utilities

### DIFF
--- a/projects/eslint-config/README.md
+++ b/projects/eslint-config/README.md
@@ -200,6 +200,20 @@ The bundled `@liferay/portal` plugin includes the following [rules](./plugins/po
 -   [@liferay/portal/no-react-dom-render](./plugins/portal/docs/rules/no-react-dom-render.md): Prevents direct usage of `ReactDOM.render` in favor of our wrapper.
 -   [@liferay/portal/no-side-navigation](./plugins/portal/docs/rules/no-side-navigation.md): Guards against the use of the legacy jQuery `sideNavigation` plugin.
 
+#### `@liferay/aui`
+
+The bundled `@liferay/aui` plugin includes the following [rules](./plugins/aui/docs/rules):
+
+-   [@liferay/aui/no-all](./plugins/aui/docs/rules/no-all.md): Prevents usage of `A.all()`
+-   [@liferay/aui/no-array](./plugins/aui/docs/rules/no-array.md): Prevents usage of `A.Array`
+-   [@liferay/aui/no-each](./plugins/aui/docs/rules/no-each.md): Prevents usage of `A.each()`
+-   [@liferay/aui/no-get-body](./plugins/aui/docs/rules/no-get-body.md): Prevents usage of `A.getBody()`
+-   [@liferay/aui/no-io](./plugins/aui/docs/rules/no-io.md): Prevents usage of `A.io()`
+-   [@liferay/aui/no-modal](./plugins/aui/docs/rules/no-modal.md): Prevents usage of `A.Modal()`
+-   [@liferay/aui/no-node](./plugins/aui/docs/rules/no-node.md): Prevents usage of `A.Node()`
+-   [@liferay/aui/no-object](./plugins/aui/docs/rules/no-object.md): Prevents usage of `A.Object`
+-   [@liferay/aui/no-one](./plugins/aui/docs/rules/no-one.md): Prevents usage of `A.one()`
+
 ## License
 
 MIT

--- a/projects/eslint-config/aui.js
+++ b/projects/eslint-config/aui.js
@@ -5,18 +5,21 @@
 
 'use strict';
 
+const local = require('./utils/local');
+
 const config = {
+	plugins: [local('@liferay/aui')],
 	rules: {
-		'@liferay/aui/no-all': 'off',
-		'@liferay/aui/no-array': 'off',
-		'@liferay/aui/no-each': 'off',
-		'@liferay/aui/no-get-body': 'off',
-		'@liferay/aui/no-io': 'off',
-		'@liferay/aui/no-merge': 'off',
-		'@liferay/aui/no-modal': 'off',
-		'@liferay/aui/no-node': 'off',
-		'@liferay/aui/no-object': 'off',
-		'@liferay/aui/no-one': 'off',
+		'@liferay/aui/no-all': 'error',
+		'@liferay/aui/no-array': 'error',
+		'@liferay/aui/no-each': 'error',
+		'@liferay/aui/no-get-body': 'error',
+		'@liferay/aui/no-io': 'error',
+		'@liferay/aui/no-merge': 'error',
+		'@liferay/aui/no-modal': 'error',
+		'@liferay/aui/no-node': 'error',
+		'@liferay/aui/no-object': 'error',
+		'@liferay/aui/no-one': 'error',
 	},
 };
 

--- a/projects/eslint-config/aui.js
+++ b/projects/eslint-config/aui.js
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: © 2021 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+'use strict';
+
+const local = require('./utils/local');
+
+const config = {
+	extends: [require.resolve('./react')],
+	plugins: [local('@liferay/portal')],
+	rules: {
+		'@liferay/aui/no-all': 'error',
+		'@liferay/aui/no-array': 'error',
+		'@liferay/aui/no-each': 'error',
+		'@liferay/aui/no-get-body': 'error',
+		'@liferay/aui/no-io': 'error',
+		'@liferay/aui/no-merge': 'error',
+		'@liferay/aui/no-modal': 'error',
+		'@liferay/aui/no-node': 'error',
+		'@liferay/aui/no-object': 'error',
+		'@liferay/aui/no-one': 'error',
+	},
+};
+
+module.exports = config;

--- a/projects/eslint-config/aui.js
+++ b/projects/eslint-config/aui.js
@@ -5,22 +5,18 @@
 
 'use strict';
 
-const local = require('./utils/local');
-
 const config = {
-	extends: [require.resolve('./react')],
-	plugins: [local('@liferay/portal')],
 	rules: {
-		'@liferay/aui/no-all': 'error',
-		'@liferay/aui/no-array': 'error',
-		'@liferay/aui/no-each': 'error',
-		'@liferay/aui/no-get-body': 'error',
-		'@liferay/aui/no-io': 'error',
-		'@liferay/aui/no-merge': 'error',
-		'@liferay/aui/no-modal': 'error',
-		'@liferay/aui/no-node': 'error',
-		'@liferay/aui/no-object': 'error',
-		'@liferay/aui/no-one': 'error',
+		'@liferay/aui/no-all': 'off',
+		'@liferay/aui/no-array': 'off',
+		'@liferay/aui/no-each': 'off',
+		'@liferay/aui/no-get-body': 'off',
+		'@liferay/aui/no-io': 'off',
+		'@liferay/aui/no-merge': 'off',
+		'@liferay/aui/no-modal': 'off',
+		'@liferay/aui/no-node': 'off',
+		'@liferay/aui/no-object': 'off',
+		'@liferay/aui/no-one': 'off',
 	},
 };
 

--- a/projects/eslint-config/package.json
+++ b/projects/eslint-config/package.json
@@ -14,6 +14,7 @@
 	"description": "ESLint shareable config for the Liferay JavaScript Style",
 	"files": [
 		".eslintrc.js",
+		"aui.js",
 		"index.js",
 		"metal.js",
 		"plugins",

--- a/projects/eslint-config/plugins/aui/docs/rules/no-all.md
+++ b/projects/eslint-config/plugins/aui/docs/rules/no-all.md
@@ -1,0 +1,17 @@
+# Avoid using `A.all('selector')`
+
+This rule prohibits using `A.all`, and suggests use of the native `document.querySelectorAll` utility.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+var listItems = A.all('.list-item');
+```
+
+Examples of **correct** code for this rule:
+
+```js
+const listItems = document.querySelectorAll('.list-item');
+```

--- a/projects/eslint-config/plugins/aui/docs/rules/no-array.md
+++ b/projects/eslint-config/plugins/aui/docs/rules/no-array.md
@@ -1,0 +1,17 @@
+# Avoid using `A.Array` and its utilities
+
+This rule prohibits using `A.Array` and its utilities.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+A.Array.remove(array, itemIndex);
+```
+
+Examples of **correct** code for this rule:
+
+```js
+array.splice(itemIndex, 1);
+```

--- a/projects/eslint-config/plugins/aui/docs/rules/no-each.md
+++ b/projects/eslint-config/plugins/aui/docs/rules/no-each.md
@@ -1,6 +1,6 @@
 # Avoid using `A.each(array, (item) => item)`
 
-This rule prohibits using `A.Array` and its utilities.
+This rule prohibits using `A.each`.
 
 ## Rule Details
 

--- a/projects/eslint-config/plugins/aui/docs/rules/no-each.md
+++ b/projects/eslint-config/plugins/aui/docs/rules/no-each.md
@@ -1,0 +1,17 @@
+# Avoid using `A.each(array, (item) => item)`
+
+This rule prohibits using `A.Array` and its utilities.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+A.each(array, (item) => console.log(item));
+```
+
+Examples of **correct** code for this rule:
+
+```js
+array.forEach((item) => console.log(item));
+```

--- a/projects/eslint-config/plugins/aui/docs/rules/no-get-body.md
+++ b/projects/eslint-config/plugins/aui/docs/rules/no-get-body.md
@@ -1,0 +1,17 @@
+# Avoid using `A.getBody()`
+
+This rule prohibits using `A.getBody()`.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+var body = A.getBody();
+```
+
+Examples of **correct** code for this rule:
+
+```js
+const body = document.body;
+```

--- a/projects/eslint-config/plugins/aui/docs/rules/no-io.md
+++ b/projects/eslint-config/plugins/aui/docs/rules/no-io.md
@@ -1,0 +1,17 @@
+# Avoid using `A.io.request('url')`
+
+This rule prohibits using `A.getBody()`.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+A.io.request('url');
+```
+
+Examples of **correct** code for this rule:
+
+```js
+Liferay.Util.fetch('url').then((response) => response.json());
+```

--- a/projects/eslint-config/plugins/aui/docs/rules/no-io.md
+++ b/projects/eslint-config/plugins/aui/docs/rules/no-io.md
@@ -1,6 +1,6 @@
 # Avoid using `A.io.request('url')`
 
-This rule prohibits using `A.getBody()`.
+This rule prohibits using `A.io`.
 
 ## Rule Details
 

--- a/projects/eslint-config/plugins/aui/docs/rules/no-merge.md
+++ b/projects/eslint-config/plugins/aui/docs/rules/no-merge.md
@@ -1,0 +1,17 @@
+# Avoid using `A.merge`
+
+This rule prohibits using `A.merge()` and proposes the usage of `Object.assign()`.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+var mergedObject = A.merge(object1, object2);
+```
+
+Examples of **correct** code for this rule:
+
+```js
+const mergedObject = Object.assign(object1, object2);
+```

--- a/projects/eslint-config/plugins/aui/docs/rules/no-modal.md
+++ b/projects/eslint-config/plugins/aui/docs/rules/no-modal.md
@@ -1,0 +1,17 @@
+# Avoid using `A.Modal`
+
+This rule prohibits using `A.Modal()` and proposes the usage of `Liferay.Util.openModal()`.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+var modal = new A.Modal({modalOptions});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+Liferay.Util.openModal({modalOptions});
+```

--- a/projects/eslint-config/plugins/aui/docs/rules/no-node.md
+++ b/projects/eslint-config/plugins/aui/docs/rules/no-node.md
@@ -1,0 +1,17 @@
+# Avoid using `A.Node`
+
+This rule prohibits using `A.Node`.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+var newButton = A.Node.create('button');
+```
+
+Examples of **correct** code for this rule:
+
+```js
+const newButton = document.createElement('button');
+```

--- a/projects/eslint-config/plugins/aui/docs/rules/no-object.md
+++ b/projects/eslint-config/plugins/aui/docs/rules/no-object.md
@@ -1,0 +1,17 @@
+# Avoid using `A.Object` utilities
+
+This rule prohibits using `A.Node` and proposes the use of the native Object class instead.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+var objectKeys = A.Object.keys(object);
+```
+
+Examples of **correct** code for this rule:
+
+```js
+const objectKeys = Object.keys(object);
+```

--- a/projects/eslint-config/plugins/aui/docs/rules/no-one.md
+++ b/projects/eslint-config/plugins/aui/docs/rules/no-one.md
@@ -1,0 +1,17 @@
+# Avoid using `A.one('selector')`
+
+This rule prohibits using `A.one`, and suggests use of the native `document.querySelector` utility.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+var listItem = A.one('.list-item');
+```
+
+Examples of **correct** code for this rule:
+
+```js
+const listItem = document.querySelector('.list-item');
+```

--- a/projects/eslint-config/plugins/aui/index.js
+++ b/projects/eslint-config/plugins/aui/index.js
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+module.exports = {
+	rules: {
+		'no-all': require('./lib/rules/no-all'),
+		'no-array': require('./lib/rules/no-array'),
+		'no-each': require('./lib/rules/no-each'),
+		'no-get-body': require('./lib/rules/no-get-body'),
+		'no-io': require('./lib/rules/no-io'),
+		'no-merge': require('./lib/rules/no-merge'),
+		'no-modal': require('./lib/rules/no-modal'),
+		'no-node': require('./lib/rules/no-node'),
+		'no-object': require('./lib/rules/no-object'),
+		'no-one': require('./lib/rules/no-one'),
+	},
+};

--- a/projects/eslint-config/plugins/aui/lib/rules/no-all.js
+++ b/projects/eslint-config/plugins/aui/lib/rules/no-all.js
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const message = 'use document.querySelectorAll instead';
+
+module.exports = {
+	create(context) {
+		return {
+			MemberExpression(node) {
+				if (node.object.name === 'A' && node.property.name === 'all') {
+					context.report({
+						message,
+						node,
+					});
+				}
+			},
+		};
+	},
+	meta: {
+		docs: {
+			category: 'Best Practices',
+			description: message,
+			recommended: false,
+			url:
+				'https://github.com/liferay/liferay-frontend-projects/issues/617',
+		},
+		fixable: 'code',
+		schema: [],
+		type: 'problem',
+	},
+};

--- a/projects/eslint-config/plugins/aui/lib/rules/no-array.js
+++ b/projects/eslint-config/plugins/aui/lib/rules/no-array.js
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const message = 'use the native Array class methods instead';
+
+module.exports = {
+	create(context) {
+		return {
+			MemberExpression(node) {
+				if (
+					node.object.name === 'A' &&
+					node.property.name === 'Array'
+				) {
+					context.report({
+						message,
+						node,
+					});
+				}
+			},
+		};
+	},
+	meta: {
+		docs: {
+			category: 'Best Practices',
+			description: message,
+			recommended: false,
+			url:
+				'https://github.com/liferay/liferay-frontend-projects/issues/617',
+		},
+		fixable: 'code',
+		schema: [],
+		type: 'problem',
+	},
+};

--- a/projects/eslint-config/plugins/aui/lib/rules/no-each.js
+++ b/projects/eslint-config/plugins/aui/lib/rules/no-each.js
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const message = 'use the native Array class methods instead';
+
+module.exports = {
+	create(context) {
+		return {
+			MemberExpression(node) {
+				if (node.object.name === 'A' && node.property.name === 'each') {
+					context.report({
+						message,
+						node,
+					});
+				}
+			},
+		};
+	},
+	meta: {
+		docs: {
+			category: 'Best Practices',
+			description: message,
+			recommended: false,
+			url:
+				'https://github.com/liferay/liferay-frontend-projects/issues/617',
+		},
+		fixable: 'code',
+		schema: [],
+		type: 'problem',
+	},
+};

--- a/projects/eslint-config/plugins/aui/lib/rules/no-get-body.js
+++ b/projects/eslint-config/plugins/aui/lib/rules/no-get-body.js
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const message = "this is a shortcut to A.one('body'), use document.body";
+
+module.exports = {
+	create(context) {
+		return {
+			MemberExpression(node) {
+				if (
+					node.object.name === 'A' &&
+					node.property.name === 'getBody'
+				) {
+					context.report({
+						message,
+						node,
+					});
+				}
+			},
+		};
+	},
+	meta: {
+		docs: {
+			category: 'Best Practices',
+			description: message,
+			recommended: false,
+			url:
+				'https://github.com/liferay/liferay-frontend-projects/issues/617',
+		},
+		fixable: 'code',
+		schema: [],
+		type: 'problem',
+	},
+};

--- a/projects/eslint-config/plugins/aui/lib/rules/no-io.js
+++ b/projects/eslint-config/plugins/aui/lib/rules/no-io.js
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const message = 'use Liferay.Util.fetch instead';
+
+module.exports = {
+	create(context) {
+		return {
+			MemberExpression(node) {
+				if (node.object.name === 'A' && node.property.name === 'io') {
+					context.report({
+						message,
+						node,
+					});
+				}
+			},
+		};
+	},
+	meta: {
+		docs: {
+			category: 'Best Practices',
+			description: message,
+			recommended: false,
+			url:
+				'https://github.com/liferay/liferay-frontend-projects/issues/617',
+		},
+		fixable: 'code',
+		schema: [],
+		type: 'problem',
+	},
+};

--- a/projects/eslint-config/plugins/aui/lib/rules/no-merge.js
+++ b/projects/eslint-config/plugins/aui/lib/rules/no-merge.js
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const message = 'use Object.assign instead';
+
+module.exports = {
+	create(context) {
+		return {
+			MemberExpression(node) {
+				if (
+					node.object.name === 'A' &&
+					node.property.name === 'merge'
+				) {
+					context.report({
+						message,
+						node,
+					});
+				}
+			},
+		};
+	},
+	meta: {
+		docs: {
+			category: 'Best Practices',
+			description: message,
+			recommended: false,
+			url:
+				'https://github.com/liferay/liferay-frontend-projects/issues/617',
+		},
+		fixable: 'code',
+		schema: [],
+		type: 'problem',
+	},
+};

--- a/projects/eslint-config/plugins/aui/lib/rules/no-modal.js
+++ b/projects/eslint-config/plugins/aui/lib/rules/no-modal.js
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const message = 'use Liferay.Util.openModal instead';
+
+module.exports = {
+	create(context) {
+		return {
+			MemberExpression(node) {
+				if (
+					node.object.name === 'A' &&
+					node.property.name === 'Modal'
+				) {
+					context.report({
+						message,
+						node,
+					});
+				}
+			},
+		};
+	},
+	meta: {
+		docs: {
+			category: 'Best Practices',
+			description: message,
+			recommended: false,
+			url:
+				'https://github.com/liferay/liferay-frontend-projects/issues/617',
+		},
+		fixable: 'code',
+		schema: [],
+		type: 'problem',
+	},
+};

--- a/projects/eslint-config/plugins/aui/lib/rules/no-node.js
+++ b/projects/eslint-config/plugins/aui/lib/rules/no-node.js
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const message =
+	'use native methods instead, mostly found inside the Document interface';
+
+module.exports = {
+	create(context) {
+		return {
+			MemberExpression(node) {
+				if (node.object.name === 'A' && node.property.name === 'Node') {
+					context.report({
+						message,
+						node,
+					});
+				}
+			},
+		};
+	},
+	meta: {
+		docs: {
+			category: 'Best Practices',
+			description: message,
+			recommended: false,
+			url:
+				'https://github.com/liferay/liferay-frontend-projects/issues/617',
+		},
+		fixable: 'code',
+		schema: [],
+		type: 'problem',
+	},
+};

--- a/projects/eslint-config/plugins/aui/lib/rules/no-object.js
+++ b/projects/eslint-config/plugins/aui/lib/rules/no-object.js
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const message = 'use the native Object class instead';
+
+module.exports = {
+	create(context) {
+		return {
+			MemberExpression(node) {
+				if (
+					node.object.name === 'A' &&
+					node.property.name === 'Object'
+				) {
+					context.report({
+						message,
+						node,
+					});
+				}
+			},
+		};
+	},
+	meta: {
+		docs: {
+			category: 'Best Practices',
+			description: message,
+			recommended: false,
+			url:
+				'https://github.com/liferay/liferay-frontend-projects/issues/617',
+		},
+		fixable: 'code',
+		schema: [],
+		type: 'problem',
+	},
+};

--- a/projects/eslint-config/plugins/aui/lib/rules/no-one.js
+++ b/projects/eslint-config/plugins/aui/lib/rules/no-one.js
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const message = 'use document.querySelector instead';
+
+module.exports = {
+	create(context) {
+		return {
+			MemberExpression(node) {
+				if (node.object.name === 'A' && node.property.name === 'one') {
+					context.report({
+						message,
+						node,
+					});
+				}
+			},
+		};
+	},
+	meta: {
+		docs: {
+			category: 'Best Practices',
+			description: message,
+			recommended: false,
+			url:
+				'https://github.com/liferay/liferay-frontend-projects/issues/617',
+		},
+		fixable: 'code',
+		schema: [],
+		type: 'problem',
+	},
+};

--- a/projects/eslint-config/plugins/aui/package.json
+++ b/projects/eslint-config/plugins/aui/package.json
@@ -1,0 +1,11 @@
+{
+	"directories": {
+		"doc": "docs",
+		"lib": "lib",
+		"test": "tests"
+	},
+	"main": "index.js",
+	"name": "eslint-plugin-liferay",
+	"private": true,
+	"version": "1.0.0"
+}

--- a/projects/eslint-config/plugins/aui/package.json
+++ b/projects/eslint-config/plugins/aui/package.json
@@ -5,7 +5,7 @@
 		"test": "tests"
 	},
 	"main": "index.js",
-	"name": "eslint-plugin-liferay",
+	"name": "eslint-plugin-liferay-aui",
 	"private": true,
 	"version": "1.0.0"
 }

--- a/projects/eslint-config/plugins/aui/tests/lib/rules/no-all.js
+++ b/projects/eslint-config/plugins/aui/tests/lib/rules/no-all.js
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const MultiTester = require('../../../../../scripts/MultiTester');
+const rule = require('../../../lib/rules/no-all');
+
+const parserOptions = {
+	parserOptions: {
+		ecmaVersion: 6,
+		sourceType: 'module',
+	},
+};
+
+const ruleTester = new MultiTester(parserOptions);
+
+ruleTester.run('no-all', rule, {
+	invalid: [
+		{
+			code: `var elements = A.all('selector');`,
+			errors: [
+				{
+					message: 'use document.querySelectorAll instead',
+					type: 'MemberExpression',
+				},
+			],
+		},
+	],
+	valid: [
+		{
+			code: `const elements = document.querySelectorAll('selector');`,
+		},
+	],
+});

--- a/projects/eslint-config/plugins/aui/tests/lib/rules/no-array.js
+++ b/projects/eslint-config/plugins/aui/tests/lib/rules/no-array.js
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const MultiTester = require('../../../../../scripts/MultiTester');
+const rule = require('../../../lib/rules/no-array');
+
+const parserOptions = {
+	parserOptions: {
+		ecmaVersion: 6,
+		sourceType: 'module',
+	},
+};
+
+const ruleTester = new MultiTester(parserOptions);
+
+ruleTester.run('no-array', rule, {
+	invalid: [
+		{
+			code: `A.Array.remove(array, itemIndex);`,
+			errors: [
+				{
+					message: 'use the native Array class methods instead',
+					type: 'MemberExpression',
+				},
+			],
+		},
+	],
+	valid: [
+		{
+			code: `array.splice(itemIndex, 1);`,
+		},
+	],
+});

--- a/projects/eslint-config/plugins/aui/tests/lib/rules/no-each.js
+++ b/projects/eslint-config/plugins/aui/tests/lib/rules/no-each.js
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const MultiTester = require('../../../../../scripts/MultiTester');
+const rule = require('../../../lib/rules/no-each');
+
+const parserOptions = {
+	parserOptions: {
+		ecmaVersion: 6,
+		sourceType: 'module',
+	},
+};
+
+const ruleTester = new MultiTester(parserOptions);
+
+ruleTester.run('no-each', rule, {
+	invalid: [
+		{
+			code: `A.each(array, (item) => console.log(item));`,
+			errors: [
+				{
+					message: 'use the native Array class methods instead',
+					type: 'MemberExpression',
+				},
+			],
+		},
+	],
+	valid: [
+		{
+			code: `array.forEach((item) => console.log(item));`,
+		},
+	],
+});

--- a/projects/eslint-config/plugins/aui/tests/lib/rules/no-get-body.js
+++ b/projects/eslint-config/plugins/aui/tests/lib/rules/no-get-body.js
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const MultiTester = require('../../../../../scripts/MultiTester');
+const rule = require('../../../lib/rules/no-get-body');
+
+const parserOptions = {
+	parserOptions: {
+		ecmaVersion: 6,
+		sourceType: 'module',
+	},
+};
+
+const ruleTester = new MultiTester(parserOptions);
+
+ruleTester.run('no-get-body', rule, {
+	invalid: [
+		{
+			code: `var body = A.getBody;`,
+			errors: [
+				{
+					message:
+						"this is a shortcut to A.one('body'), use document.body",
+					type: 'MemberExpression',
+				},
+			],
+		},
+	],
+	valid: [
+		{
+			code: `const body = document.body;`,
+		},
+	],
+});

--- a/projects/eslint-config/plugins/aui/tests/lib/rules/no-io.js
+++ b/projects/eslint-config/plugins/aui/tests/lib/rules/no-io.js
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const MultiTester = require('../../../../../scripts/MultiTester');
+const rule = require('../../../lib/rules/no-io');
+
+const parserOptions = {
+	parserOptions: {
+		ecmaVersion: 6,
+		sourceType: 'module',
+	},
+};
+
+const ruleTester = new MultiTester(parserOptions);
+
+ruleTester.run('no-io', rule, {
+	invalid: [
+		{
+			code: `A.io.request('url');`,
+			errors: [
+				{
+					message: 'use Liferay.Util.fetch instead',
+					type: 'MemberExpression',
+				},
+			],
+		},
+	],
+	valid: [
+		{
+			code: `Liferay.Util.fetch('url').then((response) => response.json());`,
+		},
+	],
+});

--- a/projects/eslint-config/plugins/aui/tests/lib/rules/no-merge.js
+++ b/projects/eslint-config/plugins/aui/tests/lib/rules/no-merge.js
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const MultiTester = require('../../../../../scripts/MultiTester');
+const rule = require('../../../lib/rules/no-merge');
+
+const parserOptions = {
+	parserOptions: {
+		ecmaVersion: 6,
+		sourceType: 'module',
+	},
+};
+
+const ruleTester = new MultiTester(parserOptions);
+
+ruleTester.run('no-merge', rule, {
+	invalid: [
+		{
+			code: `var mergedObject = A.merge(object1, object2);`,
+			errors: [
+				{
+					message: 'use Object.assign instead',
+					type: 'MemberExpression',
+				},
+			],
+		},
+	],
+	valid: [
+		{
+			code: `const mergedObject = Object.assign(object1, object2);`,
+		},
+	],
+});

--- a/projects/eslint-config/plugins/aui/tests/lib/rules/no-modal.js
+++ b/projects/eslint-config/plugins/aui/tests/lib/rules/no-modal.js
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const MultiTester = require('../../../../../scripts/MultiTester');
+const rule = require('../../../lib/rules/no-modal');
+
+const parserOptions = {
+	parserOptions: {
+		ecmaVersion: 6,
+		sourceType: 'module',
+	},
+};
+
+const ruleTester = new MultiTester(parserOptions);
+
+ruleTester.run('no-modal', rule, {
+	invalid: [
+		{
+			code: `var modal = new A.Modal({modalOptions});`,
+			errors: [
+				{
+					message: 'use Liferay.Util.openModal instead',
+					type: 'MemberExpression',
+				},
+			],
+		},
+	],
+	valid: [
+		{
+			code: `Liferay.Util.openModal({modalOptions});`,
+		},
+	],
+});

--- a/projects/eslint-config/plugins/aui/tests/lib/rules/no-node.js
+++ b/projects/eslint-config/plugins/aui/tests/lib/rules/no-node.js
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const MultiTester = require('../../../../../scripts/MultiTester');
+const rule = require('../../../lib/rules/no-node');
+
+const parserOptions = {
+	parserOptions: {
+		ecmaVersion: 6,
+		sourceType: 'module',
+	},
+};
+
+const ruleTester = new MultiTester(parserOptions);
+
+ruleTester.run('no-node', rule, {
+	invalid: [
+		{
+			code: `var newButton = A.Node.create('button');`,
+			errors: [
+				{
+					message:
+						'use native methods instead, mostly found inside the Document interface',
+					type: 'MemberExpression',
+				},
+			],
+		},
+	],
+	valid: [
+		{
+			code: `const newButton = document.createElement('button');`,
+		},
+	],
+});

--- a/projects/eslint-config/plugins/aui/tests/lib/rules/no-object.js
+++ b/projects/eslint-config/plugins/aui/tests/lib/rules/no-object.js
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const MultiTester = require('../../../../../scripts/MultiTester');
+const rule = require('../../../lib/rules/no-object');
+
+const parserOptions = {
+	parserOptions: {
+		ecmaVersion: 6,
+		sourceType: 'module',
+	},
+};
+
+const ruleTester = new MultiTester(parserOptions);
+
+ruleTester.run('no-object', rule, {
+	invalid: [
+		{
+			code: `var objectKeys = A.Object.keys({foo: 'bar'});`,
+			errors: [
+				{
+					message: 'use the native Object class instead',
+					type: 'MemberExpression',
+				},
+			],
+		},
+	],
+	valid: [
+		{
+			code: `const objectKeys = Object.keys({foo: 'bar'});`,
+		},
+	],
+});

--- a/projects/eslint-config/plugins/aui/tests/lib/rules/no-one.js
+++ b/projects/eslint-config/plugins/aui/tests/lib/rules/no-one.js
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const MultiTester = require('../../../../../scripts/MultiTester');
+const rule = require('../../../lib/rules/no-one');
+
+const parserOptions = {
+	parserOptions: {
+		ecmaVersion: 6,
+		sourceType: 'module',
+	},
+};
+
+const ruleTester = new MultiTester(parserOptions);
+
+ruleTester.run('no-one', rule, {
+	invalid: [
+		{
+			code: `
+				  var element = A.one('selector');
+			   `,
+			errors: [
+				{
+					message: 'use document.querySelector instead',
+					type: 'MemberExpression',
+				},
+			],
+		},
+	],
+	valid: [
+		{
+			code: `const element = document.querySelector('selector');`,
+		},
+	],
+});


### PR DESCRIPTION
Hey @bryceosterhaus I've added the initial code for the no-aui eslint rule.

I tried testing it in DXP but I didn't succeed. I asked @izaera about it, and he suggested copy/pasting the source folder into the `dxp/modules/node_modules/@liferay`, I did that and ran `gradlew formatSource` and `yarn formatSource` from an arbitrary folder that had usage of `A.one` but it didn't react.

So I'm wondering 1st of all is the code in the rule correct, I think it is. And the other thing I'm interested in, how to test it in DXP?