### PR TITLE
feat(npm-scripts): add path to global type definition file in liferay-portal

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/typescript/configureTypeScript.js
+++ b/projects/npm-tools/packages/npm-scripts/src/typescript/configureTypeScript.js
@@ -97,6 +97,14 @@ function configureTypeScript(graph) {
 
 	const overrides = previousConfig[OVERRIDES] || {};
 
+	const include = [...BASE_CONFIG.include];
+
+	const globalDefinitionFile = path.join(root, 'global.d.ts');
+
+	if (fs.existsSync(globalDefinitionFile)) {
+		include.push(toPosix(path.relative('', globalDefinitionFile)));
+	}
+
 	const updatedConfig = deepMerge([
 		{
 			...BASE_CONFIG,
@@ -118,6 +126,7 @@ function configureTypeScript(graph) {
 					'./node_modules/@types',
 				].filter(Boolean),
 			},
+			include,
 			references: [...BASE_CONFIG.references, ...references],
 		},
 		overrides,


### PR DESCRIPTION
This adds support to our tsconfig so that they auto-generate and reference the global.d.ts file which we will be adding in https://issues.liferay.com/browse/LPS-131257