### PR TITLE
fix: add check for liferay github owner so that this doesn't run on forked repos

### DIFF
--- a/.github/workflows/new-portal-release.yml
+++ b/.github/workflows/new-portal-release.yml
@@ -9,6 +9,7 @@ on:
 jobs:
     check-for-liferay-release:
         runs-on: ubuntu-latest
+        if: github.repository_owner == 'liferay'
         steps:
             - name: Fetch latest release version
               id: fetch-latest


### PR DESCRIPTION
I think this check should prohibit the workflow from running on forked repos