### PR TITLE
feat(npm-scripts): update eslint-config version

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/package.json
+++ b/projects/npm-tools/packages/npm-scripts/package.json
@@ -14,7 +14,7 @@
 		"@babel/preset-env": "^7.4.2",
 		"@babel/preset-react": "^7.8.3",
 		"@babel/preset-typescript": "^7.10.4",
-		"@liferay/eslint-config": "26.0.0",
+		"@liferay/eslint-config": "27.0.0",
 		"@liferay/jest-junit-reporter": "1.2.0",
 		"@liferay/js-toolkit-core": "3.0.1",
 		"@testing-library/dom": "^5.6.1",


### PR DESCRIPTION
Update the `eslint-config` version used by `npm-scripts` to `27.0.0.` as it's been bumped because I merged the `empty-line-between-elements` rule.