### PR TITLE
wip(eslint-plugin): add new blank-line-declaration-usage rule and tests for it

### DIFF
--- a/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/lib/doctor.js
+++ b/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/lib/doctor.js
@@ -86,6 +86,7 @@ function assertTasksSupported(version, tasks) {
 			default:
 				{
 					const message = getSupportedTasks(task)[version] || '';
+
 					if (message !== true) {
 						log(
 							colors.yellow(

--- a/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
+++ b/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
@@ -438,6 +438,7 @@ it('_promptThemeSource should prompt correct workflow', () => {
 	prototype._promptThemeSource();
 
 	const args = inquirer.prompt.getCall(0).args;
+
 	const questions = args[0];
 
 	const extendType = questions[0];

--- a/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/lib/prompts/__tests__/prompt_util.test.js
+++ b/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/lib/prompts/__tests__/prompt_util.test.js
@@ -66,6 +66,7 @@ it('getModuleChoices should get module choices that are appropriate for extend t
 
 	_.forEach(choices, (item, index) => {
 		const number = index + 1;
+
 		const name = 'themelet-' + number;
 
 		expect(item.name).toBe(name);
@@ -78,6 +79,7 @@ it('getModuleChoices should get module choices that are appropriate for extend t
 
 	_.forEach(choices, (item, index) => {
 		const number = index + 1;
+
 		const name = 'themelet-' + number;
 
 		if (number === 1) {
@@ -93,6 +95,7 @@ it('getModuleChoices should get module choices that are appropriate for extend t
 
 	_.forEach(choices, (item, index) => {
 		const number = index + 1;
+
 		const name = 'themelet-' + number;
 
 		expect(!item.checked).toBe(true);
@@ -106,6 +109,7 @@ it('getModuleChoices should get module choices that are appropriate for extend t
 
 	_.forEach(choices, (item, index) => {
 		const number = index + 1;
+
 		const name = 'themelet-' + number;
 
 		if (number === 1) {

--- a/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
+++ b/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
@@ -71,6 +71,7 @@ class ExtendPrompt {
 		const baseTheme = this.themeConfig.baseTheme;
 		const module = answers.module;
 		const modulePackages = answers.modules;
+
 		const pkg = modulePackages[module];
 
 		if (!module) {

--- a/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/lib/theme_finder.js
+++ b/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/lib/theme_finder.js
@@ -114,9 +114,11 @@ function getLiferayThemeModuleFromURL(url) {
 		// Just in case package name doesn't match URL basename, read it.
 
 		const {dependencies} = JSON.parse(fs.readFileSync('package.json'));
+
 		const themeName = Object.keys(dependencies)[0];
 
 		const json = path.join('node_modules', themeName, 'package.json');
+
 		config = JSON.parse(fs.readFileSync(json));
 	});
 
@@ -183,6 +185,7 @@ module.exports = {
  */
 function withScratchDirectory(cb) {
 	const template = path.join(os.tmpdir(), 'theme-finder-');
+
 	const directory = fs.mkdtempSync(template);
 
 	const cwd = process.cwd();

--- a/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/lib/upgrade/6.2/upgrade.js
+++ b/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/lib/upgrade/6.2/upgrade.js
@@ -281,6 +281,7 @@ module.exports = function (options) {
 			.pipe(
 				plugins.filter((file) => {
 					const extname = path.extname(file.path).slice(1);
+
 					const basename = path.basename(file.path, `.${extname}`);
 
 					if (promptResults[basename][extname]) {

--- a/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/lib/util.js
+++ b/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/lib/util.js
@@ -18,6 +18,7 @@ const lfrThemeConfig = require('./liferay_theme_config');
 const argv = minimist(process.argv.slice(2));
 
 const pkg = lfrThemeConfig.getConfig(true);
+
 const themeConfig = pkg.liferayTheme;
 
 const CUSTOM_DEP_PATH_ENV_VARIABLE_MAP = {

--- a/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/tasks/__tests__/build.test.js
+++ b/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/tasks/__tests__/build.test.js
@@ -147,6 +147,7 @@ describe('using lib_sass', () => {
 
 	function _assertFixAtDirectives(cb) {
 		const cssPath = path.join(buildPath, 'css');
+
 		const mainCssPath = path.join(cssPath, 'main.css');
 
 		expect(fs.existsSync(cssPath)).toBe(true);
@@ -195,6 +196,7 @@ describe('using lib_sass', () => {
 		expect(fs.existsSync(templatesPath)).toBe(true);
 
 		const customCSSFileName = '_custom.scss';
+
 		const customCSSPath = path.join(cssPath, customCSSFileName);
 
 		const fileContent = testUtil.stripNewlines(
@@ -288,6 +290,7 @@ describe('using lib_sass', () => {
 		expect(fs.existsSync(velocityPath)).toBe(true);
 
 		const customCSSFileName = '_custom.scss';
+
 		const customCSSPath = path.join(buildPath, 'css', customCSSFileName);
 
 		expect(fs.readFileSync(customCSSPath).toString()).toMatch(

--- a/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/tasks/__tests__/status.test.js
+++ b/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/tasks/__tests__/status.test.js
@@ -16,6 +16,7 @@ beforeEach(() => {
 		namespace: 'status_task',
 		registerTasks: true,
 	});
+
 	runSequence = config.runSequence;
 });
 

--- a/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/tasks/deploy.js
+++ b/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/tasks/deploy.js
@@ -12,6 +12,7 @@ const DEPLOYMENT_STRATEGIES = themeUtil.DEPLOYMENT_STRATEGIES;
 
 function registerTasks(options) {
 	const {argv, gulp, pathDist} = options;
+
 	const {storage} = gulp;
 
 	const runSequence = require('run-sequence').use(gulp);

--- a/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/tasks/watch.js
+++ b/maintenance/projects/js-themes-toolkit-v8-x/packages/liferay-theme-tasks/tasks/watch.js
@@ -185,8 +185,11 @@ module.exports = function (options) {
 
 	gulp.task('watch:reload', (cb) => {
 		const changedFile = storage.get('changedFile');
+
 		const srcPath = path.relative(process.cwd(), changedFile.path);
+
 		const dstPath = srcPath.replace(/^src\//, '');
+
 		const urlPath = `${resourcePrefix}/${distName}/${dstPath}`;
 
 		livereload.changed({
@@ -276,8 +279,10 @@ module.exports = function (options) {
 			const requestUrl = url.parse(req.url);
 
 			const match = themePattern.exec(requestUrl.pathname);
+
 			if (match) {
 				const filepath = path.resolve('build', match[3]);
+
 				const ext = path.extname(filepath);
 
 				isReadable(filepath).then((exists) => {
@@ -307,9 +312,11 @@ module.exports = function (options) {
 				`Watch mode is now active at: ${url}`,
 				`Proxying: ${proxyUrl}`,
 			];
+
 			const width = messages.reduce((max, line) => {
 				return Math.max(line.length, max);
 			}, 0);
+
 			const ruler = '-'.repeat(width);
 
 			// eslint-disable-next-line no-console

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/generator-liferay-theme/generators/layout/standalone-layout.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/generator-liferay-theme/generators/layout/standalone-layout.js
@@ -30,7 +30,9 @@ module.exports = class extends Generator {
 		const cp = new Copier(this);
 
 		const {layoutId, liferayVersion} = this.answers;
+
 		const layoutName = snakeCase(layoutId);
+
 		const templateFilename = `${layoutName}.ftl`;
 		const thumbnailFilename = `${layoutName}.png`;
 
@@ -71,6 +73,7 @@ module.exports = class extends Generator {
 
 	_getDevDependencies() {
 		const {liferayVersion} = this.answers;
+
 		const devDependencies = devDependenciesMap[liferayVersion].default;
 
 		return JSON.stringify(devDependencies, null, 2)

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/generator-liferay-theme/generators/layout/theme-layout.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/generator-liferay-theme/generators/layout/theme-layout.js
@@ -25,7 +25,9 @@ module.exports = class extends Generator {
 		const cp = new Copier(this);
 
 		const {layoutId, liferayVersion} = this.answers;
+
 		const layoutName = snakeCase(layoutId);
+
 		const templateFilename = `${layoutName}.ftl`;
 		const thumbnailFilename = `${layoutName}.png`;
 

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/generator-liferay-theme/lib/Copier.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/generator-liferay-theme/lib/Copier.js
@@ -51,6 +51,7 @@ module.exports = class Copier {
 	 */
 	copyDir(src, {context = {}} = {}) {
 		const gen = this._generator;
+
 		const files = fs.readdirSync(gen.templatePath(src));
 
 		files.forEach((file) => {

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/generator-liferay-theme/lib/Project.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/generator-liferay-theme/lib/Project.js
@@ -15,6 +15,7 @@ class Project {
 
 	get type() {
 		const {fs} = this._generator;
+
 		const pkgJson = fs.readJSON('package.json');
 
 		if (pkgJson === undefined) {

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/generator-liferay-theme/lib/generation/theme-based.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/generator-liferay-theme/lib/generation/theme-based.js
@@ -28,6 +28,7 @@ const pipeline = promisify(stream.pipeline);
 
 async function writing(generator, themeName) {
 	const project = new Project(generator);
+
 	const {liferayVersion} = project;
 
 	print(

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/index.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/index.js
@@ -42,6 +42,7 @@ module.exports.registerTasks = function (options) {
 
 function register(options) {
 	const gulp = (options.gulp = plugins.help(options.gulp));
+
 	const store = gulp.storage;
 
 	store.set('changedFile');

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/__tests__/util.test.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/__tests__/util.test.js
@@ -61,6 +61,7 @@ describe('resolveDependency()', () => {
 		const resolved = util.resolveDependency(
 			'liferay-frontend-theme-styled'
 		);
+
 		expect(resolved).toContain(process.cwd());
 	});
 });

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
@@ -436,6 +436,7 @@ it('_promptThemeSource should prompt correct workflow', () => {
 	prototype._promptThemeSource();
 
 	const args = inquirer.prompt.getCall(0).args;
+
 	const questions = args[0];
 
 	const extendType = questions[0];

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/prompts/__tests__/prompt_util.test.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/prompts/__tests__/prompt_util.test.js
@@ -66,6 +66,7 @@ it('getModuleChoices should get module choices that are appropriate for extend t
 
 	_.forEach(choices, (item, index) => {
 		const number = index + 1;
+
 		const name = 'themelet-' + number;
 
 		expect(item.name).toBe(name);
@@ -78,6 +79,7 @@ it('getModuleChoices should get module choices that are appropriate for extend t
 
 	_.forEach(choices, (item, index) => {
 		const number = index + 1;
+
 		const name = 'themelet-' + number;
 
 		if (number === 1) {
@@ -93,6 +95,7 @@ it('getModuleChoices should get module choices that are appropriate for extend t
 
 	_.forEach(choices, (item, index) => {
 		const number = index + 1;
+
 		const name = 'themelet-' + number;
 
 		expect(!item.checked).toBe(true);
@@ -106,6 +109,7 @@ it('getModuleChoices should get module choices that are appropriate for extend t
 
 	_.forEach(choices, (item, index) => {
 		const number = index + 1;
+
 		const name = 'themelet-' + number;
 
 		if (number === 1) {

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
@@ -69,6 +69,7 @@ class ExtendPrompt {
 		const baseTheme = this.themeConfig.baseTheme;
 		const module = answers.module;
 		const modulePackages = answers.modules;
+
 		const pkg = modulePackages[module];
 
 		if (!module) {

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/prompts/url_package_prompt.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/prompts/url_package_prompt.js
@@ -82,6 +82,7 @@ class URLPackagePrompt {
 		if (this.themelet && answers.module) {
 			Object.keys(answers.module).forEach((k) => {
 				const moduleName = this.config.selectedModules[k];
+
 				answers.module[moduleName] = answers.module[k];
 				delete answers.module[k];
 			});

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/css-parse.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/css-parse.js
@@ -26,10 +26,12 @@ module.exports = function (css, options) {
 
 	function updatePosition(str) {
 		var lines = str.match(/\n/g);
+
 		if (lines) {
 			lineno += lines.length;
 		}
 		var i = str.lastIndexOf('\n');
+
 		column = ~i ? str.length - i : column + str.length;
 	}
 
@@ -80,6 +82,7 @@ module.exports = function (css, options) {
 
 	function error(msg, start) {
 		var err = new Error(`${filename} (${lineno}:${column}) ${msg}`);
+
 		err.position = new Position(start);
 		err.filename = filename;
 		err.description = msg;
@@ -142,10 +145,12 @@ module.exports = function (css, options) {
 
 	function match(re) {
 		var m = re.exec(css);
+
 		if (!m) {
 			return;
 		}
 		var str = m[0];
+
 		updatePosition(str);
 		css = css.slice(str.length);
 
@@ -211,6 +216,7 @@ module.exports = function (css, options) {
 
 	function selector() {
 		var m = match(/^([^{]+)/);
+
 		if (!m) {
 			return;
 		}
@@ -232,6 +238,7 @@ module.exports = function (css, options) {
 		// prop
 
 		var prop = match(/^(\*?[-#/*\w]+(\[[0-9a-z_-]+\])?)\s*/);
+
 		if (!prop) {
 			return;
 		}
@@ -246,6 +253,7 @@ module.exports = function (css, options) {
 		// val
 
 		var val = match(/^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|\([^)]*?\)|[^};])+)/);
+
 		if (!val) {
 			return error('property missing value');
 		}
@@ -462,6 +470,7 @@ module.exports = function (css, options) {
 	function atpage() {
 		var pos = position();
 		var m = match(/^@page */);
+
 		if (!m) {
 			return;
 		}
@@ -499,6 +508,7 @@ module.exports = function (css, options) {
 	function atdocument() {
 		var pos = position();
 		var m = match(/^@([-\w]+)?document *([^{]+)/);
+
 		if (!m) {
 			return;
 		}
@@ -585,10 +595,12 @@ module.exports = function (css, options) {
 	function _atrule(name) {
 		var pos = position();
 		var m = match(new RegExp('^@' + name + ' *([^;\\n]+);'));
+
 		if (!m) {
 			return;
 		}
 		var ret = {type: name};
+
 		ret[name] = trim(m[1]);
 
 		return pos(ret);

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/index.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/index.js
@@ -67,6 +67,7 @@ function bgPosition(v) {
 		v = v.replace(/\bright\b/, 'left');
 	}
 	var m = v.trim().split(/\s+/);
+
 	if (m && m.length === 1 && v.match(/(\d+)([a-z]{2}|%)/)) {
 		v = 'right ' + v;
 	}
@@ -139,6 +140,7 @@ var valueMap = {
 
 function processRule(rule, idx, list) {
 	var prev = list[idx - 1];
+
 	if (prev && prev.type === 'comment' && prev.comment.trim() === '@noflip') {
 		return;
 	}
@@ -164,9 +166,11 @@ function processDeclaration(declaration, rule) {
 	// RegEx for comments is taken from http://www.w3.org/TR/CSS21/grammar.html
 
 	var commentRegEx = /\/\*[^*]*\*+([^/*][^*]*\*+)*\//g;
+
 	var prop = declaration.property.replace(commentRegEx, ''); // remove comments
 	var val = declaration.value.replace(commentRegEx, '');
 	var important = /!important/;
+
 	var isImportant = val.match(important);
 	var asterisk = prop.match(/^(\*+)(.+)/, '');
 

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/yui3.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/yui3.js
@@ -52,6 +52,7 @@ var plug = function (r2) {
 
 		if (swap) {
 			var handle = resizeHandleInnerRegexp.exec(swap)[1];
+
 			v = swapHandleInnerBg[handle] || v;
 		}
 		else {

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/theme_finder.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/lib/theme_finder.js
@@ -114,9 +114,11 @@ function getLiferayThemeModuleFromURL(url) {
 		// Just in case package name doesn't match URL basename, read it.
 
 		const {dependencies} = JSON.parse(fs.readFileSync('package.json'));
+
 		const themeName = Object.keys(dependencies)[0];
 
 		const json = path.join('node_modules', themeName, 'package.json');
+
 		config = JSON.parse(fs.readFileSync(json));
 	});
 
@@ -183,6 +185,7 @@ module.exports = {
  */
 function withScratchDirectory(cb) {
 	const template = path.join(os.tmpdir(), 'theme-finder-');
+
 	const directory = fs.mkdtempSync(template);
 
 	const cwd = process.cwd();

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/tasks/__tests__/build.test.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/tasks/__tests__/build.test.js
@@ -158,6 +158,7 @@ describe('using lib_sass', () => {
 
 	function _assertFixAtDirectives(cb) {
 		const cssPath = path.join(buildPath, 'css');
+
 		const mainCssPath = path.join(cssPath, 'main.css');
 
 		expect(fs.existsSync(cssPath)).toBe(true);
@@ -206,6 +207,7 @@ describe('using lib_sass', () => {
 		expect(fs.existsSync(templatesPath)).toBe(true);
 
 		const customCSSFileName = '_custom.scss';
+
 		const customCSSPath = path.join(cssPath, customCSSFileName);
 
 		const fileContent = testUtil.stripNewlines(
@@ -299,6 +301,7 @@ describe('using lib_sass', () => {
 		expect(fs.existsSync(velocityPath)).toBe(true);
 
 		const customCSSFileName = '_custom.scss';
+
 		const customCSSPath = path.join(buildPath, 'css', customCSSFileName);
 
 		expect(fs.readFileSync(customCSSPath).toString()).toMatch(

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/tasks/__tests__/status.test.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/tasks/__tests__/status.test.js
@@ -14,6 +14,7 @@ beforeEach(() => {
 		namespace: 'status_task',
 		registerTasks: true,
 	});
+
 	runSequence = config.runSequence;
 });
 

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -144,6 +144,7 @@ function getSassIncludePaths() {
 	includePaths.push(path.dirname(require.resolve('compass-mixins')));
 
 	const argv = themeUtil.getArgv();
+
 	if (argv['sass-include-paths']) {
 		const customPaths = argv['sass-include-paths']
 			.split(',')
@@ -156,6 +157,7 @@ function getSassIncludePaths() {
 	}
 
 	const themeNodeModules = path.resolve('node_modules');
+
 	if (fs.existsSync(themeNodeModules)) {
 		includePaths.push(themeNodeModules);
 	}

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/tasks/deploy.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/tasks/deploy.js
@@ -12,6 +12,7 @@ const DEPLOYMENT_STRATEGIES = themeUtil.DEPLOYMENT_STRATEGIES;
 
 function registerTasks(options) {
 	const {argv, gulp, pathDist} = options;
+
 	const {storage} = gulp;
 
 	const runSequence = require('run-sequence').use(gulp);

--- a/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/tasks/watch.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/packages/liferay-theme-tasks/tasks/watch.js
@@ -185,8 +185,11 @@ module.exports = function (options) {
 
 	gulp.task('watch:reload', (cb) => {
 		const changedFile = storage.get('changedFile');
+
 		const srcPath = path.relative(process.cwd(), changedFile.path);
+
 		const dstPath = srcPath.replace(/^src\//, '');
+
 		const urlPath = `${resourcePrefix}/${distName}/${dstPath}`;
 
 		livereload.changed({
@@ -276,8 +279,10 @@ module.exports = function (options) {
 			const requestUrl = url.parse(req.url);
 
 			const match = themePattern.exec(requestUrl.pathname);
+
 			if (match) {
 				const filepath = path.resolve('build', match[3]);
+
 				const ext = path.extname(filepath);
 
 				isReadable(filepath).then((exists) => {
@@ -307,9 +312,11 @@ module.exports = function (options) {
 				`Watch mode is now active at: ${url}`,
 				`Proxying: ${proxyUrl}`,
 			];
+
 			const width = messages.reduce((max, line) => {
 				return Math.max(line.length, max);
 			}, 0);
+
 			const ruler = '-'.repeat(width);
 
 			// eslint-disable-next-line no-console

--- a/maintenance/projects/js-themes-toolkit-v9-x/scripts/qa.js
+++ b/maintenance/projects/js-themes-toolkit-v9-x/scripts/qa.js
@@ -11,6 +11,7 @@ const path = require('path');
 const {argv} = require('yargs');
 
 const workDir = path.resolve(__dirname, '..', 'qa');
+
 const pkgsDir = path.join(workDir, 'packages');
 const yoPath = path.join(workDir, 'node_modules', '.bin', 'yo');
 

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-add-module-metadata/src/__tests__/index.test.js
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-add-module-metadata/src/__tests__/index.test.js
@@ -15,6 +15,7 @@ import plugin from '../index';
 
 const prjDirPath = path.join(__dirname, '__fixtures__', 'a-project');
 const prjRelModulePath = path.join('path', 'to', 'module.js');
+
 const filename = path.join(prjDirPath, prjRelModulePath);
 const prjPkgDesc = new PkgDesc('a-project', '1.0.0', null);
 

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-add-module-metadata/src/index.js
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-add-module-metadata/src/index.js
@@ -120,7 +120,9 @@ function addEsModuleFlag(state) {
 	}
 
 	const {filename} = state.file.opts;
+
 	const pkgDir = babelUtil.getPackageDir(filename);
+
 	const pkgJson = readJsonSync(npath.join(pkgDir, 'package.json'));
 
 	const {rootPkgJson} = babelIpc.get(state);

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-alias-modules/src/index.ts
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-alias-modules/src/index.ts
@@ -44,6 +44,7 @@ export class Visitor {
 	CallExpression(bpath) {
 		const {_log} = this;
 		const {node} = bpath;
+
 		const {callee} = node;
 
 		if (!t.isIdentifier(callee)) {

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-name-amd-modules/src/__tests__/index.test.js
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-name-amd-modules/src/__tests__/index.test.js
@@ -12,6 +12,7 @@ import path from 'path';
 import plugin from '../index';
 
 const prjDirPath = path.join(__dirname, '__fixtures__', 'a-project');
+
 const filename = path.join(prjDirPath, 'path', 'to', 'module.js');
 
 beforeAll(() => {

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-namespace-modules/src/__tests__/index.test.js
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-namespace-modules/src/__tests__/index.test.js
@@ -12,6 +12,7 @@ import path from 'path';
 import plugin from '../index';
 
 const prjDirPath = path.join(__dirname, '__fixtures__', 'a-project');
+
 const filename = path.join(prjDirPath, 'path', 'to', 'module.js');
 
 const imports = {

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-namespace-modules/src/index.js
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-namespace-modules/src/index.js
@@ -45,6 +45,7 @@ export default function ({types: t}) {
 				node: {expression},
 			} = path;
 			const {opts} = state;
+
 			const {namespaces, unrolledImports} = opts;
 
 			if (!t.isCallExpression(expression)) {
@@ -137,6 +138,7 @@ export default function ({types: t}) {
 		exit(path, state) {
 			const {node} = path;
 			const {opts} = state;
+
 			const {namespaces, unrolledImports} = opts;
 
 			if (node.name !== 'require') {
@@ -269,7 +271,9 @@ export default function ({types: t}) {
  */
 function addDependencyNamespace(moduleName, namespacePkg, unrolledImports) {
 	const {pkgName, scope} = mod.splitModuleName(moduleName);
+
 	const fullPkgName = mod.joinModuleName(scope, pkgName);
+
 	const pkg = unrolledImports[fullPkgName] || namespacePkg;
 
 	return pkg.name === '' ? moduleName : ns.addNamespace(moduleName, pkg);

--- a/maintenance/projects/js-toolkit/packages/babel-plugin-wrap-modules-amd/src/index.js
+++ b/maintenance/projects/js-toolkit/packages/babel-plugin-wrap-modules-amd/src/index.js
@@ -105,6 +105,7 @@ export default function ({types: t}) {
 					path.traverse(wrapVisitor, state);
 
 					const {node} = path;
+
 					const {body} = node;
 
 					dependencies = Object.keys(dependencies).map(

--- a/maintenance/projects/js-toolkit/packages/generator-liferay-js/src/adapt/index.js
+++ b/maintenance/projects/js-toolkit/packages/generator-liferay-js/src/adapt/index.js
@@ -273,6 +273,7 @@ export default class extends Generator {
 		const npmbundlerrc = new NpmbundlerrcModifier(this);
 		const pkgJson = new PkgJsonModifier(this, 2);
 		const projectAnalyzer = new ProjectAnalyzer(this);
+
 		const portletName = getPortletName(projectAnalyzer);
 
 		const {preset} = this._options;

--- a/maintenance/projects/js-toolkit/packages/generator-liferay-js/src/facet-portlet/index.js
+++ b/maintenance/projects/js-toolkit/packages/generator-liferay-js/src/facet-portlet/index.js
@@ -46,6 +46,7 @@ export default class extends Generator {
 		const npmbundlerrc = new NpmbundlerrcModifier(this);
 		const pkgJson = new PkgJsonModifier(this);
 		const projectAnalyzer = new ProjectAnalyzer(this);
+
 		const portletName = getPortletName(projectAnalyzer);
 		const portletDisplayName = projectAnalyzer.displayName;
 

--- a/maintenance/projects/js-toolkit/packages/generator-liferay-js/src/utils/ProjectAnalyzer.js
+++ b/maintenance/projects/js-toolkit/packages/generator-liferay-js/src/utils/ProjectAnalyzer.js
@@ -84,6 +84,7 @@ export default class ProjectAnalyzer {
 	 */
 	get localizationBundleName() {
 		const bundleName = path.basename(this.localizationFilePath);
+
 		const extname = path.extname(bundleName);
 
 		return bundleName.replace(new RegExp(extname.replace('.', '\\.')), '');

--- a/maintenance/projects/js-toolkit/packages/generator-liferay-js/src/utils/index.js
+++ b/maintenance/projects/js-toolkit/packages/generator-liferay-js/src/utils/index.js
@@ -53,6 +53,7 @@ export class Copier {
 	 */
 	copyDir(src, {context = {}} = {}) {
 		const gen = this._generator;
+
 		const files = fs.readdirSync(gen.templatePath(src));
 
 		files.forEach((file) => {

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/__tests__/manifest.test.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/__tests__/manifest.test.js
@@ -48,6 +48,7 @@ describe('save', () => {
 		manifest.addPackage(srcPkg2, destPkg2);
 
 		const tmpDir = fs.mkdtempSync('manifest');
+
 		const tmpFilePath = path.join(tmpDir, 'manifest.json');
 
 		manifest.save(tmpFilePath);
@@ -67,6 +68,7 @@ describe('save', () => {
 
 it('constructor with file works', () => {
 	const tmpDir = fs.mkdtempSync('manifest');
+
 	const tmpFilePath = path.join(tmpDir, 'manifest.json');
 
 	const manifest = new Manifest(tmpFilePath);

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/alias.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/alias.ts
@@ -99,6 +99,7 @@ export function loadAliases(
 	aliasFields: string[]
 ): AliasHash {
 	const absPkgJsonFile = pkgJsonFile.resolve();
+
 	const cacheKey = `${absPkgJsonFile.asNative}|${aliasFields.join()}`;
 
 	let aliases: AliasHash = aliasesCache[cacheKey];

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/babel-ipc.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/babel-ipc.ts
@@ -12,6 +12,7 @@ import FilePath from './file-path';
 declare const global: {
 	_babel_ipc_: object;
 };
+
 global._babel_ipc_ = global._babel_ipc_ || {};
 
 /** Babel state object view */

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/packages.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/packages.ts
@@ -47,6 +47,7 @@ export function resolveModuleFile(pkgPath: string, moduleName: string): string {
 	let fullModulePath = path.resolve(
 		path.join(pkgPath, ...moduleName.split('/'))
 	);
+
 	let moduleStats = safeStat(fullModulePath);
 
 	if (moduleStats.isDirectory()) {
@@ -54,6 +55,7 @@ export function resolveModuleFile(pkgPath: string, moduleName: string): string {
 		// Given module name is a directory
 
 		const pkgJsonPath = path.join(fullModulePath, 'package.json');
+
 		const pkgJsonStats = safeStat(pkgJsonPath);
 
 		if (pkgJsonStats.isFile()) {
@@ -61,6 +63,7 @@ export function resolveModuleFile(pkgPath: string, moduleName: string): string {
 			// Module directory has package.json file
 
 			const pkgJson = readJsonSync(pkgJsonPath);
+
 			const {main} = pkgJson;
 
 			if (main) {

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/index.test.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/__tests__/index.test.js
@@ -640,6 +640,7 @@ describe('deprecated config', () => {
 			const pkgOther = new PkgDesc('other-package', '1.0.0', __dirname);
 
 			let plugins = project.transform.getPrePluginDescriptors(pkg1);
+
 			expect(plugins[0].run({}, {})).toEqual(1);
 
 			plugins = project.transform.getPrePluginDescriptors(pkg2);

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/index.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/index.ts
@@ -205,6 +205,7 @@ export class Project {
 				const pkgJsonPath = this.toolResolve(
 					`${packageName}/package.json`
 				);
+
 				const pkgJson = require(pkgJsonPath);
 
 				map.set(pkgJson.name, {
@@ -224,6 +225,7 @@ export class Project {
 			// Get preset version
 
 			const {_npmbundlerrc} = this;
+
 			const preset = _npmbundlerrc['preset'];
 
 			if (preset) {

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/jar.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/jar.ts
@@ -24,6 +24,7 @@ export default class Jar {
 	 */
 	get compressionLevel(): number {
 		const {_project} = this;
+
 		const {npmbundlerrc} = _project;
 
 		if (this._compressionLevel === undefined) {
@@ -95,6 +96,7 @@ export default class Jar {
 	 */
 	get outputDir(): FilePath {
 		const {_project} = this;
+
 		const {npmbundlerrc} = _project;
 
 		if (this._outputDir === undefined) {

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/misc.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/misc.ts
@@ -50,6 +50,7 @@ export default class Misc {
 	 */
 	get noTracking(): boolean {
 		const {_project} = this;
+
 		const {npmbundlerrc} = _project;
 
 		if (!prop.has(npmbundlerrc, 'no-tracking')) {
@@ -89,6 +90,7 @@ export default class Misc {
 	 */
 	get reportFile(): FilePath | undefined {
 		const {_project} = this;
+
 		const {npmbundlerrc} = _project;
 
 		const dumpReport = prop.get(npmbundlerrc, 'dump-report', false);

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/rules.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/rules.ts
@@ -106,6 +106,7 @@ export default class Rules {
 					const pkgJsonPath = _project.toolResolve(
 						`${joinModuleName(scope, pkgName, '')}/package.json`
 					);
+
 					const pkgJson = require(pkgJsonPath);
 
 					map.set(resolvedModule, {

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/transform.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/transform.ts
@@ -43,6 +43,7 @@ export default class Transform {
 
 		if (this._versionsInfo === undefined) {
 			const {_project} = this;
+
 			const {npmbundlerrc} = _project;
 
 			const map = new Map<string, VersionInfo>();
@@ -69,6 +70,7 @@ export default class Transform {
 					const pkgJsonPath = _project.toolResolve(
 						`${pkgName}/package.json`
 					);
+
 					const pkgJson = _project.toolRequire(pkgJsonPath);
 
 					map.set(pluginName, {

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-exclude-imports/src/__tests__/index.test.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-exclude-imports/src/__tests__/index.test.js
@@ -39,6 +39,7 @@ it('empties files when package is listed in imports', () => {
 
 it('leaves files untouched when package is missing from imports', () => {
 	const originalFiles = ['1.js', '2.js', '3.js'];
+
 	const files = originalFiles.slice();
 
 	plugin(
@@ -70,6 +71,7 @@ it('leaves files untouched when package is missing from imports', () => {
 
 it('leaves files untouched when package is self-imported from project', () => {
 	const originalFiles = ['1.js', '2.js', '3.js'];
+
 	const files = originalFiles.slice();
 
 	plugin(

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-inject-peer-dependencies/src/index.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-inject-peer-dependencies/src/index.js
@@ -27,6 +27,7 @@ export default function ({config, log, pkg, source}, {pkgJson}) {
 		.map((posixPath) => new FilePath(posixPath, {posix: true}))
 		.forEach((file) => {
 			const code = fs.readFileSync(file.asNative);
+
 			const defineCallOffset = code.indexOf(defineCall);
 
 			if (defineCallOffset !== -1) {
@@ -105,6 +106,7 @@ function processModuleDependencies(
 		}
 
 		const {pkgName, scope} = mod.splitModuleName(dep);
+
 		const scopedPkgName = mod.joinModuleName(scope, pkgName);
 
 		if (!pkgJson.dependencies[scopedPkgName]) {

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-namespace-packages/src/__tests__/index.test.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler-plugin-namespace-packages/src/__tests__/index.test.js
@@ -14,6 +14,7 @@ const fixturesDir = path.join(__dirname, '__fixtures__');
 
 it('namespaces packages correctly for the root package', () => {
 	const pkgJson = readJsonSync(`${fixturesDir}/project/package.json`);
+
 	const pkg = new PkgDesc(pkgJson.name, pkgJson.version, fixturesDir, true);
 	const log = new PluginLogger();
 
@@ -25,7 +26,9 @@ it('namespaces packages correctly for the root package', () => {
 it('namespaces packages correctly for non-root package', () => {
 	const rootPkgJson = readJsonSync(`${fixturesDir}/project/package.json`);
 	const dir = `${fixturesDir}/project/node_modules/is-finite`;
+
 	const pkgJson = readJsonSync(`${dir}/package.json`);
+
 	const pkg = new PkgDesc(pkgJson.name, pkgJson.version, dir);
 	const log = new PluginLogger();
 
@@ -37,7 +40,9 @@ it('namespaces packages correctly for non-root package', () => {
 it('logs results correctly', () => {
 	const rootPkgJson = readJsonSync(`${fixturesDir}/project/package.json`);
 	const dir = `${fixturesDir}/project/node_modules/is-finite`;
+
 	const pkgJson = readJsonSync(`${dir}/package.json`);
+
 	const pkg = new PkgDesc(pkgJson.name, pkgJson.version, dir);
 	const log = new PluginLogger();
 

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/__tests__/dependencies.test.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/__tests__/dependencies.test.js
@@ -31,6 +31,7 @@ expect.extend({
 				}
 				else {
 					const pkgIdParts = pkgId.split('@');
+
 					pkgName = pkgIdParts[0];
 					pkgVersion = pkgIdParts[1];
 				}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/dependencies.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/dependencies.js
@@ -12,6 +12,7 @@ import resolveModule from 'resolve';
 import report from './report';
 
 const pkgJson = project.pkgJson;
+
 const rootPkg = new PkgDesc(pkgJson.name, pkgJson.version);
 
 /**
@@ -53,6 +54,7 @@ export function addPackageDependencies(
 	collectedDependencies[pkg.id] = pkg;
 
 	let dependencies = packageJson.dependencies || {};
+
 	dependencies = Object.keys(dependencies);
 	dependencies = dependencies.concat(extraDependencies);
 

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/index.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/index.ts
@@ -86,6 +86,7 @@ function run(): void {
 				// Report and show execution time
 
 				const hrtime = process.hrtime(start);
+
 				report.executionTime(hrtime);
 				log.info(`Bundling took ${pretty(hrtime)}`);
 

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/__tests__/xml.test.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/__tests__/xml.test.js
@@ -13,6 +13,7 @@ import {
 describe('addMetatypeAttr', () => {
 	it('works with just the type', () => {
 		const xml = createMetatype('id', 'name');
+
 		addMetatypeAttr(xml, 'an-attr', {
 			type: 'string',
 		});
@@ -22,6 +23,7 @@ describe('addMetatypeAttr', () => {
 
 	it('adds description if present', () => {
 		const xml = createMetatype('id', 'name');
+
 		addMetatypeAttr(xml, 'an-attr', {
 			type: 'string',
 			description: 'a-description',
@@ -32,6 +34,7 @@ describe('addMetatypeAttr', () => {
 
 	it('adds required if present', () => {
 		const xml = createMetatype('id', 'name');
+
 		addMetatypeAttr(xml, 'an-attr', {
 			type: 'string',
 			required: true,
@@ -42,6 +45,7 @@ describe('addMetatypeAttr', () => {
 
 	it('adds default if present', () => {
 		const xml = createMetatype('id', 'name');
+
 		addMetatypeAttr(xml, 'an-attr', {
 			type: 'string',
 			default: 'default-value',
@@ -52,6 +56,7 @@ describe('addMetatypeAttr', () => {
 
 	it('adds options if present', () => {
 		const xml = createMetatype('id', 'name');
+
 		addMetatypeAttr(xml, 'an-attr', {
 			type: 'string',
 			options: {
@@ -66,6 +71,7 @@ describe('addMetatypeAttr', () => {
 
 it('addMetatypeLocalization works', () => {
 	const xml = createMetatype('id', 'name');
+
 	addMetatypeLocalization(xml, 'localization/file.properties');
 
 	expect(xml).toMatchSnapshot();
@@ -79,6 +85,7 @@ it('createMetatype works', () => {
 
 it('all together works', () => {
 	const xml = createMetatype('id', 'name');
+
 	addMetatypeLocalization(xml, 'localization/file.properties');
 	addMetatypeAttr(xml, 'a-number', {type: 'number'});
 	addMetatypeAttr(xml, 'a-float', {type: 'float'});

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/index.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/index.js
@@ -75,6 +75,7 @@ function addFiles(srcDirPath, srcGlobs, destFolder) {
 
 	filePaths.forEach((filePath) => {
 		const parts = filePath.split(path.sep);
+
 		const dirs = parts.slice(0, parts.length - 1);
 		const name = parts[parts.length - 1];
 
@@ -290,6 +291,7 @@ function getPortletInstanceConfigurationJson() {
 	}
 
 	const filePath = project.jar.configurationFile.asNative;
+
 	const configurationJson = fs.readJSONSync(filePath);
 
 	if (
@@ -313,6 +315,7 @@ function getSystemConfigurationJson() {
 	}
 
 	const filePath = project.jar.configurationFile.asNative;
+
 	const configurationJson = fs.readJSONSync(filePath);
 
 	if (

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/osgi.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/osgi.js
@@ -10,6 +10,7 @@
  */
 export function getBundleVersionAndClassifier(pkgJsonVersion) {
 	const parts = pkgJsonVersion.split('-');
+
 	if (parts.length > 1) {
 		return parts[0] + '.' + parts.slice(1).join('-');
 	}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/xml.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/xml.js
@@ -22,7 +22,9 @@ const TYPES = {
  */
 export function addMetatypeAttr(metatype, id, desc) {
 	const metadata = findChild(metatype, 'metatype:MetaData');
+
 	const ocd = findChild(metadata, 'OCD');
+
 	const ad = addChild(ocd, 'AD');
 
 	addAttr(ad, 'id', id);

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/report/__tests__/index.test.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/report/__tests__/index.test.js
@@ -73,6 +73,7 @@ describe('when describing the run', () => {
 			name: 'a-package',
 			version: '1.1.0',
 		};
+
 		report.dependencies([pkg]);
 		report.linkedDependency(pkg.name, 'file:../a-package', pkg.version);
 	});

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/report/html.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/report/html.js
@@ -125,7 +125,9 @@ export function htmlDump(report) {
 	const packageProcessesPresent = Object.keys(_packages).reduce(
 		(found, pkgId) => {
 			const pkg = _packages[pkgId];
+
 			const {babel, copy, post, pre} = pkg.process;
+
 			const copyKeys = Object.keys(copy);
 			const preKeys = Object.keys(pre);
 			const postKeys = Object.keys(post);
@@ -154,7 +156,9 @@ export function htmlDump(report) {
 				.sort()
 				.map((pkgId) => {
 					const pkg = _packages[pkgId];
+
 					const {babel, copy, post, pre} = pkg.process;
+
 					const copyKeys = Object.keys(copy);
 					const preKeys = Object.keys(pre);
 					const postKeys = Object.keys(post);
@@ -211,7 +215,9 @@ export function htmlDump(report) {
 			.sort()
 			.map((pkgId) => {
 				const pkg = _packages[pkgId];
+
 				const {copy, post, pre} = pkg.process;
+
 				const copyKeys = Object.keys(copy);
 				const preKeys = Object.keys(pre);
 				const postKeys = Object.keys(post);
@@ -298,7 +304,9 @@ export function htmlDump(report) {
 			.sort()
 			.map((pkgId) => {
 				const pkg = _packages[pkgId];
+
 				const {babel} = pkg.process;
+
 				const babelKeys = Object.keys(babel.files);
 
 				return htmlIf(babelKeys.length > 0, () =>

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/report/index.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/report/index.js
@@ -117,6 +117,7 @@ export class Report {
 	 */
 	linkedDependency(packageName, packageLink, packageVersion) {
 		const pkgId = `${packageName}@${packageVersion}`;
+
 		const pkg = this._getPackage(pkgId, false);
 
 		if (pkg) {

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/steps/rules.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/steps/rules.js
@@ -104,6 +104,7 @@ function runLoaders(loaders, firstLoaderIndex, context) {
 	}
 
 	const loader = loaders[firstLoaderIndex];
+
 	const encoding = loader.metadata.encoding;
 
 	let result;

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/steps/transform.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/steps/transform.js
@@ -287,6 +287,7 @@ export function loadSourceMap(filePath) {
 	const annotation = fileContent.toString().substring(offset);
 
 	let matches = annotation.match(/\/\/# sourceMappingURL=(.*)/);
+
 	if (!matches) {
 		matches = annotation.match(/\/\*# sourceMappingURL=(.*) \*\//);
 

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-imports-checker/src/__tests__/config.test.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-imports-checker/src/__tests__/config.test.js
@@ -21,6 +21,7 @@ beforeEach(() => {
 			'modules',
 			'a-project'
 		);
+
 		process.chdir(testDir);
 		cfg = require('../config');
 		cfg.reloadConfig();

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-imports-checker/src/config.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-imports-checker/src/config.js
@@ -217,6 +217,7 @@ function safeReadJsonSync(filePath) {
 	catch (err) {
 		if (err.code !== 'ENOENT') {
 			const msg = `(at ${filePath}) ${err.message}`;
+
 			err.message = msg;
 			throw err;
 		}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-imports-checker/src/liferay-npm-imports-checker.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-imports-checker/src/liferay-npm-imports-checker.js
@@ -114,6 +114,7 @@ function loadProjects() {
 
 			try {
 				const pkgJson = readJsonSync(pkgJsonPath);
+
 				const project = projects[pkgJson.name];
 
 				if (project) {

--- a/maintenance/projects/js-toolkit/resources/devtools/find-generator/find-generator.js
+++ b/maintenance/projects/js-toolkit/resources/devtools/find-generator/find-generator.js
@@ -9,6 +9,7 @@ const fs = require('fs');
 const yeoman = require('yeoman-environment');
 
 const env = yeoman.createEnv();
+
 const paths = env.getNpmPaths();
 
 paths.forEach((path) => {

--- a/maintenance/projects/js-toolkit/resources/devtools/link-js-toolkit/link-dependencies.js
+++ b/maintenance/projects/js-toolkit/resources/devtools/link-js-toolkit/link-dependencies.js
@@ -15,6 +15,7 @@ function linkDependencies(extraDependencies = []) {
 	// Read package.json
 
 	const pkgJson = readJsonSync(path.join('.', 'package.json'));
+
 	pkgJson.dependencies = pkgJson.dependencies || {};
 	pkgJson.devDependencies = pkgJson.devDependencies || {};
 

--- a/maintenance/projects/js-toolkit/scripts/level-deps.js
+++ b/maintenance/projects/js-toolkit/scripts/level-deps.js
@@ -25,6 +25,7 @@ Object.values(depVersions[dep]).forEach((prjs) => {
 
 	prjs.forEach((prj) => {
 		const pkgJsonPath = path.join('packages', prj, 'package.json');
+
 		const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath));
 
 		console.log(`  ${prj}`);

--- a/maintenance/projects/js-toolkit/scripts/qa/generate-samples.js
+++ b/maintenance/projects/js-toolkit/scripts/qa/generate-samples.js
@@ -25,6 +25,7 @@ function generateSamples() {
 	ensureDirectories();
 	writeConfigurations();
 	const configs = getUsedConfigurations();
+
 	generateLiferaySamples(configs);
 	prepareManualProjects();
 	generateCreateReactAppSample();
@@ -157,6 +158,7 @@ function prepareManualProjects() {
 		// Change deploy directory
 
 		const npmbuildrcPath = path.join(packagesDir, prj, '.npmbuildrc');
+
 		const npmbuildrc = JSON.parse(fs.readFileSync(npmbuildrcPath));
 
 		npmbuildrc.liferayDir = liferayDir;
@@ -174,6 +176,7 @@ function generateCreateReactAppSample() {
 	// to our QA folder.
 
 	const tmpDir = path.join(qaDir, 'tmp');
+
 	const tmpPrjDir = path.join(tmpDir, 'create-react-app');
 
 	fs.emptyDirSync(tmpPrjDir);

--- a/maintenance/projects/js-toolkit/scripts/qa/index.js
+++ b/maintenance/projects/js-toolkit/scripts/qa/index.js
@@ -68,6 +68,7 @@ if (argv['install']) {
 
 	fs.readdirSync(projectsDir).forEach((projectName) => {
 		const projectDir = path.join(projectsDir, projectName);
+
 		const pkgJson = fs.readJsonSync(path.join(projectDir, 'package.json'));
 
 		if (pkgJson.bin) {

--- a/maintenance/projects/js-toolkit/scripts/qa/resources.js
+++ b/maintenance/projects/js-toolkit/scripts/qa/resources.js
@@ -8,9 +8,12 @@ const os = require('os');
 const path = require('path');
 
 const workspaceDir = path.join(__dirname, '..', '..');
+
 const projectsDir = path.join(workspaceDir, 'packages');
 const qaDir = path.join(workspaceDir, 'qa');
+
 const samplesDir = path.join(qaDir, 'samples');
+
 const packagesDir = path.join(samplesDir, 'packages');
 
 const {version: currentSDKVersion} = require(path.join(
@@ -101,6 +104,7 @@ function findLiferayDir() {
 				path.join(os.homedir(), '.generator-liferay-js.json')
 			)
 		);
+
 		liferayDir = json.answers['*'].liferayDir;
 	}
 	catch (err) {

--- a/maintenance/projects/senna/examples/blog/js/spa.js
+++ b/maintenance/projects/senna/examples/blog/js/spa.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	console.log('Senna version:', senna.version);
 
 	var app = new senna.App();
+
 	app.setBasePath('/examples/blog');
 	app.addSurfaces('posts');
 	app.addRoutes(new senna.Route(/\w+\.html/, senna.HtmlScreen));

--- a/maintenance/projects/senna/examples/form/server.js
+++ b/maintenance/projects/senna/examples/form/server.js
@@ -16,6 +16,7 @@ app.use(express.static('../../'));
 
 app.post('/post', upload.array(), (req, res, _next) => {
 	var content = '<div id="result1">';
+
 	content += JSON.stringify(req.body, 5);
 	content += '</div>';
 	res.end(content);

--- a/maintenance/projects/senna/examples/gallery/js/dynamic.js
+++ b/maintenance/projects/senna/examples/gallery/js/dynamic.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
      ========================================================================== */
 
 	var app = new senna.App();
+
 	app.addSurfaces('preview');
 	app.addRoutes(
 		new senna.Route(
@@ -36,6 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	function customScreenRouteHandler() {
 		var screenInstance = new senna.Screen();
+
 		screenInstance.cached = true;
 		screenInstance.getSurfaceContent = function (surfaceId) {
 			if (surfaceId === 'preview') {

--- a/maintenance/projects/senna/examples/gallery/js/static.js
+++ b/maintenance/projects/senna/examples/gallery/js/static.js
@@ -5,6 +5,7 @@
 
 document.addEventListener('DOMContentLoaded', () => {
 	var app = new senna.App();
+
 	app.setBasePath('/examples/gallery');
 	app.addSurfaces('preview');
 	app.addRoutes(new senna.Route(/\w+\.html/, senna.HtmlScreen));

--- a/maintenance/projects/senna/src/app/App.js
+++ b/maintenance/projects/senna/src/app/App.js
@@ -396,6 +396,7 @@ class App extends EventEmitter {
 		}
 		/* jshint newcap: false */
 		var screen = this.screens[path];
+
 		if (!screen) {
 			var handler = route.getHandler();
 			if (
@@ -444,6 +445,7 @@ class App extends EventEmitter {
 	 */
 	doNavigate_(path, opt_replaceHistory) {
 		var route = this.findRoute(path);
+
 		if (!route) {
 			this.pendingNavigate = CancellablePromise.reject(
 				new CancellablePromise.CancellationError('No route for ' + path)
@@ -555,6 +557,7 @@ class App extends EventEmitter {
 		path = this.getRoutePath(path);
 		for (var i = 0; i < this.routes.length; i++) {
 			var route = this.routes[i];
+
 			if (route.matchesPath(path)) {
 				return route;
 			}
@@ -720,6 +723,7 @@ class App extends EventEmitter {
 	 */
 	lockHistoryScrollPosition_() {
 		var state = globals.window.history.state;
+
 		if (!state) {
 			return;
 		}
@@ -908,14 +912,17 @@ class App extends EventEmitter {
 	 */
 	maybeRepositionScrollToHashedAnchor() {
 		const hash = globals.window.location.hash;
+
 		if (hash) {
 			const anchorElement = globals.document.getElementById(
 				hash.substring(1)
 			);
+
 			if (anchorElement) {
 				const {offsetLeft, offsetTop} = utils.getNodeOffset(
 					anchorElement
 				);
+
 				globals.window.scrollTo(offsetLeft, offsetTop);
 			}
 		}
@@ -956,9 +963,12 @@ class App extends EventEmitter {
 	 */
 	maybeUpdateScrollPositionState_() {
 		var hash = globals.window.location.hash;
+
 		var anchorElement = globals.document.getElementById(hash.substring(1));
+
 		if (anchorElement) {
 			const {offsetLeft, offsetTop} = utils.getNodeOffset(anchorElement);
+
 			this.saveHistoryCurrentPageScrollPosition_(offsetTop, offsetLeft);
 		}
 	}
@@ -1046,6 +1056,7 @@ class App extends EventEmitter {
 	 */
 	onBeforeUnloadDefault_(event) {
 		var func = window._onbeforeunload;
+
 		if (func && !func._overloaded && func()) {
 			event.preventDefault();
 		}
@@ -1082,6 +1093,7 @@ class App extends EventEmitter {
 	 */
 	onDocSubmitDelegate_(event) {
 		var form = event.delegateTarget;
+
 		if (form.method === 'get') {
 			console.log('GET method not supported');
 
@@ -1090,6 +1102,7 @@ class App extends EventEmitter {
 		event.capturedFormElement = form;
 		const buttonSelector =
 			'button:not([type]),button[type=submit],input[type=submit]';
+
 		if (match(globals.document.activeElement, buttonSelector)) {
 			event.capturedFormButtonElement = globals.document.activeElement;
 		}
@@ -1186,12 +1199,14 @@ class App extends EventEmitter {
 				}
 			});
 			const uri = new Uri(state.path);
+
 			uri.setHostname(globals.window.location.hostname);
 			uri.setPort(globals.window.location.port);
 			const isNavigationScheduled = this.maybeScheduleNavigation_(
 				uri.toString(),
 				{}
 			);
+
 			if (isNavigationScheduled) {
 				return;
 			}
@@ -1262,6 +1277,7 @@ class App extends EventEmitter {
 	 */
 	prefetch(path) {
 		var route = this.findRoute(path);
+
 		if (!route) {
 			return CancellablePromise.reject(
 				new CancellablePromise.CancellationError('No route for ' + path)
@@ -1293,6 +1309,7 @@ class App extends EventEmitter {
 	 */
 	prepareNavigateHistory_(path, nextScreen, opt_replaceHistory) {
 		let title = nextScreen.getTitle();
+
 		if (!isString(title)) {
 			title = this.getDefaultTitle();
 		}
@@ -1333,6 +1350,7 @@ class App extends EventEmitter {
 	prepareNavigateSurfaces_(nextScreen, surfaces, params) {
 		Object.keys(surfaces).forEach((id) => {
 			var surfaceContent = nextScreen.getSurfaceContent(id, params);
+
 			surfaces[id].addContent(nextScreen.getId(), surfaceContent);
 			console.log(
 				'Screen [' +
@@ -1369,6 +1387,7 @@ class App extends EventEmitter {
 	 */
 	removeScreen(path) {
 		var screen = this.screens[path];
+
 		if (screen) {
 			Object.keys(this.surfaces).forEach((surfaceId) =>
 				this.surfaces[surfaceId].remove(screen.getId())
@@ -1385,6 +1404,7 @@ class App extends EventEmitter {
 	 */
 	saveHistoryCurrentPageScrollPosition_(scrollTop, scrollLeft) {
 		var state = globals.window.history.state;
+
 		if (state && state.senna) {
 			[state.scrollTop, state.scrollLeft] = [scrollTop, scrollLeft];
 			globals.window.history.replaceState(state, null, null);
@@ -1495,6 +1515,7 @@ class App extends EventEmitter {
 	 */
 	syncScrollPositionSyncThenAsync_() {
 		var state = globals.window.history.state;
+
 		if (!state) {
 			return;
 		}
@@ -1538,6 +1559,7 @@ class App extends EventEmitter {
 		utils.setReferrer(referrer);
 
 		const titleNode = globals.document.querySelector('title');
+
 		if (titleNode) {
 			titleNode.innerHTML = title;
 		}

--- a/maintenance/projects/senna/src/app/AppDataAttributeHandler.js
+++ b/maintenance/projects/senna/src/app/AppDataAttributeHandler.js
@@ -110,6 +110,7 @@ class AppDataAttributeHandler extends Disposable {
 	 */
 	maybeAddRoutes_() {
 		var routesSelector = 'link[rel="senna-route"]';
+
 		this.querySelectorAllAsArray_(routesSelector).forEach((link) =>
 			this.maybeParseLinkRoute_(link)
 		);
@@ -124,6 +125,7 @@ class AppDataAttributeHandler extends Disposable {
 	 */
 	maybeAddSurfaces_() {
 		var surfacesSelector = '[' + dataAttributes.surface + ']';
+
 		this.querySelectorAllAsArray_(surfacesSelector).forEach(
 			(surfaceElement) => {
 				this.updateElementIdIfSpecialSurface_(surfaceElement);
@@ -151,6 +153,7 @@ class AppDataAttributeHandler extends Disposable {
 			this.maybeParseLinkRoutePath_(link),
 			this.maybeParseLinkRouteHandler_(link)
 		);
+
 		this.app.addRoutes(route);
 		console.log('Senna scanned route ' + route.getPath());
 	}
@@ -162,6 +165,7 @@ class AppDataAttributeHandler extends Disposable {
 	 */
 	maybeParseLinkRouteHandler_(link) {
 		var handler = link.getAttribute('type');
+
 		if (isDefAndNotNull(handler)) {
 			handler = object.getObjectByName(handler);
 		}
@@ -176,6 +180,7 @@ class AppDataAttributeHandler extends Disposable {
 	 */
 	maybeParseLinkRoutePath_(link) {
 		var path = link.getAttribute('href');
+
 		if (isDefAndNotNull(path)) {
 			if (path.indexOf('regex:') === 0) {
 				path = new RegExp(path.substring(6));
@@ -190,6 +195,7 @@ class AppDataAttributeHandler extends Disposable {
 	 */
 	maybeSetBasePath_() {
 		var basePath = this.baseElement.getAttribute(dataAttributes.basePath);
+
 		if (isDefAndNotNull(basePath)) {
 			this.app.setBasePath(basePath);
 			console.log('Senna scanned base path ' + basePath);
@@ -204,6 +210,7 @@ class AppDataAttributeHandler extends Disposable {
 		var linkSelector = this.baseElement.getAttribute(
 			dataAttributes.linkSelector
 		);
+
 		if (isDefAndNotNull(linkSelector)) {
 			this.app.setLinkSelector(linkSelector);
 			console.log('Senna scanned link selector ' + linkSelector);
@@ -218,6 +225,7 @@ class AppDataAttributeHandler extends Disposable {
 		var loadingCssClass = this.baseElement.getAttribute(
 			dataAttributes.loadingCssClass
 		);
+
 		if (isDefAndNotNull(loadingCssClass)) {
 			this.app.setLoadingCssClass(loadingCssClass);
 			console.log('Senna scanned loading css class ' + loadingCssClass);
@@ -232,6 +240,7 @@ class AppDataAttributeHandler extends Disposable {
 		var updateScrollPosition = this.baseElement.getAttribute(
 			dataAttributes.updateScrollPosition
 		);
+
 		if (isDefAndNotNull(updateScrollPosition)) {
 			if (updateScrollPosition === 'false') {
 				this.app.setUpdateScrollPosition(false);

--- a/maintenance/projects/senna/src/route/Route.js
+++ b/maintenance/projects/senna/src/route/Route.js
@@ -48,6 +48,7 @@ class Route {
 	buildParsedData_() {
 		if (!this.parsedData_) {
 			var tokens = parse(this.path);
+
 			var regex = toRegex(tokens);
 			this.parsedData_ = {
 				regex,

--- a/maintenance/projects/senna/src/screen/HtmlScreen.js
+++ b/maintenance/projects/senna/src/screen/HtmlScreen.js
@@ -81,11 +81,13 @@ class HtmlScreen extends RequestScreen {
 			newStyle,
 			HtmlScreen.selectors.stylesTemporary
 		);
+
 		if (isTemporaryStyle) {
 			this.pendingStyles.push(newStyle);
 		}
 		if (newStyle.id) {
 			var styleInDoc = globals.document.getElementById(newStyle.id);
+
 			if (styleInDoc) {
 				styleInDoc.parentNode.insertBefore(
 					newStyle,
@@ -123,6 +125,7 @@ class HtmlScreen extends RequestScreen {
 			const tempNode = globals.document
 				.createRange()
 				.createContextualFragment(content);
+
 			placeholder = tempNode.querySelector('senna');
 		}
 		else {
@@ -233,6 +236,7 @@ class HtmlScreen extends RequestScreen {
 
 		permanentsInDoc.forEach((resource) => {
 			var resourceKey = this.getResourceKey_(resource);
+
 			if (resourceKey) {
 				HtmlScreen.permanentResourcesInDoc[resourceKey] = true;
 			}
@@ -310,10 +314,12 @@ class HtmlScreen extends RequestScreen {
 	 */
 	getSurfaceContent(surfaceId) {
 		var surface = this.virtualDocument.querySelector('#' + surfaceId);
+
 		if (surface) {
 			var defaultChild = surface.querySelector(
 				'#' + surfaceId + '-' + Surface.DEFAULT
 			);
+
 			if (defaultChild) {
 				return defaultChild.innerHTML;
 			}
@@ -356,6 +362,7 @@ class HtmlScreen extends RequestScreen {
 		var temporariesInDoc = this.virtualQuerySelectorAll_(
 			HtmlScreen.selectors.stylesTemporary
 		);
+
 		temporariesInDoc.forEach((style) =>
 			this.replaceStyleAndMakeUnique_(style)
 		);
@@ -426,6 +433,7 @@ class HtmlScreen extends RequestScreen {
 	 */
 	resolveTitleFromVirtualDocument() {
 		const title = this.virtualDocument.querySelector(this.titleSelector);
+
 		if (title) {
 			this.setTitle(title.textContent.trim());
 		}
@@ -433,6 +441,7 @@ class HtmlScreen extends RequestScreen {
 
 	resolveMetaTagsFromVirtualDocument() {
 		const metas = this.virtualQuerySelectorAll_(this.metaTagsSelector);
+
 		if (metas) {
 			this.setMetas(metas);
 		}

--- a/maintenance/projects/senna/src/screen/RequestScreen.js
+++ b/maintenance/projects/senna/src/screen/RequestScreen.js
@@ -81,6 +81,7 @@ class RequestScreen extends Screen {
 	assertValidResponseStatusCode(status) {
 		if (!this.isValidResponseStatusCode(status)) {
 			var error = new Error(errors.INVALID_STATUS);
+
 			error.invalidStatus = true;
 			error.statusCode = status;
 			throw error;
@@ -92,6 +93,7 @@ class RequestScreen extends Screen {
 	 */
 	beforeUpdateHistoryPath(path) {
 		var redirectPath = this.getRequestPath();
+
 		if (redirectPath && redirectPath !== path) {
 			return redirectPath;
 		}
@@ -160,9 +162,11 @@ class RequestScreen extends Screen {
 	 */
 	getRequestPath() {
 		var request = this.getRequest();
+
 		if (request) {
 			var requestPath = request.requestPath;
 			var responseUrl = this.maybeExtractResponseUrlFromRequest(request);
+
 			if (responseUrl) {
 				requestPath = responseUrl;
 			}
@@ -210,6 +214,7 @@ class RequestScreen extends Screen {
 	 */
 	getFormData(formElement, submittedButtonElement) {
 		const formData = new FormData(formElement);
+
 		this.maybeAppendSubmitButtonValue_(formData, submittedButtonElement);
 
 		return formData;
@@ -220,6 +225,7 @@ class RequestScreen extends Screen {
 	 */
 	load(path) {
 		const cache = this.getCache();
+
 		if (isDefAndNotNull(cache)) {
 			return CancellablePromise.resolve(cache);
 		}
@@ -310,6 +316,7 @@ class RequestScreen extends Screen {
 	 */
 	maybeExtractResponseUrlFromRequest(request) {
 		var responseUrl = request.responseURL;
+
 		if (responseUrl) {
 			return responseUrl;
 		}
@@ -330,8 +337,10 @@ class RequestScreen extends Screen {
 			const inputs = globals.capturedFormElement.querySelectorAll(
 				'input[type="file"]:not([disabled])'
 			);
+
 			for (let index = 0; index < inputs.length; index++) {
 				const input = inputs[index];
+
 				if (input.files.length > 0) {
 					return;
 				}
@@ -353,8 +362,10 @@ class RequestScreen extends Screen {
 			const inputs = globals.capturedFormElement.querySelectorAll(
 				'input[type="file"][data-safari-temp-disabled]'
 			);
+
 			for (let index = 0; index < inputs.length; index++) {
 				const input = inputs[index];
+
 				input.removeAttribute('data-safari-temp-disabled');
 				input.removeAttribute('disabled');
 			}

--- a/maintenance/projects/senna/src/screen/Screen.js
+++ b/maintenance/projects/senna/src/screen/Screen.js
@@ -158,7 +158,9 @@ class Screen extends Cacheable {
 
 		Object.keys(surfaces).forEach((sId) => {
 			var surface = surfaces[sId];
+
 			var deferred = surface.show(this.id);
+
 			transitions.push(deferred);
 		});
 

--- a/maintenance/projects/senna/src/surface/Surface.js
+++ b/maintenance/projects/senna/src/surface/Surface.js
@@ -115,6 +115,7 @@ class Surface extends Disposable {
 	 */
 	createChild(screenId) {
 		var child = globals.document.createElement('div');
+
 		child.setAttribute('id', this.makeId_(screenId));
 
 		return child;
@@ -179,6 +180,7 @@ class Surface extends Disposable {
 	 */
 	maybeWrapContentAsDefault_() {
 		var element = this.getElement();
+
 		if (element && !this.defaultChild) {
 			var fragment = globals.document.createDocumentFragment();
 			while (element.firstChild) {
@@ -214,6 +216,7 @@ class Surface extends Disposable {
 	show(screenId) {
 		var from = this.activeChild;
 		var to = this.getChild(screenId);
+
 		if (!to) {
 			to = this.defaultChild;
 		}
@@ -232,6 +235,7 @@ class Surface extends Disposable {
 	 */
 	remove(screenId) {
 		var child = this.getChild(screenId);
+
 		if (child) {
 			exitDocument(child);
 		}

--- a/maintenance/projects/senna/src/utils/utils.js
+++ b/maintenance/projects/senna/src/utils/utils.js
@@ -178,6 +178,7 @@ class utils {
 	 */
 	static removePathTrailingSlash(path) {
 		var length = path ? path.length : 0;
+
 		if (length > 1 && path[length - 1] === '/') {
 			path = path.substr(0, length - 1);
 		}

--- a/maintenance/projects/senna/test/app/App.js
+++ b/maintenance/projects/senna/test/app/App.js
@@ -48,6 +48,7 @@ describe('App', function () {
 		};
 
 		const beforeunload = sinon.spy();
+
 		window.onbeforeunload = beforeunload;
 	});
 
@@ -77,6 +78,7 @@ describe('App', function () {
 	it('removes route', () => {
 		this.app = new App();
 		var route = new Route('/path', Screen);
+
 		this.app.addRoutes(route);
 		assert.ok(this.app.removeRoute(route));
 	});
@@ -109,6 +111,7 @@ describe('App', function () {
 		assert.strictEqual('/path', route.getPath());
 		assert.strictEqual(Screen, route.getHandler());
 		var routeOther = this.app.findRoute('/pathOther');
+
 		assert.ok(routeOther instanceof Route);
 		assert.strictEqual('/pathOther', routeOther.getPath());
 		assert.strictEqual(Screen, routeOther.getHandler());
@@ -222,6 +225,7 @@ describe('App', function () {
 			'/path',
 			new Route('/path', Screen)
 		);
+
 		assert.ok(screen instanceof Screen);
 	});
 
@@ -231,13 +235,16 @@ describe('App', function () {
 			'/path',
 			new Route('/path', HtmlScreen)
 		);
+
 		assert.ok(screen instanceof HtmlScreen);
 	});
 
 	it('creates screen instance to a route with function handler', () => {
 		this.app = new App();
 		var stub = sinon.stub();
+
 		var route = new Route('/path', stub);
+
 		var screen = this.app.createScreenInstance('/path', route);
 		assert.strictEqual(1, stub.callCount);
 		assert.strictEqual(route, stub.args[0][0]);
@@ -248,7 +255,9 @@ describe('App', function () {
 	it('gets same screen instance to a route', () => {
 		this.app = new App();
 		var route = new Route('/path', Screen);
+
 		var screen = this.app.createScreenInstance('/path', route);
+
 		this.app.screens['/path'] = screen;
 		assert.strictEqual(
 			screen,
@@ -259,11 +268,14 @@ describe('App', function () {
 	it('uses same screen instance when simulating navigate refresh', () => {
 		this.app = new App();
 		var route = new Route('/path', HtmlScreen);
+
 		var screen = this.app.createScreenInstance('/path', route);
+
 		this.app.screens['/path'] = screen;
 		this.app.activePath = '/path';
 		this.app.activeScreen = screen;
 		var screenRefresh = this.app.createScreenInstance('/path', route);
+
 		assert.strictEqual(screen, screenRefresh);
 	});
 
@@ -390,6 +402,7 @@ describe('App', function () {
 	it('clears screen cache and remove surfaces', () => {
 		this.app = new App();
 		var surface = new Surface('surfaceId');
+
 		surface.remove = sinon.stub();
 		this.app.addSurfaces(surface);
 		this.app.screens['/path'] = this.app.createScreenInstance(
@@ -622,6 +635,7 @@ describe('App', function () {
 		this.app.addRoutes(new Route('/path', Screen));
 		this.app.navigate('/path').then(() => {
 			const state = globals.window.history.state;
+
 			assert.equal(state.path, '/path');
 			assert.equal(state.redirectPath, '/path');
 			assert.equal(state.scrollLeft, 0);
@@ -763,6 +777,7 @@ describe('App', function () {
 			.then(() => this.app.navigate('/path1#hash'))
 			.then(() => {
 				var startNavigate = sinon.stub();
+
 				this.app.on('startNavigate', startNavigate);
 				dom.once(globals.window, 'popstate', () => {
 					assert.strictEqual(0, startNavigate.callCount);
@@ -1151,6 +1166,7 @@ describe('App', function () {
 		this.app = new App();
 		this.app.addRoutes(new Route('/path', Screen));
 		const link = enterDocumentLinkElement('/path');
+
 		link.setAttribute('target', '_blank');
 		link.addEventListener('click', (event) => event.preventDefault());
 		dom.triggerEvent(link, 'click');
@@ -1342,10 +1358,12 @@ describe('App', function () {
 
 	it('does not navigate on clicking links when onbeforeunload returns truthy value', () => {
 		const beforeunload = sinon.spy();
+
 		window.onbeforeunload = beforeunload;
 		this.app = new App();
 		this.app.addRoutes(new Route('/path', Screen));
 		const link = enterDocumentLinkElement('/path');
+
 		dom.triggerEvent(link, 'click');
 		exitDocumentLinkElement();
 		assert.strictEqual(1, beforeunload.callCount);
@@ -1353,6 +1371,7 @@ describe('App', function () {
 
 	it('does not navigate back to the previous page on navigate back when onbeforeunload returns a truthy value', (done) => {
 		const beforeunload = sinon.spy();
+
 		window.onbeforeunload = beforeunload;
 		this.app = new App();
 		this.app.addRoutes(new Route('/path1', Screen));
@@ -1379,6 +1398,7 @@ describe('App', function () {
 
 		showPageScrollbar();
 		var link = enterDocumentLinkElement('/path');
+
 		link.style.position = 'absolute';
 		link.style.top = '1000px';
 		link.style.left = '1000px';
@@ -1408,6 +1428,7 @@ describe('App', function () {
 		this.app = new App();
 		this.app.addRoutes(new Route('/path', Screen));
 		const form = enterDocumentFormElement('/path', 'post');
+
 		dom.triggerEvent(form, 'submit');
 		assert.ok(this.app.pendingNavigate);
 
@@ -1454,6 +1475,7 @@ describe('App', function () {
 		this.app = new App();
 		this.app.addRoutes(new Route('/path', Screen));
 		const form = enterDocumentFormElement('/path', 'post');
+
 		dom.triggerEvent(form, 'submit');
 		this.app.on('startNavigate', (data) => {
 			assert.ok(data.form);
@@ -1536,6 +1558,7 @@ describe('App', function () {
 	it('captures form button when submitting', () => {
 		const form = enterDocumentFormElement('/path', 'post');
 		const button = globals.document.createElement('button');
+
 		form.appendChild(button);
 		this.app = new App();
 		this.app.setAllowPreventNavigate(false);
@@ -1558,6 +1581,7 @@ describe('App', function () {
 	it('captures form button when clicking submit button', () => {
 		const form = enterDocumentFormElement('/path', 'post');
 		const button = globals.document.createElement('button');
+
 		button.type = 'submit';
 		button.tabindex = 1;
 		form.appendChild(button);
@@ -1669,6 +1693,7 @@ describe('App', function () {
 					StubScreen2.prototype.activate,
 					StubScreen.prototype.disposeInternal,
 				];
+
 				for (var i = 1; i < lifecycleOrder.length - 1; i++) {
 					assert.ok(
 						lifecycleOrder[i - 1].calledBefore(lifecycleOrder[i])
@@ -1688,6 +1713,7 @@ describe('App', function () {
 			}
 		}
 		var surface = new Surface('surfaceId');
+
 		surface.addContent = sinon.stub();
 		this.app = new App();
 		this.app.addRoutes(new Route('/path', ContentScreen));
@@ -1779,11 +1805,13 @@ describe('App', function () {
 		this.app = new App();
 		this.app.setBasePath('/path');
 		var route = new Route('/:foo(\\d+)/:bar', () => {});
+
 		var params = this.app.extractParams(route, '/path/123/abc');
 		var expectedParams = {
 			foo: '123',
 			bar: 'abc',
 		};
+
 		assert.deepEqual(expectedParams, params);
 	});
 
@@ -1853,6 +1881,7 @@ describe('App', function () {
 
 	it('adds surface content after history path is updated', (done) => {
 		var surface = new Surface('surfaceId');
+
 		surface.addContent = () => {
 			assert.strictEqual('/path', globals.window.location.pathname);
 		};
@@ -2027,6 +2056,7 @@ describe('App', function () {
 		}
 
 		var app = new App();
+
 		this.app = app;
 		app.addRoutes(new Route('/path1', CacheScreen));
 		app.addRoutes(new Route('/path2', CacheScreen));
@@ -2075,7 +2105,9 @@ describe('App', function () {
 		this.app.addSurfaces(['surfaceId1']);
 		this.app.navigate('/path1#surfaceId1').then(() => {
 			const surfaceNode = document.querySelector('#surfaceId1');
+
 			const {offsetLeft, offsetTop} = utils.getNodeOffset(surfaceNode);
+
 			assert.strictEqual(window.pageYOffset, offsetTop);
 			assert.strictEqual(window.pageXOffset, offsetLeft);
 			hidePageScrollbar();
@@ -2217,7 +2249,9 @@ const originalReplaceState = globals.window.history.replaceState;
 
 const syncTimeout = (fn, ms) => {
 	const start = Date.now();
+
 	let now = start;
+
 	while (now - start < ms) {
 		now = Date.now();
 	}

--- a/maintenance/projects/senna/test/app/AppDataAttributeHandler.js
+++ b/maintenance/projects/senna/test/app/AppDataAttributeHandler.js
@@ -38,6 +38,7 @@ describe('AppDataAttributeHandler', () => {
 	it('throws error when base element not valid', () => {
 		assert.throws(() => {
 			var appDataAttributeHandler = new AppDataAttributeHandler();
+
 			appDataAttributeHandler.setBaseElement({});
 			appDataAttributeHandler.handle();
 		}, Error);
@@ -46,6 +47,7 @@ describe('AppDataAttributeHandler', () => {
 	it('throws error when already handled', () => {
 		assert.throws(() => {
 			var appDataAttributeHandler = new AppDataAttributeHandler();
+
 			appDataAttributeHandler.setBaseElement(globals.document.body);
 			appDataAttributeHandler.handle();
 			appDataAttributeHandler.handle();
@@ -55,6 +57,7 @@ describe('AppDataAttributeHandler', () => {
 	it('does not throw error when base element specified', () => {
 		assert.doesNotThrow(() => {
 			var appDataAttributeHandler = new AppDataAttributeHandler();
+
 			appDataAttributeHandler.setBaseElement(globals.document.body);
 			appDataAttributeHandler.handle();
 			appDataAttributeHandler.dispose();
@@ -63,6 +66,7 @@ describe('AppDataAttributeHandler', () => {
 
 	it('disposes internal app when disposed', () => {
 		var appDataAttributeHandler = new AppDataAttributeHandler();
+
 		appDataAttributeHandler.setBaseElement(globals.document.body);
 		appDataAttributeHandler.handle();
 		appDataAttributeHandler.dispose();
@@ -72,12 +76,14 @@ describe('AppDataAttributeHandler', () => {
 	it('disposes when not handled', () => {
 		assert.doesNotThrow(() => {
 			var appDataAttributeHandler = new AppDataAttributeHandler();
+
 			appDataAttributeHandler.dispose();
 		});
 	});
 
 	it('gets app', () => {
 		var appDataAttributeHandler = new AppDataAttributeHandler();
+
 		appDataAttributeHandler.setBaseElement(globals.document.body);
 		appDataAttributeHandler.handle();
 		assert.ok(appDataAttributeHandler.getApp());
@@ -86,6 +92,7 @@ describe('AppDataAttributeHandler', () => {
 
 	it('gets base element', () => {
 		var appDataAttributeHandler = new AppDataAttributeHandler();
+
 		appDataAttributeHandler.setBaseElement(globals.document.body);
 		assert.strictEqual(
 			globals.document.body,
@@ -96,6 +103,7 @@ describe('AppDataAttributeHandler', () => {
 	it('adds app surfaces from document', () => {
 		enterDocumentSurfaceElement('surfaceId');
 		var appDataAttributeHandler = new AppDataAttributeHandler();
+
 		appDataAttributeHandler.setBaseElement(globals.document.body);
 		appDataAttributeHandler.handle();
 		assert.ok('surfaceId' in appDataAttributeHandler.getApp().surfaces);
@@ -106,6 +114,7 @@ describe('AppDataAttributeHandler', () => {
 	it('adds random id to body without id when used as app surface', () => {
 		globals.document.body.setAttribute('data-senna-surface', '');
 		var appDataAttributeHandler = new AppDataAttributeHandler();
+
 		appDataAttributeHandler.setBaseElement(globals.document.body);
 		appDataAttributeHandler.handle();
 		assert.ok(globals.document.body);
@@ -117,6 +126,7 @@ describe('AppDataAttributeHandler', () => {
 		enterDocumentSurfaceElementMissingId('surfaceId');
 		assert.throws(() => {
 			var appDataAttributeHandler = new AppDataAttributeHandler();
+
 			appDataAttributeHandler.setBaseElement(globals.document.body);
 			appDataAttributeHandler.handle();
 		}, Error);
@@ -125,6 +135,7 @@ describe('AppDataAttributeHandler', () => {
 
 	it('adds default route if not found in document', () => {
 		var appDataAttributeHandler = new AppDataAttributeHandler();
+
 		appDataAttributeHandler.setBaseElement(globals.document.body);
 		appDataAttributeHandler.handle();
 		assert.ok(appDataAttributeHandler.getApp().hasRoutes());
@@ -135,6 +146,7 @@ describe('AppDataAttributeHandler', () => {
 		enterDocumentRouteElement('/path1');
 		enterDocumentRouteElement('/path2');
 		var appDataAttributeHandler = new AppDataAttributeHandler();
+
 		appDataAttributeHandler.setBaseElement(globals.document.body);
 		appDataAttributeHandler.handle();
 		assert.strictEqual(2, appDataAttributeHandler.getApp().routes.length);
@@ -146,6 +158,7 @@ describe('AppDataAttributeHandler', () => {
 	it('adds routes from document with regex paths', () => {
 		enterDocumentRouteElement('regex:[a-z]');
 		var appDataAttributeHandler = new AppDataAttributeHandler();
+
 		appDataAttributeHandler.setBaseElement(globals.document.body);
 		appDataAttributeHandler.handle();
 		assert.ok(
@@ -160,6 +173,7 @@ describe('AppDataAttributeHandler', () => {
 		enterDocumentRouteElementMissingScreenType('/path');
 		assert.throws(() => {
 			var appDataAttributeHandler = new AppDataAttributeHandler();
+
 			appDataAttributeHandler.setBaseElement(globals.document.body);
 			appDataAttributeHandler.handle();
 		}, Error);
@@ -170,6 +184,7 @@ describe('AppDataAttributeHandler', () => {
 		enterDocumentRouteElementMissingPath();
 		assert.throws(() => {
 			var appDataAttributeHandler = new AppDataAttributeHandler();
+
 			appDataAttributeHandler.setBaseElement(globals.document.body);
 			appDataAttributeHandler.handle();
 		}, Error);
@@ -179,6 +194,7 @@ describe('AppDataAttributeHandler', () => {
 	it('sets base path from data attribute', () => {
 		globals.document.body.setAttribute('data-senna-base-path', '/base');
 		var appDataAttributeHandler = new AppDataAttributeHandler();
+
 		appDataAttributeHandler.setBaseElement(globals.document.body);
 		appDataAttributeHandler.handle();
 		assert.strictEqual(
@@ -192,6 +208,7 @@ describe('AppDataAttributeHandler', () => {
 	it('sets link selector from data attribute', () => {
 		globals.document.body.setAttribute('data-senna-link-selector', 'a');
 		var appDataAttributeHandler = new AppDataAttributeHandler();
+
 		appDataAttributeHandler.setBaseElement(globals.document.body);
 		appDataAttributeHandler.handle();
 		assert.strictEqual(
@@ -208,6 +225,7 @@ describe('AppDataAttributeHandler', () => {
 			'loading'
 		);
 		var appDataAttributeHandler = new AppDataAttributeHandler();
+
 		appDataAttributeHandler.setBaseElement(globals.document.body);
 		appDataAttributeHandler.handle();
 		assert.strictEqual(
@@ -224,6 +242,7 @@ describe('AppDataAttributeHandler', () => {
 			'false'
 		);
 		var appDataAttributeHandler = new AppDataAttributeHandler();
+
 		appDataAttributeHandler.setBaseElement(globals.document.body);
 		appDataAttributeHandler.handle();
 		assert.strictEqual(
@@ -242,6 +261,7 @@ describe('AppDataAttributeHandler', () => {
 			'true'
 		);
 		var appDataAttributeHandler = new AppDataAttributeHandler();
+
 		appDataAttributeHandler.setBaseElement(globals.document.body);
 		appDataAttributeHandler.handle();
 		assert.strictEqual(
@@ -257,6 +277,7 @@ describe('AppDataAttributeHandler', () => {
 	it('dispatches app from data attribute', () => {
 		globals.document.body.setAttribute('data-senna-dispatch', '');
 		var appDataAttributeHandler = new AppDataAttributeHandler();
+
 		appDataAttributeHandler.setBaseElement(globals.document.body);
 		appDataAttributeHandler.handle();
 

--- a/maintenance/projects/senna/test/cacheable/Cacheable.js
+++ b/maintenance/projects/senna/test/cacheable/Cacheable.js
@@ -14,12 +14,14 @@ describe('Cacheable', () => {
 
 	it('is cacheable', () => {
 		var cacheable = new Cacheable();
+
 		cacheable.setCacheable(true);
 		assert.ok(cacheable.isCacheable());
 	});
 
 	it('clears cache when toggle cacheable state', () => {
 		var cacheable = new Cacheable();
+
 		cacheable.setCacheable(true);
 		cacheable.addCache('data');
 		assert.strictEqual('data', cacheable.getCache());
@@ -29,6 +31,7 @@ describe('Cacheable', () => {
 
 	it('clears cache on dispose', () => {
 		var cacheable = new Cacheable();
+
 		cacheable.setCacheable(true);
 		cacheable.addCache('data');
 		cacheable.dispose();

--- a/maintenance/projects/senna/test/route/Route.js
+++ b/maintenance/projects/senna/test/route/Route.js
@@ -49,6 +49,7 @@ describe('Route', () => {
 
 		it('sets path and handler from constructor', () => {
 			var route = new Route('/path', core.nullFunction);
+
 			assert.strictEqual('/path', route.getPath());
 			assert.strictEqual(core.nullFunction, route.getHandler());
 		});
@@ -57,11 +58,13 @@ describe('Route', () => {
 	describe('Matching', () => {
 		it('matches route by string path', () => {
 			var route = new Route('/path', core.nullFunction);
+
 			assert.ok(route.matchesPath('/path'));
 		});
 
 		it('matches route by string path with params', () => {
 			var route = new Route('/path/:foo(\\d+)', core.nullFunction);
+
 			assert.ok(route.matchesPath('/path/10'));
 			assert.ok(route.matchesPath('/path/10/'));
 			assert.ok(!route.matchesPath('/path/abc'));
@@ -70,6 +73,7 @@ describe('Route', () => {
 
 		it('matches route by regex path', () => {
 			var route = new Route(/\/path/, core.nullFunction);
+
 			assert.ok(route.matchesPath('/path'));
 		});
 
@@ -77,16 +81,19 @@ describe('Route', () => {
 			var route = new Route((path) => {
 				return path === '/path';
 			}, core.nullFunction);
+
 			assert.ok(route.matchesPath('/path'));
 		});
 
 		it('does not match any route', () => {
 			var route = new Route('/path', core.nullFunction);
+
 			assert.ok(!route.matchesPath('/invalid'));
 		});
 
 		it('does not match any route for invalid path', () => {
 			var route = new Route({}, core.nullFunction);
+
 			assert.ok(!route.matchesPath('/invalid'));
 		});
 	});
@@ -97,11 +104,13 @@ describe('Route', () => {
 				'/path/:foo(\\d+)/:bar(\\w+)',
 				core.nullFunction
 			);
+
 			var params = route.extractParams('/path/123/abc');
 			var expected = {
 				foo: '123',
 				bar: 'abc',
 			};
+
 			assert.deepEqual(expected, params);
 		});
 
@@ -110,13 +119,17 @@ describe('Route', () => {
 				'/path/:foo(\\d+)/:bar(\\w+)',
 				core.nullFunction
 			);
+
 			var params = route.extractParams('/path/abc/123');
+
 			assert.strictEqual(null, params);
 		});
 
 		it('returns empty object if trying to extract params from path given as function', () => {
 			var route = new Route(core.nullFunction, core.nullFunction);
+
 			var params = route.extractParams('/path/123/abc');
+
 			assert.deepEqual({}, params);
 		});
 	});

--- a/maintenance/projects/senna/test/screen/HtmlScreen.js
+++ b/maintenance/projects/senna/test/screen/HtmlScreen.js
@@ -33,6 +33,7 @@ describe('HtmlScreen', function () {
 
 	it('gets title selector', () => {
 		var screen = new HtmlScreen();
+
 		assert.strictEqual('title', screen.getTitleSelector());
 		screen.setTitleSelector('div.title');
 		assert.strictEqual('div.title', screen.getTitleSelector());
@@ -40,6 +41,7 @@ describe('HtmlScreen', function () {
 
 	it('returns loaded content', (done) => {
 		var screen = new HtmlScreen();
+
 		screen.load('/url').then((content) => {
 			assert.strictEqual('content', content);
 			done();
@@ -49,6 +51,7 @@ describe('HtmlScreen', function () {
 
 	it('sets title from response content', (done) => {
 		var screen = new HtmlScreen();
+
 		screen.load('/url').then(() => {
 			assert.strictEqual('new', screen.getTitle());
 			done();
@@ -58,6 +61,7 @@ describe('HtmlScreen', function () {
 
 	it('does not set title from response content if not present', (done) => {
 		var screen = new HtmlScreen();
+
 		screen.load('/url').then(() => {
 			assert.strictEqual(null, screen.getTitle());
 			done();
@@ -67,6 +71,7 @@ describe('HtmlScreen', function () {
 
 	it('cancels load request to an url', (done) => {
 		var screen = new HtmlScreen();
+
 		screen
 			.load('/url')
 			.catch((reason) => {
@@ -78,6 +83,7 @@ describe('HtmlScreen', function () {
 
 	it('copies surface root node attributes from response content', (done) => {
 		var screen = new HtmlScreen();
+
 		screen.allocateVirtualDocumentForContent(
 			'<html attributeA="valueA"><div id="surfaceId">surface</div></html>'
 		);
@@ -92,6 +98,7 @@ describe('HtmlScreen', function () {
 
 	it('extracts surface content from response content', () => {
 		var screen = new HtmlScreen();
+
 		screen.allocateVirtualDocumentForContent(
 			'<div id="surfaceId">surface</div>'
 		);
@@ -107,6 +114,7 @@ describe('HtmlScreen', function () {
 
 	it('extracts surface content from response content default child if present', () => {
 		var screen = new HtmlScreen();
+
 		screen.allocateVirtualDocumentForContent(
 			'<div id="surfaceId">static<div id="surfaceId-default">surface</div></div>'
 		);
@@ -122,6 +130,7 @@ describe('HtmlScreen', function () {
 
 	it('releases virtual document after activate', () => {
 		var screen = new HtmlScreen();
+
 		screen.allocateVirtualDocumentForContent('');
 		assert.ok(screen.virtualDocument);
 		screen.activate();
@@ -171,6 +180,7 @@ describe('HtmlScreen', function () {
 		);
 		var surface = new Surface('surfaceId');
 		var screen = new HtmlScreen();
+
 		screen.allocateVirtualDocumentForContent('');
 		assert.ok(!window.sentinel);
 		screen
@@ -192,6 +202,7 @@ describe('HtmlScreen', function () {
 		);
 		var surface = new Surface('surfaceId');
 		var screen = new HtmlScreen();
+
 		screen.allocateVirtualDocumentForContent('');
 		screen
 			.evaluateStyles({
@@ -208,12 +219,15 @@ describe('HtmlScreen', function () {
 		enterDocumentSurfaceElement('surfaceId', '');
 		new Surface('surfaceId');
 		var screen = new HtmlScreen();
+
 		screen.allocateVirtualDocumentForContent(
 			'<link rel="Shortcut Icon" href="/for/favicon.ico" />'
 		);
 		screen.evaluateFavicon_().then(() => {
 			var element = document.querySelector('link[rel="Shortcut Icon"]');
+
 			var uri = new Uri(element.href);
+
 			assert.strictEqual('/for/favicon.ico', uri.getPathname());
 			exitDocumentElement('surfaceId');
 			done();
@@ -222,6 +236,7 @@ describe('HtmlScreen', function () {
 
 	it('always evaluate tracked favicon', (done) => {
 		var screen = new HtmlScreen();
+
 		screen.allocateVirtualDocumentForContent(
 			'<link id="favicon" rel="Shortcut Icon" href="/for/favicon.ico" />'
 		);
@@ -234,6 +249,7 @@ describe('HtmlScreen', function () {
 				var element = document.querySelector(
 					'link[rel="Shortcut Icon"]'
 				);
+
 				assert.ok(element);
 				new Uri(element.href);
 				exitDocumentElement('favicon');
@@ -256,6 +272,7 @@ describe('HtmlScreen', function () {
 			);
 			new Surface('surfaceId');
 			var screen = new HtmlScreen();
+
 			screen.allocateVirtualDocumentForContent(
 				'<link rel="Shortcut Icon" href="/for/favicon.ico" />'
 			);
@@ -263,7 +280,9 @@ describe('HtmlScreen', function () {
 				var element = document.querySelector(
 					'link[rel="Shortcut Icon"]'
 				);
+
 				var uri = new Uri(element.href);
+
 				assert.strictEqual('/for/favicon.ico', uri.getPathname());
 				assert.ok(uri.hasParameter('q') === false);
 				exitDocumentElement('surfaceId');
@@ -286,6 +305,7 @@ describe('HtmlScreen', function () {
 			);
 			new Surface('surfaceId');
 			var screen = new HtmlScreen();
+
 			screen.allocateVirtualDocumentForContent(
 				'<link rel="Shortcut Icon" href="/for/favicon.ico" />'
 			);
@@ -293,7 +313,9 @@ describe('HtmlScreen', function () {
 				var element = document.querySelector(
 					'link[rel="Shortcut Icon"]'
 				);
+
 				var uri = new Uri(element.href);
+
 				assert.strictEqual('/for/favicon.ico', uri.getPathname());
 				assert.ok(uri.hasParameter('q'));
 				exitDocumentElement('surfaceId');
@@ -304,6 +326,7 @@ describe('HtmlScreen', function () {
 
 	it('always evaluate tracked temporary scripts', (done) => {
 		var screen = new HtmlScreen();
+
 		screen.allocateVirtualDocumentForContent(
 			'<script data-senna-track="temporary">window.sentinel=true;</script>'
 		);
@@ -324,6 +347,7 @@ describe('HtmlScreen', function () {
 
 	it('always evaluate tracked temporary styles', (done) => {
 		var screen = new HtmlScreen();
+
 		screen.allocateVirtualDocumentForContent(
 			'<style id="temporaryStyle" data-senna-track="temporary">body{background-color:rgb(0, 255, 0);}</style>'
 		);
@@ -342,6 +366,7 @@ describe('HtmlScreen', function () {
 
 	it('appends existing teporary styles with id in the same place as the reference', (done) => {
 		var screen = new HtmlScreen();
+
 		screen.allocateVirtualDocumentForContent(
 			'<style id="temporaryStyle" data-senna-track="temporary">body{background-color:rgb(0, 255, 0);}</style>'
 		);
@@ -366,6 +391,7 @@ describe('HtmlScreen', function () {
 
 	it('evaluates tracked permanent scripts only once', (done) => {
 		var screen = new HtmlScreen();
+
 		screen.allocateVirtualDocumentForContent(
 			'<script id="permanentScriptKey" data-senna-track="permanent">window.sentinel=true;</script>'
 		);
@@ -385,6 +411,7 @@ describe('HtmlScreen', function () {
 
 	it('evaluates tracked permanent styles only once', (done) => {
 		var screen = new HtmlScreen();
+
 		screen.allocateVirtualDocumentForContent(
 			'<style id="permanentStyle" data-senna-track="permanent">body{background-color:rgb(0, 255, 0);}</style>'
 		);
@@ -421,6 +448,7 @@ describe('HtmlScreen', function () {
 
 	it('clears pendingStyles after screen activates', (done) => {
 		var screen = new HtmlScreen();
+
 		screen.allocateVirtualDocumentForContent(
 			'<style id="temporaryStyle" data-senna-track="temporary"></style>'
 		);
@@ -476,6 +504,7 @@ describe('HtmlScreen', function () {
 
 			screen.load('/url').then(() => {
 				var style = screen.virtualQuerySelectorAll_('#style')[0];
+
 				style.addEventListener('load', () => {
 					window.sentinelLoadCount++;
 				});
@@ -501,6 +530,7 @@ describe('HtmlScreen', function () {
 
 	it('has correct title', (done) => {
 		var screen = new HtmlScreen();
+
 		screen.allocateVirtualDocumentForContent('<title>left</title>');
 		screen.resolveTitleFromVirtualDocument();
 		screen.flip([]).then(() => {
@@ -511,6 +541,7 @@ describe('HtmlScreen', function () {
 
 	it('has correct title when the title contains html entities', (done) => {
 		var screen = new HtmlScreen();
+
 		screen.allocateVirtualDocumentForContent(
 			'<title>left &amp; right</title>'
 		);

--- a/maintenance/projects/senna/test/screen/RequestScreen.js
+++ b/maintenance/projects/senna/test/screen/RequestScreen.js
@@ -39,11 +39,13 @@ describe('RequestScreen', function () {
 
 	it('is cacheable', () => {
 		var screen = new RequestScreen();
+
 		assert.ok(screen.isCacheable());
 	});
 
 	it('sets HTTP method', () => {
 		var screen = new RequestScreen();
+
 		assert.strictEqual(RequestScreen.GET, screen.getHttpMethod());
 		screen.setHttpMethod(RequestScreen.POST);
 		assert.strictEqual(RequestScreen.POST, screen.getHttpMethod());
@@ -64,6 +66,7 @@ describe('RequestScreen', function () {
 
 	it('sets timeout', () => {
 		var screen = new RequestScreen();
+
 		assert.strictEqual(30000, screen.getTimeout());
 		screen.setTimeout(0);
 		assert.strictEqual(0, screen.getTimeout());
@@ -71,6 +74,7 @@ describe('RequestScreen', function () {
 
 	it('screen beforeUpdateHistoryPath return request path if responseURL or X-Request-URL not present', () => {
 		var screen = new RequestScreen();
+
 		sinon.stub(screen, 'getRequest', () => {
 			return {
 				requestPath: '/path',
@@ -84,6 +88,7 @@ describe('RequestScreen', function () {
 
 	it('screen beforeUpdateHistoryPath return responseURL if present', () => {
 		var screen = new RequestScreen();
+
 		sinon.stub(screen, 'getRequest', () => {
 			return {
 				requestPath: '/path',
@@ -98,6 +103,7 @@ describe('RequestScreen', function () {
 
 	it('screen beforeUpdateHistoryPath return X-Request-URL if present and responseURL is not', () => {
 		var screen = new RequestScreen();
+
 		sinon.stub(screen, 'getRequest', () => {
 			return {
 				requestPath: '/path',
@@ -129,6 +135,7 @@ describe('RequestScreen', function () {
 
 	it('requests path return null if no requests were made', () => {
 		var screen = new RequestScreen();
+
 		assert.strictEqual(null, screen.getRequestPath());
 	});
 
@@ -141,6 +148,7 @@ describe('RequestScreen', function () {
 		}
 		else {
 			var screen = new RequestScreen();
+
 			screen.load('/url').then(() => {
 				assert.strictEqual(
 					globals.window.location.origin + '/url',
@@ -162,6 +170,7 @@ describe('RequestScreen', function () {
 	it('loads response content from cache', (done) => {
 		var screen = new RequestScreen();
 		var cache = {};
+
 		screen.addCache(cache);
 		screen.load('/url').then((cachedContent) => {
 			assert.strictEqual(cache, cachedContent);
@@ -185,6 +194,7 @@ describe('RequestScreen', function () {
 
 	it('cancels load request to an url', (done) => {
 		var screen = new RequestScreen();
+
 		screen
 			.load('/url')
 			.then(() => assert.fail())
@@ -197,6 +207,7 @@ describe('RequestScreen', function () {
 
 	it('fails for timeout request', (done) => {
 		var screen = new RequestScreen();
+
 		screen.setTimeout(0);
 		screen.load('/url').catch((reason) => {
 			assert.ok(reason.timeout);
@@ -241,6 +252,7 @@ describe('RequestScreen', function () {
 	it('form navigate force post method and request body wrapped in FormData', (done) => {
 		globals.capturedFormElement = globals.document.createElement('form');
 		var screen = new RequestScreen();
+
 		screen.load('/url').then(() => {
 			assert.strictEqual(RequestScreen.POST, screen.getRequest().method);
 			assert.ok(screen.getRequest().requestBody instanceof FormData);
@@ -253,6 +265,7 @@ describe('RequestScreen', function () {
 	it('adds submit input button value into request FormData', (done) => {
 		globals.capturedFormElement = globals.document.createElement('form');
 		const submitButton = globals.document.createElement('button');
+
 		submitButton.name = 'submitButton';
 		submitButton.type = 'submit';
 		submitButton.value = 'Send';
@@ -280,6 +293,7 @@ describe('RequestScreen', function () {
 		else {
 			var url = '/url';
 			var screen = new RequestScreen();
+
 			screen.load(url).then(() => {
 				assert.notStrictEqual(url, screen.getRequest().url);
 				assert.strictEqual(url, screen.getRequestPath());
@@ -299,6 +313,7 @@ describe('RequestScreen', function () {
 		else {
 			var url = '/url';
 			var screen = new RequestScreen();
+
 			screen.load(url).then(() => {
 				assert.notStrictEqual(url, screen.getRequest().url);
 				done();
@@ -320,6 +335,7 @@ describe('RequestScreen', function () {
 			);
 			var url = '/url';
 			var screen = new RequestScreen();
+
 			screen.load(url).then(() => {
 				assert.ok(
 					'"0"',
@@ -337,8 +353,10 @@ describe('RequestScreen', function () {
 			'http',
 			'https'
 		);
+
 		screen.load(wrongProtocol + '/url').then(() => {
 			var url = screen.getRequest().url;
+
 			assert.ok(url.indexOf('http:') === 0);
 			done();
 		});

--- a/maintenance/projects/senna/test/screen/Screen.js
+++ b/maintenance/projects/senna/test/screen/Screen.js
@@ -97,6 +97,7 @@ describe('Screen', () => {
 
 	it('gets screen id', () => {
 		var screen = new Screen();
+
 		assert.ok(screen.getId());
 		screen.setId('otherId');
 		assert.strictEqual('otherId', screen.getId());
@@ -104,6 +105,7 @@ describe('Screen', () => {
 
 	it('gets screen title', () => {
 		var screen = new Screen();
+
 		assert.strictEqual(null, screen.getTitle());
 		screen.setTitle('other');
 		assert.strictEqual('other', screen.getTitle());
@@ -140,6 +142,7 @@ describe('Screen', () => {
 		);
 		var surface = new Surface('surfaceId');
 		var screen = new Screen();
+
 		screen
 			.evaluateStyles({
 				surfaceId: surface,

--- a/maintenance/projects/senna/test/surface/Surface.js
+++ b/maintenance/projects/senna/test/surface/Surface.js
@@ -30,20 +30,25 @@ describe('Surface', () => {
 		it('creates surface child when adding screen content to surface', () => {
 			enterDocumentSurfaceElement('surfaceId');
 			var surface = new Surface('surfaceId');
+
 			var surfaceChild = surface.addContent('screenId', 'content');
+
 			assert.ok(core.isElement(surfaceChild));
 			exitDocumentSurfaceElement('surfaceId');
 		});
 
 		it('creates surface child when adding screen content to surface outside document', () => {
 			var surface = new Surface('virtualSurfaceId');
+
 			var surfaceChild = surface.addContent('screenId', 'content');
+
 			assert.strictEqual('content', surfaceChild.innerHTML);
 		});
 
 		it('wraps initial surface content as default child if default wrapper missing', () => {
 			enterDocumentSurfaceElement('surfaceId', 'default');
 			var surface = new Surface('surfaceId');
+
 			assert.strictEqual('default', surface.defaultChild.innerHTML);
 			exitDocumentSurfaceElement('surfaceId');
 		});
@@ -51,7 +56,9 @@ describe('Surface', () => {
 		it('adds screen content to surface child', () => {
 			enterDocumentSurfaceElement('surfaceId');
 			var surface = new Surface('surfaceId');
+
 			var surfaceChild = surface.addContent('screenId', 'content');
+
 			assert.strictEqual('content', surfaceChild.innerHTML);
 			exitDocumentSurfaceElement('surfaceId');
 		});
@@ -59,7 +66,9 @@ describe('Surface', () => {
 		it('adds empty string as screen content to surface child', () => {
 			enterDocumentSurfaceElement('surfaceId');
 			var surface = new Surface('surfaceId');
+
 			var surfaceChild = surface.addContent('screenId', '');
+
 			assert.strictEqual('', surfaceChild.innerHTML);
 			exitDocumentSurfaceElement('surfaceId');
 		});
@@ -67,7 +76,9 @@ describe('Surface', () => {
 		it('does not add null/undefined as screen content to surface child', () => {
 			enterDocumentSurfaceElement('surfaceId');
 			var surface = new Surface('surfaceId');
+
 			var surfaceChild = surface.addContent('screenId', undefined);
+
 			assert.strictEqual(surface.defaultChild, surfaceChild);
 			surfaceChild = surface.addContent('screenId', null);
 			assert.strictEqual(surface.defaultChild, surfaceChild);
@@ -77,7 +88,9 @@ describe('Surface', () => {
 		it('surface child be inserted into surface element', () => {
 			enterDocumentSurfaceElement('surfaceId');
 			var surface = new Surface('surfaceId');
+
 			var surfaceChild = surface.addContent('screenId', 'content');
+
 			assert.strictEqual(surface.getElement(), surfaceChild.parentNode);
 			exitDocumentSurfaceElement('surfaceId');
 		});
@@ -85,7 +98,9 @@ describe('Surface', () => {
 		it('surface child enter document invisible', () => {
 			enterDocumentSurfaceElement('surfaceId');
 			var surface = new Surface('surfaceId');
+
 			var surfaceChild = surface.addContent('screenId', 'content');
+
 			assert.strictEqual('none', surfaceChild.style.display);
 			exitDocumentSurfaceElement('surfaceId');
 		});
@@ -93,6 +108,7 @@ describe('Surface', () => {
 		it('surface child become visible for its screen', () => {
 			enterDocumentSurfaceElement('surfaceId');
 			var surface = new Surface('surfaceId');
+
 			var surfaceChild = surface.addContent('screenId', 'content');
 			surface.show('screenId');
 			assert.strictEqual('block', surfaceChild.style.display);
@@ -102,12 +118,14 @@ describe('Surface', () => {
 		it('only one surface child be visible at time', () => {
 			enterDocumentSurfaceElement('surfaceId');
 			var surface = new Surface('surfaceId');
+
 			var surfaceChild = surface.addContent('screenId', 'content');
 			surface.show('screenId');
 			var surfaceChildNext = surface.addContent(
 				'screenNextId',
 				'content'
 			);
+
 			assert.strictEqual('none', surfaceChildNext.style.display);
 			surface.show('screenNextId');
 			assert.strictEqual('none', surfaceChild.style.display);
@@ -118,6 +136,7 @@ describe('Surface', () => {
 		it('removes screen content from surface child', () => {
 			enterDocumentSurfaceElement('surfaceId');
 			var surface = new Surface('surfaceId');
+
 			surface.addContent('screenId', 'content');
 			surface.remove('screenId');
 			assert.strictEqual(null, surface.getChild('screenId'));
@@ -127,6 +146,7 @@ describe('Surface', () => {
 		it('removes screen content from surface child outside document', () => {
 			enterDocumentSurfaceElement('surfaceId');
 			var surface = new Surface('surfaceId');
+
 			surface.remove('screenId');
 			assert.strictEqual(null, surface.getChild('screenId'));
 			exitDocumentSurfaceElement('surfaceId');
@@ -134,19 +154,23 @@ describe('Surface', () => {
 
 		it('creates surface child relating surface id and screen id', () => {
 			var surface = new Surface('surfaceId');
+
 			var surfaceChild = surface.createChild('screenId');
+
 			assert.strictEqual('surfaceId-screenId', surfaceChild.id);
 		});
 
 		it('gets surface element by surfaceId', () => {
 			var surfaceElement = enterDocumentSurfaceElement('surfaceId');
 			var surface = new Surface('surfaceId');
+
 			assert.strictEqual(surfaceElement, surface.getElement());
 			exitDocumentSurfaceElement('surfaceId');
 		});
 
 		it('gets surface id', () => {
 			var surface = new Surface('surfaceId');
+
 			assert.strictEqual('surfaceId', surface.getId());
 			surface.setId('otherId');
 			assert.strictEqual('otherId', surface.getId());
@@ -154,10 +178,13 @@ describe('Surface', () => {
 
 		it('shows default surface child if screen id not found and hide when found', () => {
 			var defaultChild = enterDocumentSurfaceElement('surfaceId-default');
+
 			enterDocumentSurfaceElement('surfaceId').appendChild(defaultChild);
 			var surface = new Surface('surfaceId');
+
 			surface.show('screenId');
 			var surfaceChild = surface.addContent('screenId', 'content');
+
 			assert.strictEqual('none', surfaceChild.style.display);
 			assert.strictEqual('block', defaultChild.style.display);
 			surface.show('screenId');
@@ -170,9 +197,11 @@ describe('Surface', () => {
 			var surfaceChild = enterDocumentSurfaceElement(
 				'surfaceId-screenId'
 			);
+
 			enterDocumentSurfaceElement('surfaceId').appendChild(surfaceChild);
 			surfaceChild.innerHTML = 'temp';
 			var surface = new Surface('surfaceId');
+
 			surface.addContent('screenId', 'content');
 			assert.strictEqual('content', surfaceChild.innerHTML);
 			exitDocumentSurfaceElement('surfaceId');
@@ -181,8 +210,10 @@ describe('Surface', () => {
 		it('is able to overwrite default transition', () => {
 			enterDocumentSurfaceElement('surfaceId');
 			var surface = new Surface('surfaceId');
+
 			surface.addContent('screenId', 'content');
 			var transitionFn = sinon.stub();
+
 			surface.setTransitionFn(transitionFn);
 			surface.show('screenId');
 			assert.strictEqual(1, transitionFn.callCount);
@@ -193,12 +224,14 @@ describe('Surface', () => {
 		it('is able to wait deferred transition before removing visible surface child', (done) => {
 			enterDocumentSurfaceElement('surfaceId');
 			var surface = new Surface('surfaceId');
+
 			var surfaceChild = surface.addContent('screenId', 'content');
 			var surfaceChildNext = surface.addContent(
 				'screenNextId',
 				'content'
 			);
 			var transitionFn = () => CancellablePromise.resolve();
+
 			surface.setTransitionFn(transitionFn);
 			surface.show('screenId');
 			surface.show('screenNextId').then(() => {
@@ -214,6 +247,7 @@ describe('Surface', () => {
 		it('transition deferred be cancellable', (done) => {
 			var surface = new Surface('surfaceId');
 			var transitionFn = () => CancellablePromise.resolve();
+
 			surface.setTransitionFn(transitionFn);
 			surface
 				.transition(null, null)

--- a/maintenance/projects/senna/test/utils/utils.js
+++ b/maintenance/projects/senna/test/utils/utils.js
@@ -31,10 +31,12 @@ describe('utils', () => {
 
 	it('copies attributes from source node to target node', () => {
 		var nodeA = document.createElement('div');
+
 		nodeA.setAttribute('a', 'valueA');
 		nodeA.setAttribute('b', 'valueB');
 
 		var nodeB = document.createElement('div');
+
 		utils.copyNodeAttributes(nodeA, nodeB);
 
 		assert.strictEqual(nodeA.attributes.length, nodeB.attributes.length);
@@ -46,6 +48,7 @@ describe('utils', () => {
 
 	it('clears attributes from a given node', () => {
 		var node = document.createElement('div');
+
 		node.setAttribute('a', 'valueA');
 		node.setAttribute('b', 'valueB');
 

--- a/projects/amd-loader/bin/build-demo.js
+++ b/projects/amd-loader/bin/build-demo.js
@@ -39,6 +39,7 @@ globby.sync('src/demo/modules/**/*.js').forEach((file) => {
 	const filePath = file.substring(
 		path.join(DEMO_SRC, 'modules').length + path.sep.length
 	);
+
 	const dirname = path.dirname(filePath);
 
 	fs.mkdirsSync(DEMO_BUILD, 'modules', dirname);

--- a/projects/amd-loader/src/loader/bootstrap.js
+++ b/projects/amd-loader/src/loader/bootstrap.js
@@ -6,12 +6,14 @@
 import Loader from './loader';
 
 const cfg = window.__CONFIG__ || {};
+
 const namespace = typeof cfg.namespace === 'string' ? cfg.namespace : undefined;
 const exposeGlobal = cfg.exposeGlobal === undefined ? true : cfg.exposeGlobal;
 const loader = new Loader(cfg);
 
 if (namespace) {
 	const ns = window[namespace] ? window[namespace] : {};
+
 	ns.Loader = loader;
 	window[namespace] = ns;
 }

--- a/projects/amd-loader/src/loader/dependency-resolver.js
+++ b/projects/amd-loader/src/loader/dependency-resolver.js
@@ -43,6 +43,7 @@ export default class DependencyResolver {
 			}
 
 			const modulesParam = `modules=${encodeURIComponent(modules)}`;
+
 			let url = `${config.resolvePath}?${modulesParam}`;
 			let options = {};
 
@@ -58,6 +59,7 @@ export default class DependencyResolver {
 				.then((response) => response.text())
 				.then((text) => {
 					const resolution = JSON.parse(text);
+
 					this._cachedResolutions[modules] = resolution;
 					resolve(resolution);
 				})

--- a/projects/amd-loader/src/loader/script-loader.js
+++ b/projects/amd-loader/src/loader/script-loader.js
@@ -58,6 +58,7 @@ export default class ScriptLoader {
 	 */
 	_loadScript(modulesURL) {
 		const config = this._config;
+
 		const modules = config.getModules(modulesURL.modules);
 
 		let script = this._injectedScripts[modulesURL.url];

--- a/projects/amd-loader/src/loader/url-builder.js
+++ b/projects/amd-loader/src/loader/url-builder.js
@@ -38,6 +38,7 @@ export default class URLBuilder {
 
 		moduleNames.forEach((moduleName) => {
 			const module = config.getModule(moduleName);
+
 			const path = this._getModulePath(module);
 
 			if (config.combine) {

--- a/projects/amd-loader/test/loader/script-loader.js
+++ b/projects/amd-loader/test/loader/script-loader.js
@@ -32,6 +32,7 @@ describe('ScriptLoader', () => {
 
 	it('inserts synchronous DOM script nodes', (done) => {
 		const config = new Config({combine: false, url: 'http://localhost'});
+
 		const scriptLoader = new ScriptLoader(document, config);
 
 		config.addModule('a@1.0.0');
@@ -50,6 +51,7 @@ describe('ScriptLoader', () => {
 
 	it('works without combine flag', (done) => {
 		const config = new Config({combine: false, url: 'http://localhost'});
+
 		const scriptLoader = new ScriptLoader(document, config);
 
 		const moduleNames = ['a@1.0.0', 'b@1.2.0'];
@@ -75,6 +77,7 @@ describe('ScriptLoader', () => {
 
 	it('works with combine flag', (done) => {
 		const config = new Config({combine: true, url: 'http://localhost'});
+
 		const scriptLoader = new ScriptLoader(document, config);
 
 		const moduleNames = ['a@1.0.0', 'b@1.2.0'];
@@ -96,6 +99,7 @@ describe('ScriptLoader', () => {
 
 	it('rejects on error', (done) => {
 		const config = new Config({combine: true, url: 'http://localhost'});
+
 		const scriptLoader = new ScriptLoader(document, config);
 
 		const moduleNames = ['a@1.0.0', 'b@1.2.0'];

--- a/projects/eslint-plugin/configs/general.js
+++ b/projects/eslint-plugin/configs/general.js
@@ -93,6 +93,7 @@ const config = {
 		'@liferay/aui/no-node': 'error',
 		'@liferay/aui/no-object': 'error',
 		'@liferay/aui/no-one': 'error',
+		'@liferay/blank-line-declaration-usage': 'error',
 		'@liferay/destructure-requires': 'error',
 		'@liferay/empty-line-between-elements': 'error',
 		'@liferay/expect-assert': 'error',

--- a/projects/eslint-plugin/rules/general/index.js
+++ b/projects/eslint-plugin/rules/general/index.js
@@ -6,6 +6,7 @@
 module.exports = {
 	'array-is-array': require('./lib/rules/array-is-array'),
 	'destructure-requires': require('./lib/rules/destructure-requires'),
+	'blank-line-declaration-usage': require('./lib/rules/blank-line-declaration-usage'),
 	'empty-line-between-elements': require('./lib/rules/empty-line-between-elements'),
 	'expect-assert': require('./lib/rules/expect-assert'),
 	'group-imports': require('./lib/rules/group-imports'),

--- a/projects/eslint-plugin/rules/general/lib/rules/blank-line-declaration-usage.js
+++ b/projects/eslint-plugin/rules/general/lib/rules/blank-line-declaration-usage.js
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const message =
+	'Expected an empty line between variable declaration and usage.';
+
+module.exports = {
+	create(context) {
+		const sourceCode = context.getSourceCode();
+
+		return {
+			VariableDeclaration(node) {
+				if (
+					node.parent.type === 'ForStatement' ||
+					node.parent.type === 'ForInStatement' ||
+					node.parent.type === 'ForOfStatement' ||
+					node.parent.type === 'WhileStatement'
+				) {
+					return;
+				}
+
+				const varsDeclaredOnLine = context.getDeclaredVariables(node);
+
+				const declarationLine =
+					varsDeclaredOnLine[0].identifiers[0].loc.start.line;
+
+				varsDeclaredOnLine.forEach((reference) => {
+					const varReference = reference.references[1];
+
+					if (varReference === undefined) {
+						return;
+					}
+
+					const referenceLine =
+						varReference.identifier.loc.start.line;
+
+					if (
+						sourceCode.lines
+							.slice(declarationLine, referenceLine - 1)
+							.indexOf('') === -1
+					) {
+						context.report({
+							fix: (fixer) => {
+								const declarationEndLine = node.loc.end.line;
+
+								if (referenceLine === declarationEndLine + 1) {
+									return fixer.insertTextAfter(node, '\n');
+								}
+							},
+							message,
+							node: reference.references[1].identifier,
+						});
+					}
+				});
+			},
+		};
+	},
+
+	meta: {
+		docs: {
+			category: 'Best Practices',
+			description: message,
+			recommended: false,
+			url: 'https://github.com/liferay/eslint-config-liferay/issues/139',
+		},
+		fixable: 'code',
+		schema: [],
+		type: 'problem',
+	},
+};

--- a/projects/eslint-plugin/rules/general/lib/rules/group-imports.js
+++ b/projects/eslint-plugin/rules/general/lib/rules/group-imports.js
@@ -23,7 +23,9 @@ module.exports = {
 
 		function expectBlankLines(node, count = 1) {
 			const comments = getLeadingComments(node, context);
+
 			const initial = comments[0] || node;
+
 			const token = context.getTokenBefore(initial, {
 				includeComments: true,
 			});

--- a/projects/eslint-plugin/rules/general/lib/rules/padded-test-blocks.js
+++ b/projects/eslint-plugin/rules/general/lib/rules/padded-test-blocks.js
@@ -122,6 +122,7 @@ module.exports = {
 							) {
 								const start = previous.range[1];
 								const end = node.range[0];
+
 								const between = source.text.slice(start, end);
 
 								let newlines = 0;

--- a/projects/eslint-plugin/rules/general/lib/rules/ref-name-suffix.js
+++ b/projects/eslint-plugin/rules/general/lib/rules/ref-name-suffix.js
@@ -26,6 +26,7 @@ module.exports = {
 						!variableName.match(NAME_PATTERN)
 					) {
 						const [variable] = context.getDeclaredVariables(node);
+
 						const newVariableName = variable.name + 'Ref';
 
 						for (const reference of variable.references) {

--- a/projects/eslint-plugin/rules/general/lib/rules/sort-imports.js
+++ b/projects/eslint-plugin/rules/general/lib/rules/sort-imports.js
@@ -290,7 +290,9 @@ module.exports = {
 
 						for (let i = firstMismatch; i <= lastMismatch; i++) {
 							const node = actual[i];
+
 							const range = getRangeForNode(node);
+
 							const text = code.getText().slice(...range);
 
 							sources.set(actual[i], {text});

--- a/projects/eslint-plugin/rules/general/tests/lib/rules/blank-line-declaration-usage.js
+++ b/projects/eslint-plugin/rules/general/tests/lib/rules/blank-line-declaration-usage.js
@@ -1,0 +1,243 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const MultiTester = require('../../../../../scripts/MultiTester');
+const rule = require('../../../lib/rules/blank-line-declaration-usage');
+
+const parserOptions = {
+	parserOptions: {
+		ecmaVersion: 6,
+	},
+};
+
+const message =
+	'Expected an empty line between variable declaration and usage.';
+
+const ruleTester = new MultiTester(parserOptions);
+
+ruleTester.run('blank-line-declaration-usage', rule, {
+	invalid: [
+		{
+			code: `
+				const test = 'test';
+				const testLength = test.length;
+			`,
+			errors: [
+				{
+					message,
+					type: 'Identifier',
+				},
+			],
+			output: `
+				const test = 'test';
+
+				const testLength = test.length;
+			`,
+		},
+		{
+			code: `
+				const obj = {
+					foo: 'bar',
+					bar: 'foo',
+					life: 'ray',
+				}
+				Object.keys(obj)
+			`,
+			errors: [
+				{
+					message,
+					type: 'Identifier',
+				},
+			],
+			output: `
+				const obj = {
+					foo: 'bar',
+					bar: 'foo',
+					life: 'ray',
+				}
+
+				Object.keys(obj)
+			`,
+		},
+		{
+			code: `
+				function updateData() {
+					const obj = {
+						foo: 'bar',
+						bar: 'foo',
+						life: 'ray',
+					}
+
+					const ids = Object.keys(obj).length
+						? 'superLongStringSoThatItForcesTheLineToBeWrapped'
+						: 'justASimpleString';
+					ids.length;
+				}
+			`,
+			errors: [
+				{
+					message,
+					type: 'Identifier',
+				},
+			],
+			output: `
+				function updateData() {
+					const obj = {
+						foo: 'bar',
+						bar: 'foo',
+						life: 'ray',
+					}
+
+					const ids = Object.keys(obj).length
+						? 'superLongStringSoThatItForcesTheLineToBeWrapped'
+						: 'justASimpleString';
+
+					ids.length;
+				}
+			`,
+		},
+		{
+			code: `
+				const obj = {
+					foo: 'bar',
+					bar: 'foo',
+					life: 'ray',
+				}
+
+				const {foo} = obj;
+				const length = foo.length;
+			`,
+			errors: [
+				{
+					message,
+					type: 'Identifier',
+				},
+			],
+			output: `
+				const obj = {
+					foo: 'bar',
+					bar: 'foo',
+					life: 'ray',
+				}
+
+				const {foo} = obj;
+
+				const length = foo.length;
+			`,
+		},
+		{
+			code: `
+				const {foo, bar, life} = obj;
+				const length = life.length;
+			`,
+			errors: [
+				{
+					message,
+					type: 'Identifier',
+				},
+			],
+			output: `
+				const {foo, bar, life} = obj;
+
+				const length = life.length;
+			`,
+		},
+		{
+			code: `
+				const filePath = context.getFilename();
+				const filename = path.basename(something, filePath);
+			`,
+			errors: [
+				{
+					message,
+					type: 'Identifier',
+				},
+			],
+			output: `
+				const filePath = context.getFilename();
+
+				const filename = path.basename(something, filePath);
+			`,
+		},
+		{
+			code: `
+				for (const file of files) {
+					const contents = readFileAsync(file, 'utf8');
+					const length = contents.length;
+				}
+			`,
+			errors: [
+				{
+					message,
+					type: 'Identifier',
+				},
+			],
+			output: `
+				for (const file of files) {
+					const contents = readFileAsync(file, 'utf8');
+
+					const length = contents.length;
+				}
+			`,
+		},
+		{
+			code: `
+				const cbSpy = sinon.spy();
+				prototype.rows = [cbSpy];
+			`,
+			errors: [
+				{
+					message,
+					type: 'Identifier',
+				},
+			],
+			output: `
+				const cbSpy = sinon.spy();
+
+				prototype.rows = [cbSpy];
+			`,
+		},
+	],
+	valid: [
+		{
+			code: `
+				const test = 'test';
+
+				const testLength = test.length;
+			`,
+		},
+		{
+			code: `
+				const obj = {
+					foo: 'bar',
+					bar: 'foo',
+					life: 'ray',
+				}
+
+				Object.keys(obj).map(key => {});
+			`,
+		},
+		{
+			code: `
+				const obj = {
+					foo: 'bar',
+					bar: 'foo',
+					life: 'ray',
+				}
+
+				const {foo} = obj;
+
+				const length = foo.length;
+			`,
+		},
+		{
+			code: `
+				for (const file of files) {
+					const contents = readFileAsync(file, 'utf8');
+				}
+			`,
+		},
+	],
+});

--- a/projects/eslint-plugin/rules/portal/lib/rules/no-localhost-reference.js
+++ b/projects/eslint-plugin/rules/portal/lib/rules/no-localhost-reference.js
@@ -10,6 +10,7 @@ const DESCRIPTION = 'do not make explicit references to localhost.';
 module.exports = {
 	create(context) {
 		const filePath = context.getFilename();
+
 		const filename = path.basename(filePath);
 
 		if (

--- a/projects/eslint-plugin/scripts/MultiTester.js
+++ b/projects/eslint-plugin/scripts/MultiTester.js
@@ -44,6 +44,7 @@ class MultiTester extends RuleTester {
 
 			const handleSkips = (test) => {
 				const {skip, ...config} = test;
+
 				if (skip && skip.includes(key)) {
 					return false;
 				}

--- a/projects/js-themes-toolkit/packages/generator-liferay-theme/generators/layout/standalone-layout.js
+++ b/projects/js-themes-toolkit/packages/generator-liferay-theme/generators/layout/standalone-layout.js
@@ -30,7 +30,9 @@ module.exports = class extends Generator {
 		const cp = new Copier(this);
 
 		const {layoutId, liferayVersion} = this.answers;
+
 		const layoutName = snakeCase(layoutId);
+
 		const templateFilename = `${layoutName}.ftl`;
 		const thumbnailFilename = `${layoutName}.png`;
 
@@ -71,6 +73,7 @@ module.exports = class extends Generator {
 
 	_getDevDependencies() {
 		const {liferayVersion} = this.answers;
+
 		const devDependencies = devDependenciesMap[liferayVersion].default;
 
 		return JSON.stringify(devDependencies, null, 2)

--- a/projects/js-themes-toolkit/packages/generator-liferay-theme/generators/layout/theme-layout.js
+++ b/projects/js-themes-toolkit/packages/generator-liferay-theme/generators/layout/theme-layout.js
@@ -25,7 +25,9 @@ module.exports = class extends Generator {
 		const cp = new Copier(this);
 
 		const {layoutId, liferayVersion} = this.answers;
+
 		const layoutName = snakeCase(layoutId);
+
 		const templateFilename = `${layoutName}.ftl`;
 		const thumbnailFilename = `${layoutName}.png`;
 

--- a/projects/js-themes-toolkit/packages/generator-liferay-theme/lib/generation/theme-based.js
+++ b/projects/js-themes-toolkit/packages/generator-liferay-theme/lib/generation/theme-based.js
@@ -29,6 +29,7 @@ const pipeline = promisify(stream.pipeline);
 
 async function writing(generator, themeName) {
 	const project = new Project(generator);
+
 	const {liferayVersion} = project;
 
 	let {themeVersion} = argv;

--- a/projects/js-themes-toolkit/packages/generator-liferay-theme/lib/utils/Copier.js
+++ b/projects/js-themes-toolkit/packages/generator-liferay-theme/lib/utils/Copier.js
@@ -51,6 +51,7 @@ module.exports = class Copier {
 	 */
 	copyDir(src, {context = {}} = {}) {
 		const gen = this._generator;
+
 		const files = fs.readdirSync(gen.templatePath(src));
 
 		files.forEach((file) => {

--- a/projects/js-themes-toolkit/packages/generator-liferay-theme/lib/utils/Project.js
+++ b/projects/js-themes-toolkit/packages/generator-liferay-theme/lib/utils/Project.js
@@ -15,6 +15,7 @@ class Project {
 
 	get type() {
 		const {fs} = this._generator;
+
 		const pkgJson = fs.readJSON('package.json');
 
 		if (pkgJson === undefined) {

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/__tests__/util.test.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/__tests__/util.test.js
@@ -63,6 +63,7 @@ describe('resolveDependency()', () => {
 		const resolved = util.resolveDependency(
 			'liferay-frontend-theme-styled'
 		);
+
 		expect(resolved).toContain(process.cwd());
 	});
 });

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/project/__tests__/index.test.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/project/__tests__/index.test.js
@@ -9,6 +9,7 @@ const path = require('path');
 const project = require('../index');
 
 const prjPath = path.join(__dirname, 'fixtures', 'a-project');
+
 const pkgJsonPath = path.join(prjPath, 'package.json');
 
 const savedCwd = process.cwd();

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/css-parse.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/css-parse.js
@@ -26,10 +26,12 @@ module.exports = function (css, options) {
 
 	function updatePosition(str) {
 		var lines = str.match(/\n/g);
+
 		if (lines) {
 			lineno += lines.length;
 		}
 		var i = str.lastIndexOf('\n');
+
 		column = ~i ? str.length - i : column + str.length;
 	}
 
@@ -80,6 +82,7 @@ module.exports = function (css, options) {
 
 	function error(msg, start) {
 		var errorThrown = new Error(`${filename} (${lineno}:${column}) ${msg}`);
+
 		errorThrown.position = new Position(start);
 		errorThrown.filename = filename;
 		errorThrown.description = msg;
@@ -142,10 +145,12 @@ module.exports = function (css, options) {
 
 	function match(re) {
 		var m = re.exec(css);
+
 		if (!m) {
 			return;
 		}
 		var str = m[0];
+
 		updatePosition(str);
 		css = css.slice(str.length);
 
@@ -211,6 +216,7 @@ module.exports = function (css, options) {
 
 	function selector() {
 		var m = match(/^([^{]+)/);
+
 		if (!m) {
 			return;
 		}
@@ -232,6 +238,7 @@ module.exports = function (css, options) {
 		// prop
 
 		var prop = match(/^(\*?[-#/*\w]+(\[[0-9a-z_-]+\])?)\s*/);
+
 		if (!prop) {
 			return;
 		}
@@ -246,6 +253,7 @@ module.exports = function (css, options) {
 		// val
 
 		var val = match(/^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|\([^)]*?\)|[^};])+)/);
+
 		if (!val) {
 			return error('property missing value');
 		}
@@ -462,6 +470,7 @@ module.exports = function (css, options) {
 	function atpage() {
 		var pos = position();
 		var m = match(/^@page */);
+
 		if (!m) {
 			return;
 		}
@@ -499,6 +508,7 @@ module.exports = function (css, options) {
 	function atdocument() {
 		var pos = position();
 		var m = match(/^@([-\w]+)?document *([^{]+)/);
+
 		if (!m) {
 			return;
 		}
@@ -585,10 +595,12 @@ module.exports = function (css, options) {
 	function _atrule(name) {
 		var pos = position();
 		var m = match(new RegExp('^@' + name + ' *([^;\\n]+);'));
+
 		if (!m) {
 			return;
 		}
 		var ret = {type: name};
+
 		ret[name] = trim(m[1]);
 
 		return pos(ret);

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/index.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/index.js
@@ -67,6 +67,7 @@ function bgPosition(v) {
 		v = v.replace(/\bright\b/, 'left');
 	}
 	var m = v.trim().split(/\s+/);
+
 	if (m && m.length === 1 && v.match(/(\d+)([a-z]{2}|%)/)) {
 		v = 'right ' + v;
 	}
@@ -151,6 +152,7 @@ var valueMap = {
 
 function processRule(rule, index, list) {
 	var prev = list[index - 1];
+
 	if (prev && prev.type === 'comment' && prev.comment.trim() === '@noflip') {
 		return;
 	}
@@ -176,9 +178,11 @@ function processDeclaration(declaration, rule) {
 	// RegEx for comments is taken from http://www.w3.org/TR/CSS21/grammar.html
 
 	var commentRegEx = /\/\*[^*]*\*+([^/*][^*]*\*+)*\//g;
+
 	var prop = declaration.property.replace(commentRegEx, ''); // remove comments
 	var val = declaration.value.replace(commentRegEx, '');
 	var important = /!important/;
+
 	var isImportant = val.match(important);
 	var asterisk = prop.match(/^(\*+)(.+)/, '');
 

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/yui3.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/yui3.js
@@ -52,6 +52,7 @@ var plug = function (r2) {
 
 		if (swap) {
 			var handle = resizeHandleInnerRegexp.exec(swap)[1];
+
 			v = swapHandleInnerBg[handle] || v;
 		}
 		else {

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/plugin/tasks/deploy.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/plugin/tasks/deploy.js
@@ -11,6 +11,7 @@ const project = require('../../lib/project');
 
 module.exports = function () {
 	const {gulp, store} = project;
+
 	const {runSequence} = gulp;
 
 	gulp.task('plugin:deploy', () => {

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/plugin/tasks/init.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/plugin/tasks/init.js
@@ -12,6 +12,7 @@ const InitPrompt = require('../prompts/init_prompt');
 
 module.exports = function () {
 	const {gulp, store} = project;
+
 	const {appServerPath, dockerContainerName} = store;
 
 	gulp.task('plugin:init', (callback) => {

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/plugin/tasks/war.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/plugin/tasks/war.js
@@ -11,6 +11,7 @@ const project = require('../../lib/project');
 
 module.exports = function () {
 	const {gulp} = project;
+
 	const {runSequence} = gulp;
 
 	gulp.task('plugin:war', () => {

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/lib/theme_finder.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/lib/theme_finder.js
@@ -112,9 +112,11 @@ function getLiferayThemeModuleFromURL(url) {
 		// Just in case package name doesn't match URL basename, read it.
 
 		const {dependencies} = JSON.parse(fs.readFileSync('package.json'));
+
 		const themeName = Object.keys(dependencies)[0];
 
 		const json = path.join('node_modules', themeName, 'package.json');
+
 		config = JSON.parse(fs.readFileSync(json));
 	});
 
@@ -184,6 +186,7 @@ module.exports = {
  */
 function withScratchDirectory(callback) {
 	const template = path.join(os.tmpdir(), 'theme-finder-');
+
 	const directory = fs.mkdtempSync(template);
 
 	const cwd = process.cwd();

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/prompts/__tests__/extend_prompt.test.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/prompts/__tests__/extend_prompt.test.js
@@ -332,6 +332,7 @@ it('_promptThemeSource should prompt correct workflow', () => {
 	prototype._promptThemeSource();
 
 	const args = inquirer.prompt.getCall(0).args;
+
 	const questions = args[0];
 
 	const extendType = questions[0];

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/prompts/__tests__/prompt_util.test.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/prompts/__tests__/prompt_util.test.js
@@ -66,6 +66,7 @@ it('getModuleChoices should get module choices that are appropriate for extend t
 
 	_.forEach(choices, (item, index) => {
 		const number = index + 1;
+
 		const name = 'themelet-' + number;
 
 		expect(item.name).toBe(name);
@@ -78,6 +79,7 @@ it('getModuleChoices should get module choices that are appropriate for extend t
 
 	_.forEach(choices, (item, index) => {
 		const number = index + 1;
+
 		const name = 'themelet-' + number;
 
 		if (number === 1) {
@@ -93,6 +95,7 @@ it('getModuleChoices should get module choices that are appropriate for extend t
 
 	_.forEach(choices, (item, index) => {
 		const number = index + 1;
+
 		const name = 'themelet-' + number;
 
 		expect(!item.checked).toBe(true);
@@ -106,6 +109,7 @@ it('getModuleChoices should get module choices that are appropriate for extend t
 
 	_.forEach(choices, (item, index) => {
 		const number = index + 1;
+
 		const name = 'themelet-' + number;
 
 		if (number === 1) {

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/prompts/extend_prompt.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/prompts/extend_prompt.js
@@ -63,6 +63,7 @@ class ExtendPrompt {
 		const {baseTheme} = project.themeConfig.config;
 		const module = answers.module;
 		const modulePackages = answers.modules;
+
 		const pkg = modulePackages[module];
 
 		if (!module) {

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/prompts/url_package_prompt.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/prompts/url_package_prompt.js
@@ -82,6 +82,7 @@ class URLPackagePrompt {
 		if (this.themelet && answers.module) {
 			Object.keys(answers.module).forEach((k) => {
 				const moduleName = this.config.selectedModules[k];
+
 				answers.module[moduleName] = answers.module[k];
 				delete answers.module[k];
 			});

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/tasks/__tests__/build.test.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/tasks/__tests__/build.test.js
@@ -237,6 +237,7 @@ describe('using lib_sass', () => {
 
 	function _assertFixAtDirectives(callback) {
 		const cssPath = path.join(buildPath, 'css');
+
 		const mainCssPath = path.join(cssPath, 'main.css');
 
 		assertExists(cssPath);
@@ -286,6 +287,7 @@ describe('using lib_sass', () => {
 		assertExists(templatesPath);
 
 		const customCSSFileName = '_custom.scss';
+
 		const customCSSPath = path.join(cssPath, customCSSFileName);
 
 		const fileContent = stripNewlines(
@@ -393,6 +395,7 @@ describe('using lib_sass', () => {
 		assertExists(velocityPath);
 
 		const customCSSFileName = '_custom.scss';
+
 		const customCSSPath = path.join(buildPath, 'css', customCSSFileName);
 
 		assertMatches(

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/tasks/build/compile-css.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/tasks/build/compile-css.js
@@ -18,6 +18,7 @@ const {createBourbonFile} = require('../../lib/bourbon_dependencies');
 
 module.exports = function () {
 	const {gulp, options} = project;
+
 	const {pathBuild} = options;
 
 	const handleScssError = (error) => {
@@ -154,6 +155,7 @@ function getSassIncludePaths() {
 	includePaths.push(path.dirname(require.resolve('compass-mixins')));
 
 	const argv = themeUtil.getArgv();
+
 	if (argv['sass-include-paths']) {
 		const customPaths = argv['sass-include-paths']
 			.split(',')
@@ -166,6 +168,7 @@ function getSassIncludePaths() {
 	}
 
 	const themeNodeModules = path.resolve('node_modules');
+
 	if (fs.existsSync(themeNodeModules)) {
 		includePaths.push(themeNodeModules);
 	}

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/tasks/build/index.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/tasks/build/index.js
@@ -74,6 +74,7 @@ function injectJS() {
 
 module.exports = function () {
 	const {gulp, options} = project;
+
 	const {runSequence} = gulp;
 	const {pathBuild, pathSrc} = options;
 

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/tasks/build/sass.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/tasks/build/sass.js
@@ -66,6 +66,7 @@ module.exports = (options) =>
 		catch (error) {
 			const filePath =
 				(error.file === 'stdin' ? file.path : error.file) || file.path;
+
 			const relativePath = path.relative(process.cwd(), filePath);
 			const message = [
 				chalk.underline(relativePath),

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/tasks/build/themelets.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/tasks/build/themelets.js
@@ -25,6 +25,7 @@ const defaultTemplateLanguage = 'ftl';
 
 module.exports = function () {
 	const {gulp, options} = project;
+
 	const {runSequence} = gulp;
 	const {pathBuild} = options;
 

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/tasks/deploy.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/tasks/deploy.js
@@ -12,6 +12,7 @@ const DEPLOYMENT_STRATEGIES = themeUtil.DEPLOYMENT_STRATEGIES;
 
 function registerTasks() {
 	const {gulp, options, store} = project;
+
 	const {runSequence} = gulp;
 	const {argv, pathDist} = options;
 	const {

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/tasks/upgrade.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/tasks/upgrade.js
@@ -116,7 +116,9 @@ module.exports = function () {
 
 	gulp.task('upgrade:config', () => {
 		const {targetVersion} = versionUpgrade;
+
 		const dotTargetVersion = targetVersion + '.0';
+
 		const underscoreTargetVersion = dotTargetVersion.replace(/\./g, '_');
 
 		project.themeConfig.setConfig({

--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/tasks/watch.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/theme/tasks/watch.js
@@ -66,6 +66,7 @@ function isReadable(file) {
 
 module.exports = function () {
 	const {gulp, options, store} = project;
+
 	const {runSequence} = gulp;
 	const {argv, distName, pathBuild, pathSrc, resourcePrefix} = options;
 	const {deploymentStrategy, dockerContainerName} = store;
@@ -176,8 +177,11 @@ module.exports = function () {
 
 	gulp.task('watch:reload', (callback) => {
 		const {changedFile} = store;
+
 		const srcPath = path.relative(project.dir, changedFile.path);
+
 		const dstPath = srcPath.replace(/^src\//, '');
+
 		const urlPath = `${resourcePrefix}/${distName}/${dstPath}`;
 
 		livereload.changed({
@@ -267,8 +271,10 @@ module.exports = function () {
 			const requestUrl = url.parse(req.url);
 
 			const match = themePattern.exec(requestUrl.pathname);
+
 			if (match) {
 				const filepath = path.resolve('build', match[3]);
+
 				const ext = path.extname(filepath);
 
 				// eslint-disable-next-line promise/catch-or-return
@@ -299,9 +305,11 @@ module.exports = function () {
 				`Watch mode is now active at: ${url}`,
 				`Proxying: ${proxyUrl}`,
 			];
+
 			const width = messages.reduce((max, line) => {
 				return Math.max(line.length, max);
 			}, 0);
+
 			const ruler = '-'.repeat(width);
 
 			// eslint-disable-next-line no-console

--- a/projects/js-themes-toolkit/scripts/qa.js
+++ b/projects/js-themes-toolkit/scripts/qa.js
@@ -12,7 +12,9 @@ const path = require('path');
 const {argv} = require('yargs');
 
 const projectDir = path.resolve(__dirname, '..');
+
 const workDir = path.join(projectDir, 'qa');
+
 const pkgsDir = path.join(workDir, 'packages');
 const yoPath = path.join(workDir, 'node_modules', '.bin', 'yo');
 const generatorsPath = path.join(
@@ -21,6 +23,7 @@ const generatorsPath = path.join(
 	'generator-liferay-theme',
 	'generators'
 );
+
 const generatorPath = path.join(generatorsPath, 'app', 'index.js');
 const classicGeneratorPath = path.join(generatorsPath, 'classic', 'index.js');
 const adminGeneratorPath = path.join(generatorsPath, 'admin', 'index.js');

--- a/projects/js-toolkit/packages/dev-server/src/server.ts
+++ b/projects/js-toolkit/packages/dev-server/src/server.ts
@@ -76,6 +76,7 @@ async function getModulePaths(
 	regenerate = false
 ): Promise<Map<string, string>> {
 	const mappingsTmpDirPath = resolve(tmpdir(), 'liferay-dev-server');
+
 	const mappingsTmpFilePath = resolve(mappingsTmpDirPath, 'mappings.json');
 
 	if (!regenerate) {

--- a/projects/js-toolkit/packages/js-toolkit-core/src/project/Adapt.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/project/Adapt.ts
@@ -33,6 +33,7 @@ export default class Adapt {
 
 	_lazyInit(): void {
 		const {_project} = this;
+
 		const {probe} = _project;
 
 		switch (probe.type) {

--- a/projects/js-toolkit/packages/js-toolkit-core/src/project/Jar.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/project/Jar.ts
@@ -90,6 +90,7 @@ export default class Jar {
 		}
 
 		const {_project} = this;
+
 		const {configuration} = _project;
 
 		if (this._outputDir === undefined) {
@@ -202,6 +203,7 @@ different: using the one in liferay-npm-bundler.config.js
 
 	_getBndWebContextPath(): string {
 		const {dir} = this._project;
+
 		const bndFile = dir.join('bnd.bnd');
 
 		if (fs.existsSync(bndFile.asNative)) {

--- a/projects/js-toolkit/packages/js-toolkit-core/src/project/Misc.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/project/Misc.ts
@@ -105,6 +105,7 @@ export default class Misc {
 	get reportFile(): FilePath | undefined {
 		if (this._reportFile === undefined) {
 			const {_project} = this;
+
 			const {configuration} = _project;
 
 			const dumpReport = prop.get(configuration, 'dump-report', false);
@@ -123,6 +124,7 @@ export default class Misc {
 	get reportLevel(): LogLevel {
 		if (this._reportLevel === undefined) {
 			const {_project} = this;
+
 			const {configuration} = _project;
 
 			let dumpReport = prop.get<string | boolean>(

--- a/projects/js-toolkit/packages/js-toolkit-core/src/project/Probe.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/project/Probe.ts
@@ -69,6 +69,7 @@ export default class Probe {
 
 	_hasScriptCalling(tool: string): boolean {
 		const {pkgJson} = this._project;
+
 		const {scripts} = pkgJson;
 
 		if (!scripts) {

--- a/projects/js-toolkit/packages/js-toolkit-core/src/project/Project.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/project/Project.ts
@@ -336,6 +336,7 @@ export default class Project {
 			// Get preset version
 
 			const {_configuration} = this;
+
 			const preset = _configuration['preset'];
 
 			if (preset) {
@@ -446,6 +447,7 @@ export default class Project {
 
 	_loadConfiguration(): void {
 		const {_configFile} = this;
+
 		const configDir = _configFile.dirname();
 
 		if (fs.existsSync(configDir.join('.npmbundlerrc').asNative)) {

--- a/projects/js-toolkit/packages/liferay-cli/src/adapt/index.ts
+++ b/projects/js-toolkit/packages/liferay-cli/src/adapt/index.ts
@@ -151,6 +151,7 @@ async function performBaseAdaptation(options: Options): Promise<void> {
 	);
 	/* eslint-disable-next-line @liferay/no-dynamic-require, @typescript-eslint/no-var-requires */
 	const pkgJson = require(pkgJsonFile.asNative);
+
 	const portletDisplayName = toHumanReadable(pkgJson['name']);
 	const portletName = getPortletName(pkgJson['name']);
 

--- a/projects/js-toolkit/packages/liferay-cli/src/index.ts
+++ b/projects/js-toolkit/packages/liferay-cli/src/index.ts
@@ -46,6 +46,7 @@ async function warnIfNewerVersionAvailable(): Promise<void> {
 	try {
 		/* eslint-disable-next-line @typescript-eslint/no-var-requires */
 		const packageJson = require('../package.json');
+
 		const update = await checkForUpdate(packageJson, {
 
 			// Check every 3 days

--- a/projects/js-toolkit/packages/liferay-cli/src/new/facet-portlet/index.ts
+++ b/projects/js-toolkit/packages/liferay-cli/src/new/facet-portlet/index.ts
@@ -55,6 +55,7 @@ const facet: Facet = {
 
 		/* eslint-disable-next-line @liferay/no-dynamic-require, @typescript-eslint/no-var-requires */
 		const pkgJson = require(pkgJsonFile.asNative);
+
 		const portletDisplayName = toHumanReadable(pkgJson['name']);
 		const portletName = getPortletName(pkgJson['name']);
 

--- a/projects/js-toolkit/packages/liferay-cli/src/runLiferayCli.ts
+++ b/projects/js-toolkit/packages/liferay-cli/src/runLiferayCli.ts
@@ -40,6 +40,7 @@ export default async function runLiferayCli(...args: string[]): Promise<void> {
 	}
 
 	const packageJson = projectRequire(`${targetPlatformName}/package.json`);
+
 	const liferayBin = packageJson.bin['liferay'];
 
 	if (!liferayBin) {

--- a/projects/js-toolkit/packages/npm-bundler/src/adapt/bundler-project/index.ts
+++ b/projects/js-toolkit/packages/npm-bundler/src/adapt/bundler-project/index.ts
@@ -108,6 +108,7 @@ async function transformBundles(): Promise<void> {
  */
 async function writeManifestModule(): Promise<void> {
 	const {name, version} = project.pkgJson;
+
 	const moduleName = `${name}@${version}/webpack.manifest`;
 
 	const renderer = new TemplateRenderer(

--- a/projects/js-toolkit/packages/npm-bundler/src/index.ts
+++ b/projects/js-toolkit/packages/npm-bundler/src/index.ts
@@ -30,6 +30,7 @@ export default async function (argv: {version: boolean}): Promise<void> {
 
 	try {
 		const {pkgJson, versionsInfo} = project;
+
 		const rootPkg = new PkgDesc(pkgJson.name, pkgJson.version);
 
 		const start = process.hrtime();
@@ -73,6 +74,7 @@ export default async function (argv: {version: boolean}): Promise<void> {
 		// Report and show execution time
 
 		const hrtime = process.hrtime(start);
+
 		report.executionTime(hrtime);
 		log.success(`Bundled {${pkgJson.name}} in`, pretty(hrtime));
 

--- a/projects/js-toolkit/packages/npm-bundler/src/transform/js/operation/transformImports.ts
+++ b/projects/js-toolkit/packages/npm-bundler/src/transform/js/operation/transformImports.ts
@@ -107,6 +107,7 @@ function transformImportDeclaration(
 ): boolean {
 	const {imports} = project;
 	const moduleName = node.source.value as string;
+
 	const config = imports[moduleName];
 
 	if (!config) {

--- a/projects/js-toolkit/packages/portal-base/src/build.ts
+++ b/projects/js-toolkit/packages/portal-base/src/build.ts
@@ -46,6 +46,7 @@ function copyAssets(): void {
 
 	assetFiles.forEach((assetFile) => {
 		const srcDirRelAssetFile = srcDir.relative(assetFile);
+
 		const outFile = buildDir.join(srcDirRelAssetFile);
 
 		try {
@@ -112,6 +113,7 @@ function runBundler(): void {
 	const bundlerPkgJsonPath = require.resolve(
 		'liferay-npm-bundler/package.json'
 	);
+
 	const bundlerDir = path.dirname(bundlerPkgJsonPath);
 
 	/* eslint-disable-next-line */

--- a/projects/js-toolkit/packages/portal-base/src/deploy.ts
+++ b/projects/js-toolkit/packages/portal-base/src/deploy.ts
@@ -15,6 +15,7 @@ const {fail, print, question, success} = format;
 
 const outputDir = new FilePath(project.jar.outputDir.asNative);
 const outputFilename = project.jar.outputFilename;
+
 const outputFile = outputDir.join(outputFilename);
 
 export default async function deploy(): Promise<void> {

--- a/projects/js-toolkit/packages/portal-base/src/util/sassImporter.ts
+++ b/projects/js-toolkit/packages/portal-base/src/util/sassImporter.ts
@@ -54,6 +54,7 @@ function sassResolve(module: string): string {
 
 			/* eslint-disable-next-line */
 			const packageJson = require(resolvedPath);
+
 			const entryPoint = packageJson.style || packageJson.main;
 
 			return resolve(module + '/' + entryPoint, {basedir: '.'});

--- a/projects/js-toolkit/resources/devtools/find-generator/find-generator.js
+++ b/projects/js-toolkit/resources/devtools/find-generator/find-generator.js
@@ -12,6 +12,7 @@ const path = require('path');
 const yeoman = require('yeoman-environment');
 
 const env = yeoman.createEnv();
+
 const paths = env.getNpmPaths();
 
 paths.forEach((candidate) => {

--- a/projects/js-toolkit/resources/devtools/link-js-toolkit/link-dependencies.js
+++ b/projects/js-toolkit/resources/devtools/link-js-toolkit/link-dependencies.js
@@ -17,6 +17,7 @@ function linkDependencies(extraDependencies = []) {
 	// Read package.json
 
 	const pkgJson = readJsonSync(path.join('.', 'package.json'));
+
 	pkgJson.dependencies = pkgJson.dependencies || {};
 	pkgJson.devDependencies = pkgJson.devDependencies || {};
 

--- a/projects/js-toolkit/scripts/qa/resources.js
+++ b/projects/js-toolkit/scripts/qa/resources.js
@@ -38,6 +38,7 @@ function findLiferayDir() {
 		const json = JSON.parse(
 			fs.readFileSync(path.join(os.homedir(), '.liferay.json'))
 		);
+
 		liferayDir = json.deploy.path;
 	}
 	catch (error) {

--- a/projects/npm-tools/packages/changelog-generator/src/index.js
+++ b/projects/npm-tools/packages/changelog-generator/src/index.js
@@ -135,7 +135,9 @@ async function getChanges(from, to) {
 
 			if (info) {
 				const [subject, description] = message.split(/\n+/);
+
 				const metadata = subject.match(/Merge pull request #(\d+)/);
+
 				const number = metadata ? metadata[1] : NaN;
 
 				if (description) {
@@ -191,12 +193,14 @@ async function getRemote(options) {
 	}
 
 	const remotes = await git('remote', '-v');
+
 	const lines = remotes.split('\n');
 
 	for (let i = 0; i < lines.length; i++) {
 		const match = lines[i].match(
 			/\bgithub\.com[/:]liferay\/(\S+?)(?:\.git)?\s/i
 		);
+
 		if (match) {
 			return `https://github.com/liferay/${match[1]}`;
 		}
@@ -452,6 +456,7 @@ async function go(options) {
 				to: from,
 				version: from,
 			});
+
 			contents += '\n' + chunk;
 
 			from = previousVersion;

--- a/projects/npm-tools/packages/js-publish/src/index.js
+++ b/projects/npm-tools/packages/js-publish/src/index.js
@@ -128,6 +128,7 @@ function confirm(prompt, answer = 'y', matcher = YES_REGEX) {
 
 	const promise = new Promise((resolve) => {
 		const question = answer === 'y' ? `${prompt} [y/n] ` : `${prompt} `;
+
 		readline.question(question, resolve);
 	}).then((result) => {
 		if (answer === 'y') {

--- a/projects/npm-tools/packages/npm-scripts/src/jsp/Lexer.js
+++ b/projects/npm-tools/packages/npm-scripts/src/jsp/Lexer.js
@@ -441,6 +441,7 @@ class Lexer {
 
 					for (let i = 0; i < matchers.length; i++) {
 						const matcher = lookup(matchers[i]);
+
 						const match = matcher.exec(remaining);
 
 						if (match !== null) {

--- a/projects/npm-tools/packages/npm-scripts/src/jsp/getPaddedReplacement.js
+++ b/projects/npm-tools/packages/npm-scripts/src/jsp/getPaddedReplacement.js
@@ -41,6 +41,7 @@ const IDENTIFIER = new RegExp(`${ID_START}[^${ID_END}]+${ID_END}`);
  */
 function getPaddedReplacement(match, template) {
 	const paddingLength = Math.max(match.length - template.length - 2, 0);
+
 	const padding = '_'.repeat(paddingLength);
 
 	return ID_START + template + padding + ID_END;

--- a/projects/npm-tools/packages/npm-scripts/src/jsp/processJSP.js
+++ b/projects/npm-tools/packages/npm-scripts/src/jsp/processJSP.js
@@ -97,6 +97,7 @@ async function processJSP(source, {onFormat, onLint, onMinify}) {
 
 	for (let i = 0; i < transformed.length; i++) {
 		const {closeTag, contents, openTag, range} = transformed[i];
+
 		const {index, length} = range;
 
 		result +=

--- a/projects/npm-tools/packages/npm-scripts/src/jsp/restoreTags.js
+++ b/projects/npm-tools/packages/npm-scripts/src/jsp/restoreTags.js
@@ -57,6 +57,7 @@ function restoreTags(source, tags) {
 
 	for (let i = 0; i < tokens.length; i++) {
 		const token = tokens[i];
+
 		const {contents, name} = token;
 
 		switch (name) {
@@ -125,6 +126,7 @@ function restoreTags(source, tags) {
 
 	for (let i = 0; i < tokens.length; i++) {
 		const token = tokens[i];
+
 		const {contents, name} = token;
 
 		switch (name) {
@@ -218,6 +220,7 @@ function appendScriptlet(scriptlet, token, output) {
 		// invalidated by previous edits.
 
 		const whitespace = tokens[-1].contents;
+
 		output = output.slice(0, -whitespace.length);
 
 		// Add newline to force blank line, then re-add trimmed whitespace.
@@ -315,6 +318,7 @@ function getIndentedTag(tag, token) {
 		// Look at last line to figure out original indent.
 
 		const last = lines.pop();
+
 		const {0: original} = last.match(new RegExp(`^${TAB_CHAR}*`));
 
 		// Restore original indent to first line, then dedent the whole tag.

--- a/projects/npm-tools/packages/npm-scripts/src/prettier/rules/newline-before-block-statements.js
+++ b/projects/npm-tools/packages/npm-scripts/src/prettier/rules/newline-before-block-statements.js
@@ -15,6 +15,7 @@ module.exports = {
 			// We only fix if on same line.
 
 			let last = source.getLastToken(node);
+
 			const keyword = source.getTokenAfter(last);
 
 			if (last.loc.end.line === keyword.loc.start.line) {

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/format.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/format.js
@@ -101,6 +101,7 @@ async function format(options = {}) {
 					}
 					else {
 						const formatted = await format(source, prettierOptions);
+
 						fs.writeFileSync(filepath, formatted || '');
 						fixed++;
 					}

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/test.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/test.js
@@ -106,6 +106,7 @@ function removeBabelConfig() {
 
 	if (fs.existsSync('package.json')) {
 		const configFile = fs.readFileSync('package.json', 'utf8');
+
 		const config = JSON.parse(configFile);
 
 		if (config && config[PREFIX_BACKUP + 'babel']) {

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/theme.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/theme.js
@@ -60,11 +60,13 @@ function checkExistingBuildArgs(args) {
  */
 function prepareAdditionalBuildArgs() {
 	const modules = findModulesDirectory();
+
 	if (!modules) {
 		throw new Error('Unable to find "modules" directory');
 	}
 
 	const themes = path.join(modules, 'apps/frontend-theme');
+
 	if (!fs.existsSync(themes)) {
 		throw new Error('Unable to find "frontend-theme" directory');
 	}
@@ -72,6 +74,7 @@ function prepareAdditionalBuildArgs() {
 	const args = [];
 	Object.keys(BUILD_ARGS).forEach((key) => {
 		const value = BUILD_ARGS[key];
+
 		args.push(key, value.replace(MODULES_DIR, modules));
 	});
 
@@ -83,6 +86,7 @@ function prepareAdditionalBuildArgs() {
  */
 function run(...subcommandAndArgs) {
 	const [subcommand, ...args] = subcommandAndArgs;
+
 	switch (subcommand) {
 		case 'build':
 			checkExistingBuildArgs(args);

--- a/projects/npm-tools/packages/npm-scripts/src/utils/createTempFile.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/createTempFile.js
@@ -25,6 +25,7 @@ const getMergedConfig = require('./getMergedConfig');
  */
 function createTempFile(filename, content, {autoDelete = true} = {}) {
 	const build = getMergedConfig('npmscripts', 'build');
+
 	const tempDirPath = path.join(build.temp, 'tmp');
 
 	fs.ensureDirSync(tempDirPath);

--- a/projects/npm-tools/packages/npm-scripts/src/utils/deepMerge.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/deepMerge.js
@@ -6,6 +6,7 @@
 const merge = require('deepmerge');
 
 const emptyTarget = (value) => (Array.isArray(value) ? [] : {});
+
 const clone = (value, options) => merge(emptyTarget(value), value, options);
 
 /**
@@ -19,6 +20,7 @@ function combineMerge(target, source, options) {
 			const cloneRequested = options.clone !== false;
 			const shouldClone =
 				cloneRequested && options.isMergeableObject(item);
+
 			destination[i] = shouldClone ? clone(item, options) : item;
 		}
 		else if (options.isMergeableObject(item)) {
@@ -90,8 +92,10 @@ function checkBabelName(name, kind) {
 	Object.entries(NORMALIZERS[kind]).reduce((done, [pattern, replacement]) => {
 		if (!done) {
 			const regExp = new RegExp(pattern);
+
 			if (regExp.test(name)) {
 				const normalized = name.replace(regExp, replacement);
+
 				if (normalized !== name) {
 					throw new Error(
 						`checkBabelName(): expected "${normalized}", got "${name}"`

--- a/projects/npm-tools/packages/npm-scripts/src/utils/expandGlobs.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/expandGlobs.js
@@ -128,6 +128,7 @@ function expandGlobs(matchGlobs, ignoreGlobs = [], options = {}) {
 		currentDepth++;
 
 		const entries = fs.readdirSync(directory);
+
 		entries.forEach((entry) => {
 			const file = path.posix.join(directory, entry);
 			const testedFilePath = path.isAbsolute(baseDir)

--- a/projects/npm-tools/packages/npm-scripts/src/utils/generateSoyDependencies.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/generateSoyDependencies.js
@@ -14,6 +14,7 @@ const resolve = require('resolve');
  */
 function generateSoyDependencies(dependencies) {
 	const cwd = process.cwd();
+
 	const projectName = path.basename(cwd);
 
 	const stringDependencies = dependencies

--- a/projects/npm-tools/packages/npm-scripts/src/utils/getRegExpForGlob.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/getRegExpForGlob.js
@@ -97,6 +97,7 @@ function getRegExpForGlob(glob) {
 	}
 
 	const result = new RegExp(`^${pattern}$`);
+
 	result.glob = glob;
 
 	if (negated) {

--- a/projects/npm-tools/packages/npm-scripts/src/utils/instrument.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/instrument.js
@@ -109,6 +109,7 @@ function instrument(callbacks) {
 			for (const [label, timestamps] of Object.entries(metrics)) {
 				for (const {end, start} of timestamps) {
 					const delta = end - start;
+
 					events.push({delta, end, label, start});
 				}
 			}

--- a/projects/npm-tools/packages/npm-scripts/src/utils/parseBnd.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/parseBnd.js
@@ -36,6 +36,7 @@ function parseBnd(filePath = 'bnd.bnd') {
 		}
 
 		const i = line.indexOf(':');
+
 		const key = line.substring(0, i);
 		const value = line.substring(i + 1).trimLeft();
 

--- a/projects/npm-tools/packages/npm-scripts/src/utils/preprocessGlob.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/preprocessGlob.js
@@ -44,6 +44,7 @@ function preprocessGlob(glob) {
 			}
 
 			const index = substitutions.length - 1;
+
 			if (substitutions[index] === '') {
 
 				// There were no substitutions at all; braces are literal.
@@ -61,6 +62,7 @@ function preprocessGlob(glob) {
 			// We are capturing normal text.
 
 			const index = template.length - 1;
+
 			template[index] = template[index] + char;
 		}
 		else {
@@ -68,6 +70,7 @@ function preprocessGlob(glob) {
 			// We are capturing substitution(s).
 
 			const index = substitutions.length - 1;
+
 			substitutions[index] += char;
 		}
 	}

--- a/projects/npm-tools/packages/npm-scripts/src/utils/soy.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/soy.js
@@ -14,6 +14,7 @@ const runBabel = require('./runBabel');
 const spawnSync = require('./spawnSync');
 
 const BUILD_CONFIG = getMergedConfig('npmscripts', 'build');
+
 const SOY_TEMP_DIR = path.join(BUILD_CONFIG.temp, 'soy');
 
 /**

--- a/projects/npm-tools/packages/npm-scripts/src/utils/spawnMultiple.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/spawnMultiple.js
@@ -35,6 +35,7 @@ async function spawnMultiple(...callbacks) {
 
 	if (failedCount) {
 		const jobCount = callbacks.length;
+
 		const jobs = jobCount === 1 ? 'job' : 'jobs';
 
 		throw new SpawnError(`${failedCount} of ${jobCount} ${jobs} failed`);

--- a/projects/npm-tools/packages/npm-scripts/src/utils/spawnSync.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/spawnSync.js
@@ -31,6 +31,7 @@ function spawnSync(command, args = [], options = {}) {
 		'../../node_modules/.bin',
 		command
 	);
+
 	const executable = fs.existsSync(localCommand) ? localCommand : command;
 
 	const {error, signal, status} = spawn.sync(executable, args, {

--- a/projects/npm-tools/packages/npm-scripts/src/webpack/createWebpackSoyResolver.js
+++ b/projects/npm-tools/packages/npm-scripts/src/webpack/createWebpackSoyResolver.js
@@ -26,6 +26,7 @@ module.exports = () => ({apply});
 
 function apply(resolver) {
 	const config = getMergedConfig('npmscripts');
+
 	const soyDir = path.join(config.build.temp, 'soy');
 
 	resolver.hooks.describedResolve.tapAsync(

--- a/projects/npm-tools/packages/npm-scripts/support/dedent.js
+++ b/projects/npm-tools/packages/npm-scripts/support/dedent.js
@@ -10,6 +10,7 @@
  */
 function dedent(tabs) {
 	const indent = '\t'.repeat(tabs);
+
 	const regExp = new RegExp(`^${indent}`, 'gm');
 
 	return (strings, ...interpolations) => {

--- a/projects/npm-tools/packages/npm-scripts/test/jsp/Lexer.js
+++ b/projects/npm-tools/packages/npm-scripts/test/jsp/Lexer.js
@@ -188,6 +188,7 @@ describe('Lexer()', () => {
 				const ORIGINAL = match('foo')
 					.name('ORIGINAL')
 					.onMatch(() => calls.push('ORIGINAL'));
+
 				const COPY = an(ORIGINAL)
 					.name('COPY')
 					.onMatch(() => calls.push('COPY'));

--- a/projects/npm-tools/packages/npm-scripts/test/scripts/theme.js
+++ b/projects/npm-tools/packages/npm-scripts/test/scripts/theme.js
@@ -16,7 +16,9 @@ jest.mock('../../src/utils/spawnSync');
 const {normalize} = path;
 
 const FIXTURES = getFixturePath('scripts', 'theme');
+
 const MODULES = path.join(FIXTURES, 'modules');
+
 const APPS = path.join(MODULES, 'apps');
 const NODE_MODULES = path.join(MODULES, 'node_modules');
 const FJORD = path.join(APPS, 'frontend-theme-fjord', 'frontend-theme-fjord');

--- a/projects/npm-tools/packages/npm-scripts/test/typescript/configureTypeScript.js
+++ b/projects/npm-tools/packages/npm-scripts/test/typescript/configureTypeScript.js
@@ -11,6 +11,7 @@ const configureTypeScript = require('../../src/typescript/configureTypeScript');
 const expandGlobs = require('../../src/utils/expandGlobs');
 
 const FIXTURES = path.join(__dirname, '..', '..', '__fixtures__', 'typescript');
+
 const MODULES = path.join(FIXTURES, 'modules');
 
 const EXPECT_HASH = expect.stringMatching(/^[0-9a-f]{40}$/);

--- a/projects/npm-tools/packages/npm-scripts/test/utils/expandGlobs.js
+++ b/projects/npm-tools/packages/npm-scripts/test/utils/expandGlobs.js
@@ -88,6 +88,7 @@ describe('expandGlobs()', () => {
 		cwd = process.cwd();
 
 		const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'scripts-'));
+
 		process.chdir(directory);
 
 		FIXTURES.forEach((fixture) => {

--- a/projects/npm-tools/packages/npm-scripts/test/utils/findRoot.js
+++ b/projects/npm-tools/packages/npm-scripts/test/utils/findRoot.js
@@ -10,7 +10,9 @@ const findRoot = require('../../src/utils/findRoot');
 const getFixturePath = require('../../support/getFixturePath');
 
 const FIXTURES = getFixturePath('utils', 'findRoot');
+
 const MODULES = path.join(FIXTURES, 'modules');
+
 const PUBLIC_PROJECT = path.join(MODULES, 'apps', 'some', 'project');
 const PRIVATE_PROJECT = path.join(
 	MODULES,

--- a/support/packages/local-npm/lib/index.js
+++ b/support/packages/local-npm/lib/index.js
@@ -90,6 +90,7 @@ function publish(projects) {
 
 	projects.forEach((dir) => {
 		const {name, version} = require(`${dir}/package.json`);
+
 		const pkgId = `${name}@${version}`;
 
 		console.log(`       ${pkgId}`);
@@ -102,6 +103,7 @@ function publish(projects) {
 
 	projects.forEach((dir) => {
 		const {name, version} = require(`${dir}/package.json`);
+
 		const pkgId = `${name}@${version}`;
 
 		console.log(`       ${pkgId}`);

--- a/target-platforms/packages/create-platform/bin/create-platform.js
+++ b/target-platforms/packages/create-platform/bin/create-platform.js
@@ -85,6 +85,7 @@ const dependencies = Object.entries(config.build.bundler.config.imports).reduce(
 						paths: [providerDir],
 					}
 				);
+
 				const packageJson = require(packageJsonPath);
 
 				dependencies[packageName] = packageJson.version;

--- a/target-platforms/scripts/qa.js
+++ b/target-platforms/scripts/qa.js
@@ -112,6 +112,7 @@ function runQAFor(projectName) {
 	run(projectName, 'yarn', 'build');
 
 	const projectDir = path.resolve(__dirname, '..', 'qa', projectName);
+
 	const actualBuildDir = path.join(projectDir, 'build');
 	const expectedBuildDir = path.join(projectDir, 'build.expected');
 


### PR DESCRIPTION
This is an exploration of the rule requested in https://github.com/liferay/liferay-frontend-projects/issues/15

I've implemented a rudimentary rule here to explore a couple angles while doing so and landed on this current one.

I believe it should be easy to add an autofix to this rule, simply inserting an empty line in between the lines that trigger the error.

LMK if I'm on the right track