### PR TITLE
feat(theme-tasks): update theme dependencies to match Liferay 7.4.13

### DIFF
--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/devDependencies.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/devDependencies.js
@@ -76,9 +76,9 @@ module.exports = {
 			default: {
 				'compass-mixins': strict('0.12.10'),
 				'gulp': gulpVersion,
-				'liferay-frontend-css-common': strict('6.0.0'),
-				'liferay-frontend-theme-styled': strict('6.0.2'),
-				'liferay-frontend-theme-unstyled': strict('6.0.2'),
+				'liferay-frontend-css-common': strict('6.0.4'),
+				'liferay-frontend-theme-styled': strict('6.0.10'),
+				'liferay-frontend-theme-unstyled': strict('6.0.12'),
 				'liferay-theme-tasks': themeTasksVersion,
 			},
 			optional: {


### PR DESCRIPTION
I pulled these version numbers from this release of Liferay portal, https://github.com/liferay/liferay-portal/commit/e64d3f8d5f0b61fe497d4728f1f2c878d8e589c1