### PR TITLE
feat(eslint-config): add rule to ensure JSX expressions guard against rendering 0 on accident

### DIFF
--- a/projects/eslint-config/README.md
+++ b/projects/eslint-config/README.md
@@ -181,6 +181,7 @@ The bundled `@liferay/liferay` plugin includes the following [rules](./plugins/l
 -   [@liferay/liferay/no-duplicate-imports](./plugins/liferay/docs/rules/no-duplicate-imports.md): Enforces at most one `import` of any given module per file.
 -   [@liferay/liferay/no-dynamic-require](./plugins/liferay/docs/rules/no-dynamic-require.md): Enforces that `require()` calls use static arguments.
 -   [@liferay/liferay/no-it-should](./plugins/liferay/docs/rules/no-it-should.md): Enforces that `it()` descriptions start with a verb, not with "should".
+-   [@liferay/liferay/no-length-jsx-expression](./plugins/liferay/docs/rules/no-it-should.md): Enforces that JSX expressions that check against length should make sure 0 isn't rendered".
 -   [@liferay/liferay/no-require-and-call](./plugins/liferay/docs/rules/no-require-and-call.md): Enforces that the result of a `require()` call at the top level is not immediately called.
 -   [@liferay/liferay/padded-test-blocks](./plugins/liferay/docs/rules/padded-test-blocks.md): Enforces blank lines between test blocks (`it()` etc).
 -   [@liferay/liferay/sort-class-names](./plugins/liferay/docs/rules/sort-class-names.md): Enforces (and autofixes) ordering of class names inside JSX `className` attributes.

--- a/projects/eslint-config/index.js
+++ b/projects/eslint-config/index.js
@@ -82,6 +82,7 @@ const config = {
 		'@liferay/liferay/no-duplicate-imports': 'error',
 		'@liferay/liferay/no-dynamic-require': 'error',
 		'@liferay/liferay/no-it-should': 'error',
+		'@liferay/liferay/no-length-jsx-expression': 'error',
 		'@liferay/liferay/no-require-and-call': 'error',
 		'@liferay/liferay/padded-test-blocks': 'error',
 		'@liferay/liferay/sort-import-destructures': 'error',

--- a/projects/eslint-config/plugins/liferay/docs/rules/no-length-jsx-expression.md
+++ b/projects/eslint-config/plugins/liferay/docs/rules/no-length-jsx-expression.md
@@ -1,0 +1,17 @@
+# Force JSX expressions to not check against .length without prefixing with `!!`
+
+Because it we want to avoid accidentally rendering a literal "0" when checking for length in a JSX expression.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+<div>{items.length && <div />}</div>
+```
+
+Examples of **correct** code for this rule:
+
+```js
+<div>{!!items.length && <div />}</div>
+```

--- a/projects/eslint-config/plugins/liferay/index.js
+++ b/projects/eslint-config/plugins/liferay/index.js
@@ -18,6 +18,7 @@ module.exports = {
 		'no-duplicate-imports': require('./lib/rules/no-duplicate-imports'),
 		'no-dynamic-require': require('./lib/rules/no-dynamic-require'),
 		'no-it-should': require('./lib/rules/no-it-should'),
+		'no-length-jsx-expression': require('./lib/rules/no-length-jsx-expression'),
 		'no-require-and-call': require('./lib/rules/no-require-and-call'),
 		'padded-test-blocks': require('./lib/rules/padded-test-blocks'),
 		'sort-class-names': require('./lib/rules/sort-class-names'),

--- a/projects/eslint-config/plugins/liferay/lib/rules/no-length-jsx-expression.js
+++ b/projects/eslint-config/plugins/liferay/lib/rules/no-length-jsx-expression.js
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: © 2021 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const message =
+	"Checking for length in JSX can result in rendering a literal '0'";
+
+module.exports = {
+	create(context) {
+		return {
+			LogicalExpression(node) {
+				const leftSideLength =
+					node.left.type === 'MemberExpression' &&
+					node.left.property.name === 'length';
+				const rightSideLength =
+					node.right.type === 'MemberExpression' &&
+					node.right.property.name === 'length';
+
+				if (
+					!leftSideLength &&
+					rightSideLength &&
+					node.parent.type === 'JSXExpressionContainer'
+				) {
+					return;
+				}
+
+				if (rightSideLength || leftSideLength) {
+					const jsxExpressionScope = context
+						.getAncestors()
+						.find((node) => node.type === 'JSXExpressionContainer');
+
+					if (jsxExpressionScope) {
+						context.report({
+							fix: (fixer) => {
+								return fixer.insertTextBefore(
+									node[leftSideLength ? 'left' : 'right'],
+									'!!'
+								);
+							},
+							message,
+							node,
+						});
+					}
+				}
+			},
+		};
+	},
+	meta: {
+		docs: {
+			category: 'Best Practices',
+			description: message,
+			recommended: false,
+			url:
+				'https://github.com/liferay/liferay-frontend-projects/issues/648',
+		},
+		fixable: 'code',
+		schema: [],
+		type: 'problem',
+	},
+};

--- a/projects/eslint-config/plugins/liferay/tests/lib/rules/no-length-jsx-expression.js
+++ b/projects/eslint-config/plugins/liferay/tests/lib/rules/no-length-jsx-expression.js
@@ -1,0 +1,111 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const MultiTester = require('../../../../../scripts/MultiTester');
+const rule = require('../../../lib/rules/no-length-jsx-expression');
+
+const parserOptions = {
+	parserOptions: {
+		ecmaFeatures: {
+			jsx: true,
+		},
+		ecmaVersion: 6,
+		sourceType: 'module',
+	},
+};
+
+const ruleTester = new MultiTester(parserOptions);
+
+ruleTester.run('no-length-jsx-expression', rule, {
+	invalid: [
+		{
+			code: `
+				const test = () => {
+					return (
+						<div>
+							{items.length && <div></div>}
+						</div>
+					)
+				}
+			`,
+			errors: [
+				{
+					message: `Checking for length in JSX can result in rendering a literal '0'`,
+					type: 'LogicalExpression',
+				},
+			],
+			output: `
+				const test = () => {
+					return (
+						<div>
+							{!!items.length && <div></div>}
+						</div>
+					)
+				}
+			`,
+		},
+		{
+			code: `
+				const test = () => {
+					return (
+						<div>
+							{someVal && items.length && <div></div>}
+						</div>
+					)
+				}
+			`,
+			errors: [
+				{
+					message: `Checking for length in JSX can result in rendering a literal '0'`,
+					type: 'LogicalExpression',
+				},
+			],
+			output: `
+				const test = () => {
+					return (
+						<div>
+							{someVal && !!items.length && <div></div>}
+						</div>
+					)
+				}
+			`,
+		},
+	],
+	valid: [
+		{
+			code: `
+				const test = () => {
+					return (
+						<div>
+							{!!items.length && <div></div>}
+						</div>
+					)
+				}
+			`,
+		},
+		{
+			code: `
+				const test = () => {
+					return (
+						<div>
+							{items.length ? <div></div> : null}
+						</div>
+					)
+				}
+			`,
+		},
+		{
+			code: `
+				const test = () => {
+					return (
+						<div>
+							{items && items.length}
+						</div>
+					)
+				}
+			`,
+		},
+	],
+});


### PR DESCRIPTION
fixes #648

This doesn't address if a user creates a variable first, but we can add that later if needed