### PR TITLE
feat(js-theme-toolkit): Add RTL conversion for translate properties

### DIFF
--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/__tests__/index.test.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/__tests__/index.test.js
@@ -565,3 +565,62 @@ describe('noflip', () => {
 		done();
 	});
 });
+
+describe('translate', () => {
+	it('swap for rtl', (done) => {
+		expect(swap('p{transform: translate(10px);}')).toMatchInlineSnapshot(
+			`"p{transform:translate(calc(10px * -1));}"`
+		);
+
+		expect(swap('p{transform: translateY(10px);}')).toMatchInlineSnapshot(
+			`"p{transform:translateY(10px);}"`
+		);
+
+		expect(
+			swap('p{transform: translateX(11px) translateY (10px);}')
+		).toMatchInlineSnapshot(
+			`"p{transform:translateX(calc(11px * -1)) translateY (10px);}"`
+		);
+
+		expect(
+			swap('p{transform: translatex(12px) translatey(10px);}')
+		).toMatchInlineSnapshot(
+			`"p{transform:translatex(calc(12px * -1)) translatey(10px);}"`
+		);
+
+		expect(
+			swap('p{transform: translate(13px, 15px, 20px);}')
+		).toMatchInlineSnapshot(
+			`"p{transform:translate(calc(13px * -1), 15px, 20px);}"`
+		);
+
+		expect(swap('p{transform: TRANSLATE(500%);}')).toMatchInlineSnapshot(
+			`"p{transform:TRANSLATE(calc(500% * -1));}"`
+		);
+
+		expect(swap('p{transform: translate(-11px);}')).toMatchInlineSnapshot(
+			`"p{transform:translate(calc(-11px * -1));}"`
+		);
+
+		expect(
+			swap('p{transform: translateX(-12px) translateY(10px);}')
+		).toMatchInlineSnapshot(
+			`"p{transform:translateX(calc(-12px * -1)) translateY(10px);}"`
+		);
+		expect(
+			swap('p{transform: translatex(-13px) translatey(10px);}')
+		).toMatchInlineSnapshot(
+			`"p{transform:translatex(calc(-13px * -1)) translatey(10px);}"`
+		);
+		expect(
+			swap('p{transform: translate(-14px, 15px, 20px);}')
+		).toMatchInlineSnapshot(
+			`"p{transform:translate(calc(-14px * -1), 15px, 20px);}"`
+		);
+		expect(swap('p{transform: TRANSLATE(-50%);}')).toMatchInlineSnapshot(
+			`"p{transform:TRANSLATE(calc(-50% * -1));}"`
+		);
+
+		done();
+	});
+});

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/index.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/index.js
@@ -80,13 +80,15 @@ function bgPosition(v) {
 	return v;
 }
 
+// Grabs the value of the translate property
+
+const TRANSLATE_REGEX = /(?<=translatex?(?!y)\()\S*(?=,|\))/gim;
+
 function translate(v) {
 
 	// translate(1px) => translate(calc(1px * -1))
 
-	v.replace(/(?<=translatex?(?!y)\()\S*(?=,|\))/gim, 'calc($& * -1)');
-
-	return v;
+	return v.replace(TRANSLATE_REGEX, 'calc($& * -1)');
 }
 
 var propertyMap = {


### PR DESCRIPTION
LPS: https://issues.liferay.com/browse/LPS-137648

This PR adds the missing transformation for CSS `translate` properties

e.g.: `transform: translate(10px, 15px)` => `transform: translate(calc(10px * -1), 15px)`

POC: https://codepen.io/eduardoallegrini/pen/rNwVaYv?editors=0011

REGEX: https://regex101.com/r/9x5ky6/1/

![image](https://user-images.githubusercontent.com/46778114/130995635-08b087a9-aeaa-4fb9-8c62-efa67547e648.png)
