### PR TITLE
feat(npm-scripts): add preflight check for yarn.lock validity

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/scripts/check/preflight.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/check/preflight.js
@@ -8,6 +8,7 @@ const {SpawnError} = require('../../utils/spawnSync');
 const checkConfigFileNames = require('./preflight/checkConfigFileNames');
 const checkPackageJSONFiles = require('./preflight/checkPackageJSONFiles');
 const checkTypeScriptTypeArtifacts = require('./preflight/checkTypeScriptTypeArtifacts');
+const checkYarnLock = require('./preflight/checkYarnLock');
 
 /**
  * Runs the "preflight" checks (basically everything that is not already covered
@@ -18,6 +19,7 @@ async function preflight() {
 		...checkConfigFileNames(),
 		...checkPackageJSONFiles(),
 		...(await checkTypeScriptTypeArtifacts()),
+		...checkYarnLock(),
 	];
 
 	if (errors.length) {

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/check/preflight/checkYarnLock.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/check/preflight/checkYarnLock.js
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const {readFileSync} = require('fs');
+const path = require('path');
+
+const findRoot = require('../../../utils/findRoot');
+
+const LOCAL_REGISTRY_REGEX = /^\s+resolved\s".*(localhost|127.0.0.1).*$/gm;
+
+function checkYarnLock() {
+	const yarnLock = path.join(findRoot(), 'yarn.lock');
+
+	if (!yarnLock) {
+		return [];
+	}
+
+	const yarnLockContent = readFileSync(yarnLock, 'utf8');
+
+	return LOCAL_REGISTRY_REGEX.test(yarnLockContent)
+		? ['Error: `yarn.lock` contains references to local npm registry.']
+		: [];
+}
+
+module.exports = checkYarnLock;


### PR DESCRIPTION
fixes #743

This adds a check to make sure there is no reference to localhost or 127.0.0.1 in our yarn.lock