### PR TITLE
feat(eslint-plugin): add one-var rule

### DIFF
--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/css-parse.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/css-parse.js
@@ -277,7 +277,8 @@ module.exports = function (css, options) {
 
 		// declarations
 
-		var decl, rule;
+		var decl;
+		var rule;
 		while ((decl = declaration()) || (rule = expandedatrule())) {
 			if (decl) {
 				decls.push(decl);

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/index.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/index.js
@@ -163,12 +163,12 @@ function processDeclaration(declaration, rule) {
 
 	// RegEx for comments is taken from http://www.w3.org/TR/CSS21/grammar.html
 
-	var commentRegEx = /\/\*[^*]*\*+([^/*][^*]*\*+)*\//g,
-		prop = declaration.property.replace(commentRegEx, ''), // remove comments
-		val = declaration.value.replace(commentRegEx, ''),
-		important = /!important/,
-		isImportant = val.match(important),
-		asterisk = prop.match(/^(\*+)(.+)/, '');
+	var commentRegEx = /\/\*[^*]*\*+([^/*][^*]*\*+)*\//g;
+	var prop = declaration.property.replace(commentRegEx, ''); // remove comments
+	var val = declaration.value.replace(commentRegEx, '');
+	var important = /!important/;
+	var isImportant = val.match(important);
+	var asterisk = prop.match(/^(\*+)(.+)/, '');
 
 	if (asterisk) {
 		prop = asterisk[2];

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/bg.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/bg.js
@@ -3,45 +3,45 @@
  * SPDX-License-Identifier: MIT
  */
 
-var urlLeft = /(?!left.*\/)(left)(?=.*\))/g,
-	urlRight = /(?!right.*\/)(right)(?=.*\))/g,
-	leftRe = /\s(left)\s/,
-	rightRe = /\s(right)\s/,
-	percRe = /(\d+)%/,
-	plug = function (r2) {
-		var r2bgimage = function (v) {
-			if (urlLeft.test(v)) {
-				v = v.replace(urlLeft, 'right');
-			}
-			else if (urlRight.test(v)) {
-				v = v.replace(urlRight, 'left');
-			}
+var urlLeft = /(?!left.*\/)(left)(?=.*\))/g;
+var urlRight = /(?!right.*\/)(right)(?=.*\))/g;
+var leftRe = /\s(left)\s/;
+var rightRe = /\s(right)\s/;
+var percRe = /(\d+)%/;
+var plug = function (r2) {
+	var r2bgimage = function (v) {
+		if (urlLeft.test(v)) {
+			v = v.replace(urlLeft, 'right');
+		}
+		else if (urlRight.test(v)) {
+			v = v.replace(urlRight, 'left');
+		}
 
-			return v;
-		};
-
-		var r2bg = function (v) {
-			v = r2bgimage(v);
-
-			if (v.match(leftRe)) {
-				v = v.replace(leftRe, ' right ');
-			}
-			else if (v.match(rightRe)) {
-				v = v.replace(rightRe, ' left ');
-			}
-			else {
-				var match = percRe.exec(v);
-
-				if (match) {
-					v = v.replace(percRe, 100 - match[1] + '%');
-				}
-			}
-
-			return v;
-		};
-
-		r2.valueMap['background'] = r2bg;
-		r2.valueMap['background-image'] = r2bgimage;
+		return v;
 	};
+
+	var r2bg = function (v) {
+		v = r2bgimage(v);
+
+		if (v.match(leftRe)) {
+			v = v.replace(leftRe, ' right ');
+		}
+		else if (v.match(rightRe)) {
+			v = v.replace(rightRe, ' left ');
+		}
+		else {
+			var match = percRe.exec(v);
+
+			if (match) {
+				v = v.replace(percRe, 100 - match[1] + '%');
+			}
+		}
+
+		return v;
+	};
+
+	r2.valueMap['background'] = r2bg;
+	r2.valueMap['background-image'] = r2bgimage;
+};
 
 module.exports.plug = plug;

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/fontawesome.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/fontawesome.js
@@ -4,38 +4,38 @@
  */
 
 var swapIcons = {
-		f053: 'f054',
-		f054: 'f053',
-		f060: 'f061',
-		f061: 'f060',
-		f0a4: 'f0a5',
-		f0a5: 'f0a4',
-		f0a8: 'f0a9',
-		f0a9: 'f0a8',
-		f0d9: 'f0da',
-		f0da: 'f0d9',
-		f100: 'f101',
-		f101: 'f100',
-		f104: 'f105',
-		f105: 'f104',
-		f137: 'f138',
-		f138: 'f137',
-		f177: 'f178',
-		f178: 'f177',
-	},
-	contentRegexp = /^"\\(.*)"$/,
-	plug = function (r2) {
-		r2.valueMap['content'] = function (v) {
-			if (contentRegexp.test(v)) {
-				const icon = contentRegexp.exec(v)[1];
+	f053: 'f054',
+	f054: 'f053',
+	f060: 'f061',
+	f061: 'f060',
+	f0a4: 'f0a5',
+	f0a5: 'f0a4',
+	f0a8: 'f0a9',
+	f0a9: 'f0a8',
+	f0d9: 'f0da',
+	f0da: 'f0d9',
+	f100: 'f101',
+	f101: 'f100',
+	f104: 'f105',
+	f105: 'f104',
+	f137: 'f138',
+	f138: 'f137',
+	f177: 'f178',
+	f178: 'f177',
+};
+var contentRegexp = /^"\\(.*)"$/;
+var plug = function (r2) {
+	r2.valueMap['content'] = function (v) {
+		if (contentRegexp.test(v)) {
+			const icon = contentRegexp.exec(v)[1];
 
-				if (swapIcons[icon]) {
-					v = '"\\' + swapIcons[icon] + '"';
-				}
+			if (swapIcons[icon]) {
+				v = '"\\' + swapIcons[icon] + '"';
 			}
+		}
 
-			return v;
-		};
+		return v;
 	};
+};
 
 module.exports.plug = plug;

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/yui3.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/yui3.js
@@ -3,86 +3,86 @@
  * SPDX-License-Identifier: MIT
  */
 
-var resizeHandleRegexp = /.yui3-resize-handle/,
-	resizeHandleInnerRegexp = /.yui3-resize-handle-inner-(tr|tl|br|bl)/,
-	cursorRegexp = /(.*)-resize/,
-	swapCursor = {
-		'e-resize': 'w-resize',
-		'ne-resize': 'nw-resize',
-		'nw-resize': 'ne-resize',
-		'se-resize': 'sw-resize',
-		'sw-resize': 'se-resize',
-		'w-resize': 'e-resize',
-	},
-	swapHandleInnerBg = {
-		bl: '-30px 0',
-		br: '-75px 0',
-		tl: '-58px 0',
-		tr: '-47px 0',
-	},
-	plug = function (r2) {
-		var originalBgPosFn = r2.valueMap['background-position'];
+var resizeHandleRegexp = /.yui3-resize-handle/;
+var resizeHandleInnerRegexp = /.yui3-resize-handle-inner-(tr|tl|br|bl)/;
+var cursorRegexp = /(.*)-resize/;
+var swapCursor = {
+	'e-resize': 'w-resize',
+	'ne-resize': 'nw-resize',
+	'nw-resize': 'ne-resize',
+	'se-resize': 'sw-resize',
+	'sw-resize': 'se-resize',
+	'w-resize': 'e-resize',
+};
+var swapHandleInnerBg = {
+	bl: '-30px 0',
+	br: '-75px 0',
+	tl: '-58px 0',
+	tr: '-47px 0',
+};
+var plug = function (r2) {
+	var originalBgPosFn = r2.valueMap['background-position'];
 
-		var yui3ResizeCursor = function (v, ctx) {
-			var swap = false;
+	var yui3ResizeCursor = function (v, ctx) {
+		var swap = false;
 
-			ctx.rule.selectors.forEach((selector) => {
-				if (resizeHandleRegexp.test(selector) && cursorRegexp.test(v)) {
-					swap = true;
-				}
-			});
-
-			if (swap) {
-				v = swapCursor[v] || v;
+		ctx.rule.selectors.forEach((selector) => {
+			if (resizeHandleRegexp.test(selector) && cursorRegexp.test(v)) {
+				swap = true;
 			}
+		});
 
-			return v;
-		};
+		if (swap) {
+			v = swapCursor[v] || v;
+		}
 
-		var yui3ResizeBgPosition = function (v, ctx) {
-			var swap = '';
-
-			ctx.rule.selectors.some((selector) => {
-				if (resizeHandleInnerRegexp.test(selector)) {
-					swap = selector;
-
-					return true;
-				}
-			});
-
-			if (swap) {
-				var handle = resizeHandleInnerRegexp.exec(swap)[1];
-				v = swapHandleInnerBg[handle] || v;
-			}
-			else {
-				v = originalBgPosFn(v, ctx);
-			}
-
-			return v;
-		};
-
-		var yui3ResizeOffset = function (v, ctx) {
-			var swap = '';
-
-			ctx.rule.selectors.some((selector) => {
-				if (resizeHandleInnerRegexp.test(selector)) {
-					swap = selector;
-
-					return true;
-				}
-			});
-
-			if (swap) {
-				v = '2px';
-			}
-
-			return v;
-		};
-
-		r2.valueMap['background-position'] = yui3ResizeBgPosition;
-		r2.valueMap['cursor'] = yui3ResizeCursor;
-		r2.valueMap['left'] = yui3ResizeOffset;
-		r2.valueMap['right'] = yui3ResizeOffset;
+		return v;
 	};
+
+	var yui3ResizeBgPosition = function (v, ctx) {
+		var swap = '';
+
+		ctx.rule.selectors.some((selector) => {
+			if (resizeHandleInnerRegexp.test(selector)) {
+				swap = selector;
+
+				return true;
+			}
+		});
+
+		if (swap) {
+			var handle = resizeHandleInnerRegexp.exec(swap)[1];
+			v = swapHandleInnerBg[handle] || v;
+		}
+		else {
+			v = originalBgPosFn(v, ctx);
+		}
+
+		return v;
+	};
+
+	var yui3ResizeOffset = function (v, ctx) {
+		var swap = '';
+
+		ctx.rule.selectors.some((selector) => {
+			if (resizeHandleInnerRegexp.test(selector)) {
+				swap = selector;
+
+				return true;
+			}
+		});
+
+		if (swap) {
+			v = '2px';
+		}
+
+		return v;
+	};
+
+	r2.valueMap['background-position'] = yui3ResizeBgPosition;
+	r2.valueMap['cursor'] = yui3ResizeCursor;
+	r2.valueMap['left'] = yui3ResizeOffset;
+	r2.valueMap['right'] = yui3ResizeOffset;
+};
 
 module.exports.plug = plug;

--- a/maintenance/projects/js-themes-toolkit-v9-x/scripts/qa.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/scripts/qa.js
@@ -131,7 +131,8 @@ function configureProjects() {
 
 		const pkgJson = require(pkgJsonPath);
 
-		let fileName, jsonProperty;
+		let fileName;
+		let jsonProperty;
 
 		if (pkgJson.liferayTheme && !pkgJson.liferayTheme.themelet) {
 			fileName = 'liferay-theme.json';

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-add-module-metadata/src/__tests__/index.test.js
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-add-module-metadata/src/__tests__/index.test.js
@@ -42,7 +42,8 @@ beforeAll(() => {
 });
 
 describe('plugin feature tests', () => {
-	let logger, manifest;
+	let logger;
+	let manifest;
 
 	beforeEach(() => {
 		babelIpc.set(filename, {

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-babel-loader/src/index.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-loader-babel-loader/src/index.js
@@ -57,7 +57,8 @@ function loadBabelPlugins(presets, plugins) {
 	return []
 		.concat(
 			...presets.map((preset) => {
-				let presetModule, presetName;
+				let presetModule;
+				let presetName;
 
 				try {
 					presetName = `babel-preset-${preset}`;

--- a/projects/eslint-plugin/configs/general.js
+++ b/projects/eslint-plugin/configs/general.js
@@ -111,6 +111,7 @@ const config = {
 		'no-unused-expressions': 'error',
 		'no-unused-vars': ['error', {argsIgnorePattern: '^_'}],
 		'object-shorthand': 'error',
+		'one-var': ['error', 'never'],
 		'padding-line-between-statements': [
 			'error',
 			{blankLine: 'always', next: 'return', prev: '*'},

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/css-parse.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/css-parse.js
@@ -277,7 +277,8 @@ module.exports = function (css, options) {
 
 		// declarations
 
-		var decl, rule;
+		var decl;
+		var rule;
 		while ((decl = declaration()) || (rule = expandedatrule())) {
 			if (decl) {
 				decls.push(decl);

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/index.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/index.js
@@ -175,12 +175,12 @@ function processDeclaration(declaration, rule) {
 
 	// RegEx for comments is taken from http://www.w3.org/TR/CSS21/grammar.html
 
-	var commentRegEx = /\/\*[^*]*\*+([^/*][^*]*\*+)*\//g,
-		prop = declaration.property.replace(commentRegEx, ''), // remove comments
-		val = declaration.value.replace(commentRegEx, ''),
-		important = /!important/,
-		isImportant = val.match(important),
-		asterisk = prop.match(/^(\*+)(.+)/, '');
+	var commentRegEx = /\/\*[^*]*\*+([^/*][^*]*\*+)*\//g;
+	var prop = declaration.property.replace(commentRegEx, ''); // remove comments
+	var val = declaration.value.replace(commentRegEx, '');
+	var important = /!important/;
+	var isImportant = val.match(important);
+	var asterisk = prop.match(/^(\*+)(.+)/, '');
 
 	if (asterisk) {
 		prop = asterisk[2];

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/bg.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/bg.js
@@ -3,45 +3,45 @@
  * SPDX-License-Identifier: MIT
  */
 
-var urlLeft = /(?!left.*\/)(left)(?=.*\))/g,
-	urlRight = /(?!right.*\/)(right)(?=.*\))/g,
-	leftRe = /\s(left)\s/,
-	rightRe = /\s(right)\s/,
-	percRe = /(\d+)%/,
-	plug = function (r2) {
-		var r2bgimage = function (v) {
-			if (urlLeft.test(v)) {
-				v = v.replace(urlLeft, 'right');
-			}
-			else if (urlRight.test(v)) {
-				v = v.replace(urlRight, 'left');
-			}
+var urlLeft = /(?!left.*\/)(left)(?=.*\))/g;
+var urlRight = /(?!right.*\/)(right)(?=.*\))/g;
+var leftRe = /\s(left)\s/;
+var rightRe = /\s(right)\s/;
+var percRe = /(\d+)%/;
+var plug = function (r2) {
+	var r2bgimage = function (v) {
+		if (urlLeft.test(v)) {
+			v = v.replace(urlLeft, 'right');
+		}
+		else if (urlRight.test(v)) {
+			v = v.replace(urlRight, 'left');
+		}
 
-			return v;
-		};
-
-		var r2bg = function (v) {
-			v = r2bgimage(v);
-
-			if (v.match(leftRe)) {
-				v = v.replace(leftRe, ' right ');
-			}
-			else if (v.match(rightRe)) {
-				v = v.replace(rightRe, ' left ');
-			}
-			else {
-				var match = percRe.exec(v);
-
-				if (match) {
-					v = v.replace(percRe, 100 - match[1] + '%');
-				}
-			}
-
-			return v;
-		};
-
-		r2.valueMap['background'] = r2bg;
-		r2.valueMap['background-image'] = r2bgimage;
+		return v;
 	};
+
+	var r2bg = function (v) {
+		v = r2bgimage(v);
+
+		if (v.match(leftRe)) {
+			v = v.replace(leftRe, ' right ');
+		}
+		else if (v.match(rightRe)) {
+			v = v.replace(rightRe, ' left ');
+		}
+		else {
+			var match = percRe.exec(v);
+
+			if (match) {
+				v = v.replace(percRe, 100 - match[1] + '%');
+			}
+		}
+
+		return v;
+	};
+
+	r2.valueMap['background'] = r2bg;
+	r2.valueMap['background-image'] = r2bgimage;
+};
 
 module.exports.plug = plug;

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/fontawesome.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/fontawesome.js
@@ -4,38 +4,38 @@
  */
 
 var swapIcons = {
-		f053: 'f054',
-		f054: 'f053',
-		f060: 'f061',
-		f061: 'f060',
-		f0a4: 'f0a5',
-		f0a5: 'f0a4',
-		f0a8: 'f0a9',
-		f0a9: 'f0a8',
-		f0d9: 'f0da',
-		f0da: 'f0d9',
-		f100: 'f101',
-		f101: 'f100',
-		f104: 'f105',
-		f105: 'f104',
-		f137: 'f138',
-		f138: 'f137',
-		f177: 'f178',
-		f178: 'f177',
-	},
-	contentRegexp = /^"\\(.*)"$/,
-	plug = function (r2) {
-		r2.valueMap['content'] = function (v) {
-			if (contentRegexp.test(v)) {
-				const icon = contentRegexp.exec(v)[1];
+	f053: 'f054',
+	f054: 'f053',
+	f060: 'f061',
+	f061: 'f060',
+	f0a4: 'f0a5',
+	f0a5: 'f0a4',
+	f0a8: 'f0a9',
+	f0a9: 'f0a8',
+	f0d9: 'f0da',
+	f0da: 'f0d9',
+	f100: 'f101',
+	f101: 'f100',
+	f104: 'f105',
+	f105: 'f104',
+	f137: 'f138',
+	f138: 'f137',
+	f177: 'f178',
+	f178: 'f177',
+};
+var contentRegexp = /^"\\(.*)"$/;
+var plug = function (r2) {
+	r2.valueMap['content'] = function (v) {
+		if (contentRegexp.test(v)) {
+			const icon = contentRegexp.exec(v)[1];
 
-				if (swapIcons[icon]) {
-					v = '"\\' + swapIcons[icon] + '"';
-				}
+			if (swapIcons[icon]) {
+				v = '"\\' + swapIcons[icon] + '"';
 			}
+		}
 
-			return v;
-		};
+		return v;
 	};
+};
 
 module.exports.plug = plug;

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/yui3.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/yui3.js
@@ -3,86 +3,86 @@
  * SPDX-License-Identifier: MIT
  */
 
-var resizeHandleRegexp = /.yui3-resize-handle/,
-	resizeHandleInnerRegexp = /.yui3-resize-handle-inner-(tr|tl|br|bl)/,
-	cursorRegexp = /(.*)-resize/,
-	swapCursor = {
-		'e-resize': 'w-resize',
-		'ne-resize': 'nw-resize',
-		'nw-resize': 'ne-resize',
-		'se-resize': 'sw-resize',
-		'sw-resize': 'se-resize',
-		'w-resize': 'e-resize',
-	},
-	swapHandleInnerBg = {
-		bl: '-30px 0',
-		br: '-75px 0',
-		tl: '-58px 0',
-		tr: '-47px 0',
-	},
-	plug = function (r2) {
-		var originalBgPosFn = r2.valueMap['background-position'];
+var resizeHandleRegexp = /.yui3-resize-handle/;
+var resizeHandleInnerRegexp = /.yui3-resize-handle-inner-(tr|tl|br|bl)/;
+var cursorRegexp = /(.*)-resize/;
+var swapCursor = {
+	'e-resize': 'w-resize',
+	'ne-resize': 'nw-resize',
+	'nw-resize': 'ne-resize',
+	'se-resize': 'sw-resize',
+	'sw-resize': 'se-resize',
+	'w-resize': 'e-resize',
+};
+var swapHandleInnerBg = {
+	bl: '-30px 0',
+	br: '-75px 0',
+	tl: '-58px 0',
+	tr: '-47px 0',
+};
+var plug = function (r2) {
+	var originalBgPosFn = r2.valueMap['background-position'];
 
-		var yui3ResizeCursor = function (v, ctx) {
-			var swap = false;
+	var yui3ResizeCursor = function (v, ctx) {
+		var swap = false;
 
-			ctx.rule.selectors.forEach((selector) => {
-				if (resizeHandleRegexp.test(selector) && cursorRegexp.test(v)) {
-					swap = true;
-				}
-			});
-
-			if (swap) {
-				v = swapCursor[v] || v;
+		ctx.rule.selectors.forEach((selector) => {
+			if (resizeHandleRegexp.test(selector) && cursorRegexp.test(v)) {
+				swap = true;
 			}
+		});
 
-			return v;
-		};
+		if (swap) {
+			v = swapCursor[v] || v;
+		}
 
-		var yui3ResizeBgPosition = function (v, ctx) {
-			var swap = '';
-
-			ctx.rule.selectors.some((selector) => {
-				if (resizeHandleInnerRegexp.test(selector)) {
-					swap = selector;
-
-					return true;
-				}
-			});
-
-			if (swap) {
-				var handle = resizeHandleInnerRegexp.exec(swap)[1];
-				v = swapHandleInnerBg[handle] || v;
-			}
-			else {
-				v = originalBgPosFn(v, ctx);
-			}
-
-			return v;
-		};
-
-		var yui3ResizeOffset = function (v, ctx) {
-			var swap = '';
-
-			ctx.rule.selectors.some((selector) => {
-				if (resizeHandleInnerRegexp.test(selector)) {
-					swap = selector;
-
-					return true;
-				}
-			});
-
-			if (swap) {
-				v = '2px';
-			}
-
-			return v;
-		};
-
-		r2.valueMap['background-position'] = yui3ResizeBgPosition;
-		r2.valueMap['cursor'] = yui3ResizeCursor;
-		r2.valueMap['left'] = yui3ResizeOffset;
-		r2.valueMap['right'] = yui3ResizeOffset;
+		return v;
 	};
+
+	var yui3ResizeBgPosition = function (v, ctx) {
+		var swap = '';
+
+		ctx.rule.selectors.some((selector) => {
+			if (resizeHandleInnerRegexp.test(selector)) {
+				swap = selector;
+
+				return true;
+			}
+		});
+
+		if (swap) {
+			var handle = resizeHandleInnerRegexp.exec(swap)[1];
+			v = swapHandleInnerBg[handle] || v;
+		}
+		else {
+			v = originalBgPosFn(v, ctx);
+		}
+
+		return v;
+	};
+
+	var yui3ResizeOffset = function (v, ctx) {
+		var swap = '';
+
+		ctx.rule.selectors.some((selector) => {
+			if (resizeHandleInnerRegexp.test(selector)) {
+				swap = selector;
+
+				return true;
+			}
+		});
+
+		if (swap) {
+			v = '2px';
+		}
+
+		return v;
+	};
+
+	r2.valueMap['background-position'] = yui3ResizeBgPosition;
+	r2.valueMap['cursor'] = yui3ResizeCursor;
+	r2.valueMap['left'] = yui3ResizeOffset;
+	r2.valueMap['right'] = yui3ResizeOffset;
+};
 
 module.exports.plug = plug;


### PR DESCRIPTION
With the gentle nudge by @nhpatt I ended up testing and using the [one-var](https://eslint.org/docs/rules/one-var) rule with the `['error', 'never']` settings. I have tested it inside `liferay-portal` and it produces 72 autofixable errors.

~~I found this [one-var-declaration-per-line](https://eslint.org/docs/rules/one-var-declaration-per-line) ESLint rule. When I plugged it in `liferay-portal` it produced 63 errors, all of which are auto-fixable. The autofix is weird as it just pushes the vars to a new line. The autofix issue can be seen in the 2nd commit.~~
