### PR TITLE
test(js-toolkit): fix QA scripts

### DIFF
--- a/projects/js-toolkit/scripts/qa/util.js
+++ b/projects/js-toolkit/scripts/qa/util.js
@@ -57,14 +57,14 @@ function deploy(projectDirName) {
 	});
 }
 
-function generate(projectDirName, platform, framework) {
+function generate(projectDirName, platform, projectType) {
 	logStep(`GENERATE: ${projectDirName}`);
 
 	zapProjectDir(projectDirName);
 
 	runLiferayCli(qaDir, ['new', projectDirName], {
-		framework,
 		platform,
+		projectType,
 	});
 
 	writeLiferayJsonFile(projectDirName);


### PR DESCRIPTION
They were not passing the project type correctly