### PR TITLE
fix(dev-server): fix a typo for protocol notation

### DIFF
--- a/projects/js-toolkit/packages/dev-server/src/server.ts
+++ b/projects/js-toolkit/packages/dev-server/src/server.ts
@@ -300,7 +300,9 @@ export default async function (): Promise<void> {
 		}
 	}).listen(port);
 
-	log(chalk.green(`\nLiferay Dev Server is ready at http:127.0.0.1:${port}`));
+	log(
+		chalk.green(`\nLiferay Dev Server is ready at http://127.0.0.1:${port}`)
+	);
 
 	open(`http://127.0.0.1:${port}`);
 


### PR DESCRIPTION
It came from: https://github.com/liferay/liferay-frontend-projects/pull/698

One diff(this specific one) >>> Image >>> Words 

<img width="610" alt="Screen Shot 2021-10-19 at 13 00 19" src="https://user-images.githubusercontent.com/7663513/137948372-0e7df692-c3b1-4fd6-b2ba-74827f837835.png">


