### PR TITLE
feat(eslint-config): add an ESlint rule that adds an empty line between sibling elements

### DIFF
--- a/projects/eslint-config/index.js
+++ b/projects/eslint-config/index.js
@@ -62,6 +62,7 @@ const config = {
 	rules: {
 		'@liferay/liferay/array-is-array': 'error',
 		'@liferay/liferay/destructure-requires': 'error',
+		'@liferay/liferay/empty-line-between-elements': 'error',
 		'@liferay/liferay/group-imports': 'error',
 		'@liferay/liferay/import-extensions': 'error',
 		'@liferay/liferay/imports-first': 'error',

--- a/projects/eslint-config/plugins/liferay/index.js
+++ b/projects/eslint-config/plugins/liferay/index.js
@@ -7,6 +7,7 @@ module.exports = {
 	rules: {
 		'array-is-array': require('./lib/rules/array-is-array'),
 		'destructure-requires': require('./lib/rules/destructure-requires'),
+		'empty-line-between-elements': require('./lib/rules/empty-line-between-elements'),
 		'group-imports': require('./lib/rules/group-imports'),
 		'import-extensions': require('./lib/rules/import-extensions'),
 		'imports-first': require('./lib/rules/imports-first'),

--- a/projects/eslint-config/plugins/liferay/lib/rules/empty-line-between-elements.js
+++ b/projects/eslint-config/plugins/liferay/lib/rules/empty-line-between-elements.js
@@ -11,15 +11,30 @@ module.exports = {
 			JSXElement(node) {
 				let previousNodeEndLocation;
 
-				node.children.map((childNode) => {
+				node.children.map((childNode, i) => {
 					if (childNode.type === 'JSXElement') {
 						if (
 							previousNodeEndLocation + 1 ===
 							childNode.loc.start.line
 						) {
 							context.report({
-								fix: (fixer) =>
-									fixer.insertTextBefore(childNode, '\n\n'),
+								fix: (fixer) => {
+									let insertBeforeNode = childNode;
+
+									const previousNode = node.children[i - 1];
+
+									if (
+										previousNode.type === 'Literal' ||
+										previousNode.type === 'JSXText'
+									) {
+										insertBeforeNode = previousNode;
+									}
+
+									return fixer.insertTextBefore(
+										insertBeforeNode,
+										'\n'
+									);
+								},
 								message:
 									'Expected an empty line between sibling elements.',
 								node: childNode,

--- a/projects/eslint-config/plugins/liferay/lib/rules/empty-line-between-elements.js
+++ b/projects/eslint-config/plugins/liferay/lib/rules/empty-line-between-elements.js
@@ -11,16 +11,6 @@ module.exports = {
 			JSXElement(node) {
 				let previousNodeEndLocation;
 
-				const printTabs = (amountOfTabs) => {
-					let tabs = '';
-
-					for (let i = 0; i < amountOfTabs; i++) {
-						tabs += '\t';
-					}
-
-					return tabs;
-				};
-
 				node.children.map((childNode) => {
 					if (childNode.type === 'JSXElement') {
 						if (
@@ -29,12 +19,7 @@ module.exports = {
 						) {
 							context.report({
 								fix: (fixer) =>
-									fixer.insertTextBefore(
-										childNode,
-										`\n${printTabs(
-											childNode.loc.start.col
-										)}`
-									),
+									fixer.insertTextBefore(childNode, '\n'),
 								message:
 									'Expected an empty line between sibling elements.',
 								node: childNode,

--- a/projects/eslint-config/plugins/liferay/lib/rules/empty-line-between-elements.js
+++ b/projects/eslint-config/plugins/liferay/lib/rules/empty-line-between-elements.js
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: © 2021 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const message = 'Expected an empty line between sibling elements.';
+
+module.exports = {
+	create(context) {
+		return {
+			JSXElement(node) {
+				let previousNodeEndLocation;
+
+				const printTabs = (amountOfTabs) => {
+					let tabs = '';
+
+					for (let i = 0; i < amountOfTabs; i++) {
+						tabs += '\t';
+					}
+
+					return tabs;
+				};
+
+				node.children.map((childNode) => {
+					if (childNode.type === 'JSXElement') {
+						if (
+							previousNodeEndLocation + 1 ===
+							childNode.loc.start.line
+						) {
+							context.report({
+								fix: (fixer) =>
+									fixer.insertTextBefore(
+										childNode,
+										`\n${printTabs(
+											childNode.loc.start.col
+										)}`
+									),
+								message:
+									'Expected an empty line between sibling elements.',
+								node: childNode,
+							});
+						}
+
+						previousNodeEndLocation = childNode.loc.end.line;
+					}
+				});
+			},
+		};
+	},
+
+	meta: {
+		docs: {
+			category: 'Best Practices',
+			description: message,
+			recommended: false,
+			url:
+				'https://github.com/liferay/liferay-frontend-projects/issues/618',
+		},
+		fixable: 'code',
+		schema: [],
+		type: 'problem',
+	},
+};

--- a/projects/eslint-config/plugins/liferay/lib/rules/empty-line-between-elements.js
+++ b/projects/eslint-config/plugins/liferay/lib/rules/empty-line-between-elements.js
@@ -19,7 +19,7 @@ module.exports = {
 						) {
 							context.report({
 								fix: (fixer) =>
-									fixer.insertTextBefore(childNode, '\n'),
+									fixer.insertTextBefore(childNode, '\n\n'),
 								message:
 									'Expected an empty line between sibling elements.',
 								node: childNode,

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/empty-line-between-elements.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/empty-line-between-elements.js
@@ -20,30 +20,36 @@ const ruleTester = new MultiTester(parserOptions);
 ruleTester.run('empty-line-between-elements', rule, {
 	invalid: [
 		{
-			code: `<div>
-	<Component1 />
-	<Component2 />
-</div>`,
+			code: `
+			<div>
+				<Invalid1 />
+				<Invalid2 />
+			</div>
+			`,
 			errors: [
 				{
 					message: 'Expected an empty line between sibling elements.',
 					type: 'JSXElement',
 				},
 			],
-			output: `<div>
-	<Component1 />
+			output: `
+			<div>
+				<Invalid1 />
 
-<Component2 />
-</div>`,
+				<Invalid2 />
+			</div>
+			`,
 		},
 	],
 	valid: [
 		{
-			code: `<div>
-	<Component1 />
+			code: `
+			<div>
+				<Valid1 />
 
-<Component2 />
-</div>`,
+				<Valid2 />
+			</div>
+			`,
 		},
 	],
 });

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/empty-line-between-elements.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/empty-line-between-elements.js
@@ -17,33 +17,39 @@ const ruleTester = new MultiTester(parserOptions);
 ruleTester.run('empty-line-between-elements', rule, {
 	invalid: [
 		{
-			code: `
-				const reactComponent = () => (
-					<div>
-						<Component1 />
-						<Component2 />
-					</div>
-				);
-			`,
+			code:
+				'const reactComponent = () => (' +
+				'<div>' +
+				'<Component1 />' +
+				'<Component2 />' +
+				'</div>' +
+				');',
 			errors: [
 				{
 					message: 'Expected an empty line between sibling elements.',
 					type: 'JSXElement',
 				},
 			],
+			output:
+				'const reactComponent = () => (' +
+				'<div>' +
+				'<Component1 />' +
+				'\n' +
+				'<Component2 />' +
+				'</div>' +
+				');',
 		},
 	],
 	valid: [
 		{
-			code: `
-				const reactComponent = () => (
-					<div>
-						<Component1 />
-
-						<Component2 />
-					</div>
-				);
-			`,
+			code:
+				'const reactComponent = () => (' +
+				'<div>' +
+				'<Component1 />' +
+				'\n' +
+				'<Component2 />' +
+				'</div>' +
+				');',
 		},
 	],
 });

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/empty-line-between-elements.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/empty-line-between-elements.js
@@ -8,6 +8,9 @@ const rule = require('../../../lib/rules/empty-line-between-elements');
 
 const parserOptions = {
 	parserOptions: {
+		ecmaFeatures: {
+			jsx: true,
+		},
 		ecmaVersion: 6,
 	},
 };
@@ -17,39 +20,30 @@ const ruleTester = new MultiTester(parserOptions);
 ruleTester.run('empty-line-between-elements', rule, {
 	invalid: [
 		{
-			code:
-				'const reactComponent = () => (' +
-				'<div>' +
-				'<Component1 />' +
-				'<Component2 />' +
-				'</div>' +
-				');',
+			code: `<div>
+	<Component1 />
+	<Component2 />
+</div>`,
 			errors: [
 				{
 					message: 'Expected an empty line between sibling elements.',
 					type: 'JSXElement',
 				},
 			],
-			output:
-				'const reactComponent = () => (' +
-				'<div>' +
-				'<Component1 />' +
-				'\n' +
-				'<Component2 />' +
-				'</div>' +
-				');',
+			output: `<div>
+	<Component1 />
+
+<Component2 />
+</div>`,
 		},
 	],
 	valid: [
 		{
-			code:
-				'const reactComponent = () => (' +
-				'<div>' +
-				'<Component1 />' +
-				'\n' +
-				'<Component2 />' +
-				'</div>' +
-				');',
+			code: `<div>
+	<Component1 />
+
+<Component2 />
+</div>`,
 		},
 	],
 });

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/empty-line-between-elements.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/empty-line-between-elements.js
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: © 2021 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const MultiTester = require('../../../../../scripts/MultiTester');
+const rule = require('../../../lib/rules/empty-line-between-elements');
+
+const parserOptions = {
+	parserOptions: {
+		ecmaVersion: 6,
+	},
+};
+
+const ruleTester = new MultiTester(parserOptions);
+
+ruleTester.run('empty-line-between-elements', rule, {
+	invalid: [
+		{
+			code: `
+				const reactComponent = () => (
+					<div>
+						<Component1 />
+						<Component2 />
+					</div>
+				);
+			`,
+			errors: [
+				{
+					message: 'Expected an empty line between sibling elements.',
+					type: 'JSXElement',
+				},
+			],
+		},
+	],
+	valid: [
+		{
+			code: `
+				const reactComponent = () => (
+					<div>
+						<Component1 />
+
+						<Component2 />
+					</div>
+				);
+			`,
+		},
+	],
+});

--- a/projects/eslint-config/test/integration.js
+++ b/projects/eslint-config/test/integration.js
@@ -180,12 +180,14 @@ describe('@liferay/eslint-config/liferay', () => {
 			code: `
 				<div>
 					<div className="   one two one three  "></div>
+
 					<CustomPopover triggerClassName="   foo foo bar  " />
 				</div>
 			`,
 			output: `
 				<div>
 					<div className="one three two"></div>
+
 					<CustomPopover triggerClassName="bar foo" />
 				</div>
 			`,


### PR DESCRIPTION
## Overview
With ASTExplorer finally working, I had the chance to make this rule actually work... kinda.

For code like this, it throws out an error, as it's supposed to, on lines where the `div` and `small` are opening:
```js
<label className="form-group-autofit">
	<span className="form-group-item">
		{label}
		{subTitle && (
			<span className="font-weight-normal form-text">
				{subTitle}
			</span>
		)}
	</span>
	<div className="flex-row form-group-item">
		<ClaySlider
			className="w-100"
			max={max}
			min={min}
			onValueChange={onValueChange}
			showTooltip={false}
			value={value}
		/>
		<small className="font-weight-normal form-text ml-3">
			{value + '%'}
		</small>
	</div>
</label>
```

Now, the problem I encountered was the indentation when adding a new line inside the `fix: (fixer) => ...`. I tried to add the amount of tabs equalling the column that the node was at, but I don't think it worked, as I'm getting wonky output when running `yarn test`.

## DXP

There are **697** errors found by this rule in `liferay-portal`. 

## Future

- Did we want other newline scenarios to be handled with this rule? Should I investigate further and perhaps split the task into multiple newline rules, if the investigation deems it necessary?
- I need to fix the indentation, not sure how exactly, but I can spend more time figuring it out
- I need to make sure the `fixer` is doing its job and automatically fixing these errors automatically
- Gonna need to write documentation for it