### PR TITLE
fix(dev-server): check if cwd is already at portal root

### DIFF
--- a/projects/js-toolkit/packages/dev-server/src/server.ts
+++ b/projects/js-toolkit/packages/dev-server/src/server.ts
@@ -41,6 +41,13 @@ function isHTMLResponse(response: http.IncomingMessage): boolean {
 }
 
 function findPortalRoot(directory: string): string {
+	if (
+		basename(directory) === 'liferay-portal' &&
+		existsSync(join(directory, 'modules'))
+	) {
+		return directory;
+	}
+
 	while (directory) {
 		if (existsSync(join(directory, 'yarn.lock'))) {
 			const base = basename(directory);


### PR DESCRIPTION
fixes https://github.com/liferay/liferay-frontend-projects/issues/729

We walk up directories until we find `modules`, but we never actually account for being at the root itself.