### PR TITLE
fix(liferay-font-awesome): only pack specific files for npm

### DIFF
--- a/third-party/projects/alloy-font-awesome/.yarnrc
+++ b/third-party/projects/alloy-font-awesome/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "liferay-font-awesome/v"
+version-git-message "chore: prepare liferay-font-awesome v%s release"

--- a/third-party/projects/alloy-font-awesome/package.json
+++ b/third-party/projects/alloy-font-awesome/package.json
@@ -21,6 +21,14 @@
     "type": "git",
     "url": "https://github.com/liferay/liferay-frontend-projects.git"
   },
+  "files": [
+    "font",
+    "css",
+    "less",
+    "scss",
+    "svg",
+    "fontawesome-alloy.json"
+  ],
   "contributors": [
     {
       "name": "Rob Madole",


### PR DESCRIPTION
fixes #746

I was able to verify that `src` is no longer included via `npm pack`. Meaning if we request this package from the npm registry, it should no longer serve the "src" folder.