### PR TITLE
fix(js-publish): add message when publishing fails

### DIFF
--- a/projects/npm-tools/packages/js-publish/src/index.js
+++ b/projects/npm-tools/packages/js-publish/src/index.js
@@ -223,7 +223,17 @@ async function runYarnPublish(pkg) {
 		args.push('--tag', 'prerelease');
 	}
 
-	run('yarn', 'publish', ...args);
+	try {
+		run('yarn', 'publish', ...args);
+	}
+	catch (error) {
+		printBanner(
+			'Failed to publish package! ❌',
+			'',
+			`You've already pushed to remote.`,
+			`Try publishing with 'yarn publish ${args.join(' ')}'`
+		);
+	}
 }
 
 module.exports = {


### PR DESCRIPTION
fixes https://github.com/liferay/liferay-frontend-projects/issues/639

This is to help developers know what to do next when publishing fails. This will help us avoid people running `yarn version` multiple times and accidentally pushing non-published versions to upstream.