### PR TITLE
fix(js-toolkit-core): add missing dependency

### DIFF
--- a/projects/js-toolkit/packages/js-toolkit-core/package.json
+++ b/projects/js-toolkit/packages/js-toolkit-core/package.json
@@ -6,6 +6,7 @@
 		"clone": "^2.1.2",
 		"cross-spawn": "^7.0.0",
 		"dot-prop": "^5.0.1",
+		"ejs": "^2.6.1",
 		"escodegen": "^1.14.1",
 		"estraverse": "^4.3.0",
 		"fs-extra": "^8.1.0",


### PR DESCRIPTION
We were missing `ejs` dependency.