### PR TITLE
feat(liferay-cli): add new published target platforms

### DIFF
--- a/projects/js-toolkit/packages/liferay-cli/bin/liferay.js
+++ b/projects/js-toolkit/packages/liferay-cli/bin/liferay.js
@@ -22,6 +22,7 @@ const {argv} = require('yargs')
 	)
 	.command('build', 'Build a project created with @liferay/cli')
 	.command('clean', 'Remove output directories')
+	.command('docs', 'Browse Liferay JavaScript Toolkit documentation')
 	.command(
 		'new <name>',
 		'Create a new project with the given name',

--- a/projects/js-toolkit/packages/liferay-cli/src/dependencies.json
+++ b/projects/js-toolkit/packages/liferay-cli/src/dependencies.json
@@ -43,6 +43,12 @@
 		"devDependencies": {}
 	},
 	"target-liferay": {
-		"platforms": ["portal-7.4-ga1", "portal-agnostic"]
+		"platforms": {
+			"portal-7.4": "Liferay Portal CE 7.4",
+			"portal-7.3": "Liferay Portal CE 7.3",
+			"portal-7.2": "Liferay Portal CE 7.2",
+			"portal-7.1": "Liferay Portal CE 7.1",
+			"portal-agnostic": "Liferay Portal CE (not using platform's APIs)"
+		}
 	}
 }

--- a/projects/js-toolkit/packages/liferay-cli/src/index.ts
+++ b/projects/js-toolkit/packages/liferay-cli/src/index.ts
@@ -9,6 +9,7 @@ import checkForUpdate from 'update-check';
 import adaptProject from './adapt';
 import newProject from './new';
 import runLiferayCli from './runLiferayCli';
+import showDocs from './showDocs';
 
 interface Arguments {
 	$0: string;
@@ -32,6 +33,9 @@ export default async function (argv: Arguments): Promise<void> {
 		case 'clean':
 		case 'deploy':
 			return await runLiferayCli(...process.argv.slice(2));
+
+		case 'docs':
+			return await showDocs();
 
 		case 'new':
 			return await newProject(argv.name, argv.batch, argv.options);

--- a/projects/js-toolkit/packages/liferay-cli/src/index.ts
+++ b/projects/js-toolkit/packages/liferay-cli/src/index.ts
@@ -19,7 +19,7 @@ interface Arguments {
 	options?: string;
 }
 
-const {error: fail, print, warn} = format;
+const {fail, print, warn} = format;
 
 /** Default entry point for the @liferay/cli executable. */
 export default async function (argv: Arguments): Promise<void> {

--- a/projects/js-toolkit/packages/liferay-cli/src/new/index.ts
+++ b/projects/js-toolkit/packages/liferay-cli/src/new/index.ts
@@ -9,7 +9,7 @@ import path from 'path';
 
 import prompt from '../util/prompt';
 
-const {error: fail, info, print, success, text, title} = format;
+const {fail, info, print, success, text, title} = format;
 
 export type OptionValue = FilePath | boolean | number | string;
 

--- a/projects/js-toolkit/packages/liferay-cli/src/new/target-liferay/index.ts
+++ b/projects/js-toolkit/packages/liferay-cli/src/new/target-liferay/index.ts
@@ -53,8 +53,11 @@ const target: Target = {
 
 		options = await prompt(useDefaults, options, [
 			{
-				choices: platforms,
-				default: platforms[0],
+				choices: Object.entries(platforms).map(([value, name]) => ({
+					name,
+					value,
+				})),
+				default: Object.entries(platforms)[0][1],
 				defaultDescription: `Using target platform: {${platforms[0]}`,
 				message: 'Which will be your target platform?',
 				name: 'platform',

--- a/projects/js-toolkit/packages/liferay-cli/src/runLiferayCli.ts
+++ b/projects/js-toolkit/packages/liferay-cli/src/runLiferayCli.ts
@@ -7,7 +7,7 @@ import {format} from '@liferay/js-toolkit-core';
 import child_process from 'child_process';
 import resolve from 'resolve';
 
-const {error: fail, print} = format;
+const {fail, print} = format;
 
 export default async function runLiferayCli(...args: string[]): Promise<void> {
 	const pkgJson = projectRequire('./package.json');

--- a/projects/js-toolkit/packages/liferay-cli/src/showDocs.ts
+++ b/projects/js-toolkit/packages/liferay-cli/src/showDocs.ts
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import {FilePath, format} from '@liferay/js-toolkit-core';
+
+const {info, print, success, text, title} = format;
+
+export default async function showDocs(): Promise<void> {
+	print(
+		'',
+		title`|👋 |Welcome to Liferay JavaScript Toolkit Documentation`,
+		'',
+		text`
+In the future we may add some inline documentation to be browsed right from
+here but, until that happens, we invite you to visit our online documentation
+following the next link:
+
+	{https://github.com/liferay/liferay-frontend-projects/blob/master/projects/js-toolkit/docs/README.md}
+
+	`
+	);
+}


### PR DESCRIPTION
This adds the target platforms I published yesterday to the list of available targets when `liferay new <project>` is run.

Right now I'm showing this menu:

![imagen](https://user-images.githubusercontent.com/3273630/142165696-659cad73-c415-437b-bfd3-b1a58e2e6e55.png)

I would like to find a more descriptive names, but that's all I could think of.

The main idea we need to convey is that by using a target platform for a specific version you get access to all our APIs through bundler-imports whereas choosing `portal-agnostic` (the `Liferay Portal CE (not using platform's APIs)` you don't. Sadly, expressing that intuitively, and in one line, seems very difficult to me.
