### PR TITLE
chore(github-to-jira-synchronization): Better error handling and retry mechanism

### DIFF
--- a/support/packages/github-to-jira-synchronization-tool/mapping-config.json
+++ b/support/packages/github-to-jira-synchronization-tool/mapping-config.json
@@ -1,10 +1,10 @@
 {
 	"labelMappings": {
 		"default": "Task",
-		"type:bug": "Bug",
-		"type:chore": "Task",
-		"type:enhancement": "Story",
-		"type:regression": "Bug"
+		"bug": "Bug",
+		"chore": "Task",
+		"enhancement": "Story",
+		"regression": "Bug"
 	},
 	"userMappings": {
 		"brunofernandezg": "bruno.fernandez",

--- a/support/packages/github-to-jira-synchronization-tool/src/config/config.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/config/config.js
@@ -63,7 +63,7 @@ function getLabelMapping(label) {
 
 	const labelMappings = mappingConfig.labelMappings;
 
-	return labelMappings[label?.replace('type:', '')];
+	return labelMappings[label?.replace('type:', '')?.trim()];
 }
 
 function getDefaultLabelMapping() {

--- a/support/packages/github-to-jira-synchronization-tool/src/config/config.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/config/config.js
@@ -34,7 +34,8 @@ function loadConfig() {
 		config = JSON.parse(fs.readFileSync(CONFIGURATION_PATH, 'utf-8'));
 
 		return config;
-	} catch (error) {
+	}
+	catch (error) {
 		if (config) {
 			log('new config file is wrong, reusing past config');
 

--- a/support/packages/github-to-jira-synchronization-tool/src/config/config.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/config/config.js
@@ -37,7 +37,20 @@ function getLabelMapping(label) {
 
 	const labelMappings = mappingConfig.labelMappings;
 
-	return labelMappings[label?.replace('type:', '')] || labelMappings.default;
+	return labelMappings[label?.replace('type:', '')];
 }
 
-module.exports = {getLabelMapping, getUserMapping, loadConfig};
+function getDefaultLabelMapping() {
+	const mappingConfig = loadConfig();
+
+	const labelMappings = mappingConfig.labelMappings;
+
+	return labelMappings.default;
+}
+
+module.exports = {
+	getDefaultLabelMapping,
+	getLabelMapping,
+	getUserMapping,
+	loadConfig,
+};

--- a/support/packages/github-to-jira-synchronization-tool/src/config/config.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/config/config.js
@@ -37,7 +37,7 @@ function getLabelMapping(label) {
 
 	const labelMappings = mappingConfig.labelMappings;
 
-	return labelMappings[label] || labelMappings.default;
+	return labelMappings[label?.replace('type:', '')] || labelMappings.default;
 }
 
 module.exports = {getLabelMapping, getUserMapping, loadConfig};

--- a/support/packages/github-to-jira-synchronization-tool/src/config/config.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/config/config.js
@@ -3,21 +3,46 @@
  * SPDX-License-Identifier: MIT
  */
 
+const fs = require('fs');
+const path = require('path');
+
+const log = require('../utils/log');
+
 let config = null;
+let lastModifiedTime = 0;
+
+const CONFIGURATION_PATH = path.resolve(__dirname, '../../mapping-config.json');
+
+function fileHasChanged() {
+	const stat = fs.statSync(CONFIGURATION_PATH);
+
+	if (stat.mtime > lastModifiedTime) {
+		lastModifiedTime = stat.mtime;
+
+		return true;
+	}
+
+	return false;
+}
 
 function loadConfig() {
-	if (config) {
+	if (!fileHasChanged() && config) {
 		return config;
 	}
 
 	try {
-		config = require('../../mapping-config.json');
+		config = JSON.parse(fs.readFileSync(CONFIGURATION_PATH, 'utf-8'));
 
 		return config;
-	}
-	catch (error) {
+	} catch (error) {
+		if (config) {
+			log('new config file is wrong, reusing past config');
+
+			return;
+		}
+
 		console.error(
-			'mapped-config.json cannot be read, please make sure to create it in the root of the project'
+			'mapped-config.json cannot be read, please make sure it is a valid json and to create it in the root of the project'
 		);
 
 		process.exit(1);

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueAssignedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueAssignedHandler.js
@@ -32,7 +32,8 @@ module.exports = {
 				assignee: getUserMapping(assignee.login),
 				issueId: jiraIssue.key,
 			});
-		} catch (_error) {
+		}
+		catch (_error) {
 			log(`Cannot assign issue to${getUserMapping(assignee.login)}`);
 		}
 

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueAssignedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueAssignedHandler.js
@@ -11,10 +11,7 @@ const log = require('../utils/log');
 
 module.exports = {
 	canHandleEvent(name, payload) {
-		return (
-			name === 'issues' &&
-			(payload.action === 'assigned' || payload.action === 'unassigned')
-		);
+		return name === 'issues' && payload.action === 'assigned';
 	},
 
 	async handleEvent({issue}) {
@@ -39,15 +36,15 @@ module.exports = {
 			log(`Cannot assign issue to${getUserMapping(assignee.login)}`);
 		}
 
-		const jiraStatusNames = jiraIssue.fields.status.name;
+		const jiraStatusName = jiraIssue.fields.status.name;
 
 		log(`Transitioning issue ${jiraIssue.key} to in-progress`);
 
-		if (jiraStatusNames === JIRA_STATUS.inProgress) {
+		if (jiraStatusName === JIRA_STATUS.inProgress) {
 			return;
 		}
 
-		if (jiraStatusNames === JIRA_STATUS.closed) {
+		if (jiraStatusName === JIRA_STATUS.closed) {
 			await jiraClient.transitionIssue({
 				issueId: jiraIssue.key,
 				transition: JIRA_TRANSITIONS.reopen,

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueAssignedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueAssignedHandler.js
@@ -6,6 +6,7 @@
 const {getUserMapping} = require('../config/config');
 const JiraClient = require('../jira/JiraClient');
 const {JIRA_STATUS, JIRA_TRANSITIONS} = require('../jira/jiraTransitions');
+const log = require('../utils/log');
 
 module.exports = {
 	canHandleEvent(name, payload) {
@@ -25,12 +26,20 @@ module.exports = {
 
 		const [assignee = {}] = issue.assignees;
 
+		log(
+			`Assigning issue ${jiraClient.key} to ${getUserMapping(
+				assignee.login
+			)}`
+		);
+
 		await jiraClient.updateIssue({
 			assignee: getUserMapping(assignee.login),
 			issueId: jiraIssue.key,
 		});
 
 		const jiraStatusNames = jiraIssue.fields.status.name;
+
+		log(`Transitioning issue ${jiraClient.key} to in-progress`);
 
 		if (assignee.login && jiraStatusNames !== JIRA_STATUS.inProgress) {
 			return jiraClient.transitionIssue({

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueClosedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueClosedHandler.js
@@ -5,6 +5,7 @@
 
 const JiraClient = require('../jira/JiraClient');
 const {JIRA_STATUS, JIRA_TRANSITIONS} = require('../jira/jiraTransitions');
+const getOrCreateIssue = require('../utils/getOrCreateIssue');
 const log = require('../utils/log');
 
 module.exports = {
@@ -15,10 +16,7 @@ module.exports = {
 	async handleEvent({issue}) {
 		const jiraClient = new JiraClient();
 
-		const jiraIssue = await jiraClient.searchIssueWithGithubIssueId({
-			fields: ['status'],
-			githubIssueId: issue.html_url,
-		});
+		const jiraIssue = await getOrCreateIssue(issue);
 
 		const jiraStatusNames = jiraIssue.fields.status.name;
 

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueClosedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueClosedHandler.js
@@ -5,6 +5,7 @@
 
 const JiraClient = require('../jira/JiraClient');
 const {JIRA_STATUS, JIRA_TRANSITIONS} = require('../jira/jiraTransitions');
+const log = require('../utils/log');
 
 module.exports = {
 	canHandleEvent(name, payload) {
@@ -20,6 +21,8 @@ module.exports = {
 		});
 
 		const jiraStatusNames = jiraIssue.fields.status.name;
+
+		log(`Transitioning issue ${jiraIssue.key} to close`);
 
 		if (jiraStatusNames !== JIRA_STATUS.closed) {
 			return await jiraClient.transitionIssue({

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueCommentCreatedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueCommentCreatedHandler.js
@@ -5,6 +5,7 @@
 
 const JiraClient = require('../jira/JiraClient');
 const {addGithubIssueToBody} = require('../jira/github-jira-mapping');
+const getOrCreateIssue = require('../utils/getOrCreateIssue');
 const log = require('../utils/log');
 
 module.exports = {
@@ -15,9 +16,7 @@ module.exports = {
 	async handleEvent({comment, issue}) {
 		const jiraClient = new JiraClient();
 
-		const jiraIssue = await jiraClient.searchIssueWithGithubIssueId({
-			githubIssueId: issue.html_url,
-		});
+		const jiraIssue = await getOrCreateIssue(issue);
 
 		const commentBody = `
 		 ${issue?.user?.login} commented

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueCommentCreatedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueCommentCreatedHandler.js
@@ -18,8 +18,17 @@ module.exports = {
 
 		const jiraIssue = await getOrCreateIssue(issue);
 
+		const jiraComment = await jiraClient.searchCommentWithGithubCommentId({
+			githubCommentId: comment.html_url,
+			issueId: jiraIssue.key,
+		});
+
+		if (jiraComment) {
+			return;
+		}
+
 		const commentBody = `
-		 ${issue?.user?.login} commented
+		 ${comment?.user?.login} commented
 
 		 {quote}
 		 	${comment.body}

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueCommentCreatedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueCommentCreatedHandler.js
@@ -5,6 +5,7 @@
 
 const JiraClient = require('../jira/JiraClient');
 const {addGithubIssueToBody} = require('../jira/github-jira-mapping');
+const log = require('../utils/log');
 
 module.exports = {
 	canHandleEvent(name, payload) {
@@ -25,6 +26,8 @@ module.exports = {
 		 	${comment.body}
 		 {quote}
 		`;
+
+		log(`Creating comment for issue ${jiraIssue.key}`);
 
 		return await jiraClient.createComment({
 			comment: addGithubIssueToBody(comment.html_url, commentBody),

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueCommentDeletedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueCommentDeletedHandler.js
@@ -5,6 +5,7 @@
 
 const JiraClient = require('../jira/JiraClient');
 const {addGithubIssueToBody} = require('../jira/github-jira-mapping');
+const log = require('../utils/log');
 
 module.exports = {
 	canHandleEvent(name, payload) {
@@ -21,6 +22,8 @@ module.exports = {
 			githubCommentId: comment.html_url,
 			githubIssueId: issue.html_url,
 		});
+
+		log(`Deleting comment ${jiraComment.id}`);
 
 		return await jiraClient.deleteComment({
 			comment: addGithubIssueToBody(comment.html_url, comment.body),

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueCommentDeletedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueCommentDeletedHandler.js
@@ -5,6 +5,7 @@
 
 const JiraClient = require('../jira/JiraClient');
 const {addGithubIssueToBody} = require('../jira/github-jira-mapping');
+const getOrCreateComment = require('../utils/getOrCreateComment');
 const log = require('../utils/log');
 
 module.exports = {
@@ -15,12 +16,9 @@ module.exports = {
 	async handleEvent({comment, issue}) {
 		const jiraClient = new JiraClient();
 
-		const {
-			comment: jiraComment,
-			issueId,
-		} = await jiraClient.searchCommentWithGithubCommentId({
-			githubCommentId: comment.html_url,
-			githubIssueId: issue.html_url,
+		const {comment: jiraComment, issueId} = await getOrCreateComment({
+			comment,
+			issue,
 		});
 
 		log(`Deleting comment ${jiraComment.id}`);

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueCommentEditedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueCommentEditedHandler.js
@@ -5,6 +5,7 @@
 
 const JiraClient = require('../jira/JiraClient');
 const {addGithubIssueToBody} = require('../jira/github-jira-mapping');
+const log = require('../utils/log');
 
 module.exports = {
 	canHandleEvent(name, payload) {
@@ -21,6 +22,8 @@ module.exports = {
 			githubCommentId: comment.html_url,
 			githubIssueId: issue.html_url,
 		});
+
+		log(`Editing comment ${jiraComment.id}`);
 
 		return await jiraClient.updateComment({
 			comment: addGithubIssueToBody(comment.html_url, comment.body),

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueCommentEditedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueCommentEditedHandler.js
@@ -5,6 +5,7 @@
 
 const JiraClient = require('../jira/JiraClient');
 const {addGithubIssueToBody} = require('../jira/github-jira-mapping');
+const getOrCreateComment = require('../utils/getOrCreateComment');
 const log = require('../utils/log');
 
 module.exports = {
@@ -15,18 +16,23 @@ module.exports = {
 	async handleEvent({comment, issue}) {
 		const jiraClient = new JiraClient();
 
-		const {
-			comment: jiraComment,
-			issueId,
-		} = await jiraClient.searchCommentWithGithubCommentId({
-			githubCommentId: comment.html_url,
-			githubIssueId: issue.html_url,
+		const {comment: jiraComment, issueId} = await getOrCreateComment({
+			comment,
+			issue,
 		});
+
+		const commentBody = `
+		 ${comment?.user?.login} commented
+
+		 {quote}
+		 	${comment.body}
+		 {quote}
+		`;
 
 		log(`Editing comment ${jiraComment.id}`);
 
 		return await jiraClient.updateComment({
-			comment: addGithubIssueToBody(comment.html_url, comment.body),
+			comment: addGithubIssueToBody(comment.html_url, commentBody),
 			commentId: jiraComment.id,
 			issueId,
 		});

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueCreatedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueCreatedHandler.js
@@ -11,10 +11,20 @@ module.exports = {
 		return name === 'issues' && payload.action === 'opened';
 	},
 
-	handleEvent({issue}) {
+	async handleEvent({issue}) {
 		const jiraClient = new JiraClient();
 
 		log(`Creating jira issue for github issue ${issue.html_url}`);
+
+		const jiraIssue = await jiraClient.searchIssueWithGithubIssueId({
+			githubIssueId: issue.html_url,
+		});
+
+		if (jiraIssue) {
+			log(`Jira issue already created ${jiraIssue.key}`);
+
+			return;
+		}
 
 		return jiraClient.createIssue({
 			description: issue.body,

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueCreatedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueCreatedHandler.js
@@ -4,6 +4,7 @@
  */
 
 const JiraClient = require('../jira/JiraClient');
+const log = require('../utils/log');
 
 module.exports = {
 	canHandleEvent(name, payload) {
@@ -12,6 +13,8 @@ module.exports = {
 
 	handleEvent({issue}) {
 		const jiraClient = new JiraClient();
+
+		log(`Creating jira issue for github issue ${issue.html_url}`);
 
 		return jiraClient.createIssue({
 			description: issue.body,

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueEditedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueEditedHandler.js
@@ -4,7 +4,7 @@
  */
 
 const JiraClient = require('../jira/JiraClient');
-const {addGithubIssueToBody} = require('../jira/github-jira-mapping');
+const getOrCreateIssue = require('../utils/getOrCreateIssue');
 const log = require('../utils/log');
 
 module.exports = {
@@ -15,14 +15,12 @@ module.exports = {
 	async handleEvent({issue}) {
 		const jiraClient = new JiraClient();
 
-		const jiraIssue = await jiraClient.searchIssueWithGithubIssueId({
-			githubIssueId: issue.html_url,
-		});
+		const jiraIssue = await getOrCreateIssue(issue);
 
 		log(`Updating jira issue ${jiraIssue.key}`);
 
 		const options = {
-			description: addGithubIssueToBody(issue.html_url, issue.body),
+			description: issue.body || '',
 			title: issue.title,
 		};
 

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueEditedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueEditedHandler.js
@@ -5,6 +5,7 @@
 
 const JiraClient = require('../jira/JiraClient');
 const {addGithubIssueToBody} = require('../jira/github-jira-mapping');
+const log = require('../utils/log');
 
 module.exports = {
 	canHandleEvent(name, payload) {
@@ -17,6 +18,8 @@ module.exports = {
 		const jiraIssue = await jiraClient.searchIssueWithGithubIssueId({
 			githubIssueId: issue.html_url,
 		});
+
+		log(`Updating jira issue ${jiraIssue.key}`);
 
 		const options = {
 			description: addGithubIssueToBody(issue.html_url, issue.body),

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueLabeledHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueLabeledHandler.js
@@ -5,6 +5,7 @@
 
 const {getLabelMapping} = require('../config/config');
 const JiraClient = require('../jira/JiraClient');
+const log = require('../utils/log');
 
 module.exports = {
 	canHandleEvent(name, payload) {
@@ -24,6 +25,9 @@ module.exports = {
 		const [firstLabel = {}] = issue.labels;
 
 		const type = getLabelMapping(firstLabel.name);
+
+		log(`Label ${firstLabel.name} added`);
+		log(`Updating jira issue ${jiraIssue.key} to type ${type}`);
 
 		return jiraClient.updateIssue({issueId: jiraIssue.key, type});
 	},

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueLabeledHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueLabeledHandler.js
@@ -5,6 +5,7 @@
 
 const {getDefaultLabelMapping, getLabelMapping} = require('../config/config');
 const JiraClient = require('../jira/JiraClient');
+const getOrCreateIssue = require('../utils/getOrCreateIssue');
 const log = require('../utils/log');
 
 module.exports = {
@@ -18,9 +19,7 @@ module.exports = {
 	async handleEvent({issue}) {
 		const jiraClient = new JiraClient();
 
-		const jiraIssue = await jiraClient.searchIssueWithGithubIssueId({
-			githubIssueId: issue.html_url,
-		});
+		const jiraIssue = await getOrCreateIssue(issue);
 
 		let type = getDefaultLabelMapping();
 

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueMilestonedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueMilestonedHandler.js
@@ -6,6 +6,7 @@
 const JiraClient = require('../jira/JiraClient');
 const getJiraMilestoneId = require('../utils/getJiraMilestoneId');
 const isValidMilestone = require('../utils/isValidMilestone');
+const log = require('../utils/log');
 
 module.exports = {
 	canHandleEvent(name, payload) {
@@ -24,6 +25,8 @@ module.exports = {
 		});
 
 		if (action === 'demilestoned') {
+			log(`Removing milestone for issue ${jiraIssue.key}`);
+
 			return jiraClient.updateIssueEpic({
 				epic: null,
 				issueId: jiraIssue.key,
@@ -35,6 +38,8 @@ module.exports = {
 		const jiraMilestoneId = getJiraMilestoneId(milestone.title);
 
 		if (isValidMilestone(jiraMilestoneId, jiraClient)) {
+			log(`Adding milestone for issue ${jiraIssue.key}`);
+
 			return jiraClient.updateIssueEpic({
 				epic: jiraMilestoneId,
 				issueId: jiraIssue.key,

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueMilestonedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueMilestonedHandler.js
@@ -5,6 +5,7 @@
 
 const JiraClient = require('../jira/JiraClient');
 const getJiraMilestoneId = require('../utils/getJiraMilestoneId');
+const getOrCreateIssue = require('../utils/getOrCreateIssue');
 const isValidMilestone = require('../utils/isValidMilestone');
 const log = require('../utils/log');
 
@@ -20,9 +21,7 @@ module.exports = {
 	async handleEvent({action, issue}) {
 		const jiraClient = new JiraClient();
 
-		const jiraIssue = await jiraClient.searchIssueWithGithubIssueId({
-			githubIssueId: issue.html_url,
-		});
+		const jiraIssue = await getOrCreateIssue(issue);
 
 		if (action === 'demilestoned') {
 			log(`Removing milestone for issue ${jiraIssue.key}`);

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueReopenedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueReopenedHandler.js
@@ -5,6 +5,7 @@
 
 const JiraClient = require('../jira/JiraClient');
 const {JIRA_STATUS, JIRA_TRANSITIONS} = require('../jira/jiraTransitions');
+const getOrCreateIssue = require('../utils/getOrCreateIssue');
 const log = require('../utils/log');
 
 module.exports = {
@@ -15,10 +16,7 @@ module.exports = {
 	async handleEvent({issue}) {
 		const jiraClient = new JiraClient();
 
-		const jiraIssue = await jiraClient.searchIssueWithGithubIssueId({
-			fields: ['status'],
-			githubIssueId: issue.html_url,
-		});
+		const jiraIssue = await getOrCreateIssue(issue);
 
 		const jiraStatusNames = jiraIssue.fields.status.name;
 

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueReopenedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueReopenedHandler.js
@@ -5,6 +5,7 @@
 
 const JiraClient = require('../jira/JiraClient');
 const {JIRA_STATUS, JIRA_TRANSITIONS} = require('../jira/jiraTransitions');
+const log = require('../utils/log');
 
 module.exports = {
 	canHandleEvent(name, payload) {
@@ -20,6 +21,8 @@ module.exports = {
 		});
 
 		const jiraStatusNames = jiraIssue.fields.status.name;
+
+		log(`Transition issue ${jiraIssue.key} to open`);
 
 		if (jiraStatusNames !== JIRA_STATUS.open) {
 			return await jiraClient.transitionIssue({

--- a/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueUnassignedHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/event-handlers/issueUnassignedHandler.js
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const JiraClient = require('../jira/JiraClient');
+const {JIRA_STATUS, JIRA_TRANSITIONS} = require('../jira/jiraTransitions');
+const getOrCreateIssue = require('../utils/getOrCreateIssue');
+const log = require('../utils/log');
+
+module.exports = {
+	canHandleEvent(name, payload) {
+		return name === 'issues' && payload.action === 'unassigned';
+	},
+
+	async handleEvent({issue}) {
+		const jiraClient = new JiraClient();
+
+		const jiraIssue = await getOrCreateIssue(issue);
+
+		const jiraStatusName = jiraIssue.fields.status.name;
+
+		log(`Transitioning issue ${jiraIssue.key} to open`);
+
+		if (
+			jiraStatusName === JIRA_STATUS.open ||
+			jiraStatusName === JIRA_STATUS.onHold
+		) {
+			return;
+		}
+
+		return jiraClient.transitionIssue({
+			issueId: jiraIssue.key,
+			transition: JIRA_TRANSITIONS.reopen,
+		});
+	},
+};

--- a/support/packages/github-to-jira-synchronization-tool/src/index.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/index.js
@@ -6,6 +6,7 @@
 const Server = require('./Server');
 const {loadConfig} = require('./config/config');
 const {PORT, SECRET} = require('./constants');
+const log = require('./utils/log');
 
 const eventHandlers = [
 	require('./event-handlers/issueAssignedHandler'),
@@ -28,12 +29,14 @@ async function main() {
 	server.start(['issues', 'issue_comment'], async ({name, payload}) => {
 		for (const eventHandler of eventHandlers) {
 			if (eventHandler.canHandleEvent(name, payload)) {
+				log(
+					`Handling event ${name} ${payload.action} for issue: ${payload.issue?.html_url}`
+				);
 				try {
 					await eventHandler.handleEvent(payload);
-				}
-				catch (error) {
-					console.error(
-						`Error while processing ${name} ${payload.action} webhook\n\n${error.message}`
+				} catch (error) {
+					log(
+						`Error while processing ${name} ${payload.action} webhook: ${error.message}`
 					);
 				}
 			}

--- a/support/packages/github-to-jira-synchronization-tool/src/index.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/index.js
@@ -16,6 +16,7 @@ const eventHandlers = [
 	require('./event-handlers/issueLabeledHandler'),
 	require('./event-handlers/issueMilestonedHandler'),
 	require('./event-handlers/issueReopenedHandler'),
+	require('./event-handlers/issueUnassignedHandler'),
 	require('./event-handlers/issueCommentCreatedHandler'),
 	require('./event-handlers/issueCommentEditedHandler'),
 	require('./event-handlers/issueCommentDeletedHandler'),

--- a/support/packages/github-to-jira-synchronization-tool/src/index.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/index.js
@@ -35,7 +35,8 @@ async function main() {
 				);
 				try {
 					await eventHandler.handleEvent(payload);
-				} catch (error) {
+				}
+				catch (error) {
 					log(
 						`Error while processing ${name} ${payload.action} webhook: ${error.message}`
 					);

--- a/support/packages/github-to-jira-synchronization-tool/src/index.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/index.js
@@ -28,6 +28,13 @@ async function main() {
 	const server = new Server(SECRET, PORT);
 
 	server.start(['issues', 'issue_comment'], async ({name, payload}) => {
+
+		// Don't handle comments in pull requests
+
+		if (name === 'issue_comment' && payload.issue?.pull_request) {
+			return;
+		}
+
 		for (const eventHandler of eventHandlers) {
 			if (eventHandler.canHandleEvent(name, payload)) {
 				log(

--- a/support/packages/github-to-jira-synchronization-tool/src/jira/JiraClient.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/jira/JiraClient.js
@@ -20,32 +20,18 @@ module.exports = class JiraClient {
 		});
 	}
 
-	async searchIssueWithGithubIssueId({fields = [], githubIssueId}) {
+	async searchIssueWithGithubIssueId({githubIssueId}) {
 		const query = `project=${PROJECT} AND "Git Issue URL" = "${githubIssueId}"`;
 
-		const response = await this.client.searchJira(query, {
-			fields,
-		});
+		const response = await this.client.searchJira(query);
 
 		const {issues} = response;
-
-		if (!issues.length) {
-			throw new Error(
-				`Cannot find jira issue with github issue ${githubIssueId}`
-			);
-		}
 
 		return issues[0];
 	}
 
-	async searchCommentWithGithubCommentId({githubCommentId, githubIssueId}) {
-		const issue = await this.searchIssueWithGithubIssueId({githubIssueId});
-
-		if (!issue) {
-			return null;
-		}
-
-		const commentsResponse = await this.client.getComments(issue.key);
+	async searchCommentWithGithubCommentId({githubCommentId, issueId}) {
+		const commentsResponse = await this.client.getComments(issueId);
 
 		const {comments = []} = commentsResponse;
 
@@ -53,16 +39,7 @@ module.exports = class JiraClient {
 			comment.body.includes(getGithubMarking(githubCommentId))
 		);
 
-		if (!comment) {
-			throw new Error(
-				`Cannot find jira comment with github comment id ${githubIssueId}`
-			);
-		}
-
-		return {
-			comment,
-			issueId: issue.key,
-		};
+		return comment;
 	}
 
 	createIssue({

--- a/support/packages/github-to-jira-synchronization-tool/src/jira/JiraClient.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/jira/JiraClient.js
@@ -29,6 +29,12 @@ module.exports = class JiraClient {
 
 		const {issues} = response;
 
+		if (!issues.length) {
+			throw new Error(
+				`Cannot find jira issue with github issue ${githubIssueId}`
+			);
+		}
+
 		return issues[0];
 	}
 
@@ -43,10 +49,18 @@ module.exports = class JiraClient {
 
 		const {comments = []} = commentsResponse;
 
+		const comment = comments.find((comment) =>
+			comment.body.includes(getGithubMarking(githubCommentId))
+		);
+
+		if (!comment) {
+			throw new Error(
+				`Cannot find jira comment with github comment id ${githubIssueId}`
+			);
+		}
+
 		return {
-			comment: comments.find((comment) =>
-				comment.body.includes(getGithubMarking(githubCommentId))
-			),
+			comment,
 			issueId: issue.key,
 		};
 	}

--- a/support/packages/github-to-jira-synchronization-tool/src/jira/JiraRetryHandler.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/jira/JiraRetryHandler.js
@@ -1,0 +1,106 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const isJiraUp = require('../utils/isJiraUp');
+
+module.exports = class JiraRetryHandler {
+	static FILE_PATH = path.resolve(__dirname, '../../pending-retries.json');
+	static RETRY_DELAY = 1 * 60 * 60 * 1000;
+
+	constructor() {
+		this.pendingWebhooks = this._readFile();
+	}
+
+	async addPendingWebhook(name, payload) {
+		this.pendingWebhooks.push({
+			name,
+			payload,
+		});
+
+		await this._writeFile();
+	}
+
+	shouldRetry(error) {
+		if (error.response?.statusCode >= 500) {
+			return true;
+		}
+
+		if (
+			error.cause?.code === 'ESOCKETTIMEDOUT' ||
+			error.cause?.code === 'ECONNREFUSED'
+		) {
+			return true;
+		}
+
+		return false;
+	}
+
+	start(retryPendingHookFn) {
+		const retry = async () => {
+			let pendingWebhooks = this.pendingWebhooks.length;
+
+			if (pendingWebhooks === 0) {
+				return;
+			}
+
+			const jiraUp = await isJiraUp();
+
+			if (!jiraUp) {
+				return;
+			}
+
+			while (pendingWebhooks > 0) {
+				pendingWebhooks--;
+
+				const {name, payload} = await this._getNextPendingWebhook();
+
+				retryPendingHookFn(name, payload);
+			}
+		};
+
+		setInterval(retry, JiraRetryHandler.RETRY_DELAY);
+	}
+
+	async _getNextPendingWebhook() {
+		if (this.pendingWebhooks.length === 0) {
+			return null;
+		}
+
+		const [nextPendingWebhook, ...rest] = this.pendingWebhooks;
+
+		this.pendingWebhooks = rest;
+		await this._writeFile();
+
+		return nextPendingWebhook;
+	}
+
+	_readFile() {
+		if (fs.existsSync(JiraRetryHandler.FILE_PATH)) {
+			try {
+				const content = fs.readFileSync(
+					JiraRetryHandler.FILE_PATH,
+					'utf-8'
+				);
+
+				return JSON.parse(content);
+			}
+			catch (_error) {
+				return [];
+			}
+		}
+
+		return [];
+	}
+
+	_writeFile() {
+		return fs.promises.writeFile(
+			JiraRetryHandler.FILE_PATH,
+			JSON.stringify(this.pendingWebhooks)
+		);
+	}
+};

--- a/support/packages/github-to-jira-synchronization-tool/src/utils/getOrCreateComment.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/utils/getOrCreateComment.js
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const JiraClient = require('../jira/JiraClient');
+const {addGithubIssueToBody} = require('../jira/github-jira-mapping');
+const getOrCreateIssue = require('./getOrCreateIssue');
+
+module.exports = async function getOrCreateComment({comment, issue}) {
+	const jiraClient = new JiraClient();
+
+	const jiraIssue = await getOrCreateIssue(issue);
+
+	const jiraComment = await jiraClient.searchCommentWithGithubCommentId({
+		githubCommentId: comment.html_url,
+		issueId: jiraIssue.key,
+	});
+
+	if (jiraComment) {
+		return {comment: jiraComment, issueId: jiraIssue.key};
+	}
+
+	const commentBody = `
+		 ${comment?.user?.login} commented
+
+		 {quote}
+		 	${comment.body}
+		 {quote}
+		`;
+
+	const newJiraComment = await jiraClient.createComment({
+		comment: addGithubIssueToBody(comment.html_url, commentBody),
+		issueId: jiraIssue.key,
+	});
+
+	return {
+		comment: newJiraComment,
+		issueId: jiraIssue.key,
+	};
+};

--- a/support/packages/github-to-jira-synchronization-tool/src/utils/getOrCreateIssue.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/utils/getOrCreateIssue.js
@@ -16,11 +16,9 @@ module.exports = async function getOrCreateIssue(issue) {
 		return jiraIssue;
 	}
 
-	const a = await jiraClient.createIssue({
+	return jiraClient.createIssue({
 		description: issue.body || '',
 		githubIssueId: issue.html_url,
 		title: issue.title,
 	});
-
-	return a;
 };

--- a/support/packages/github-to-jira-synchronization-tool/src/utils/getOrCreateIssue.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/utils/getOrCreateIssue.js
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const JiraClient = require('../jira/JiraClient');
+
+module.exports = async function getOrCreateIssue(issue) {
+	const jiraClient = new JiraClient();
+
+	const jiraIssue = await jiraClient.searchIssueWithGithubIssueId({
+		githubIssueId: issue.html_url,
+	});
+
+	if (jiraIssue) {
+		return jiraIssue;
+	}
+
+	const a = await jiraClient.createIssue({
+		description: issue.body || '',
+		githubIssueId: issue.html_url,
+		title: issue.title,
+	});
+
+	return a;
+};

--- a/support/packages/github-to-jira-synchronization-tool/src/utils/isJiraUp.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/utils/isJiraUp.js
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const JiraClient = require('../jira/JiraClient');
+
+module.exports = async function isJiraUp() {
+	const jiraClient = new JiraClient();
+
+	try {
+
+		// Checking an arbitrary issue
+
+		await jiraClient.getIssue({issueId: 'IFI-2759'});
+
+		return true;
+	}
+	catch (_error) {
+		return false;
+	}
+};

--- a/support/packages/github-to-jira-synchronization-tool/src/utils/log.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/utils/log.js
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const fs = require('fs');
+
+let logFile;
+
+module.exports = function log(message) {
+	if (!logFile) {
+		logFile = fs.createWriteStream(process.cwd() + '/debug.log', {
+			flags: 'a',
+		});
+	}
+
+	logFile.write(`${message}\n`);
+};

--- a/support/packages/github-to-jira-synchronization-tool/src/utils/log.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/utils/log.js
@@ -14,5 +14,5 @@ module.exports = function log(message) {
 		});
 	}
 
-	logFile.write(`${message}\n`);
+	logFile.write(`${new Date().toISOString()}: ${message}\n`);
 };

--- a/support/packages/github-to-jira-synchronization-tool/src/utils/runSequentially.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/utils/runSequentially.js
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+let promise = Promise.resolve();
+
+module.exports = function runSequentially(fn) {
+	promise = promise.then(async () => {
+		try {
+			await fn();
+		}
+		catch (error) {
+			console.error('Error executing fn ', error);
+		}
+	});
+
+	return promise;
+};


### PR DESCRIPTION
This is the second PR of the github-to-jira-integration tool:

This PR includes a bunch of enhancements after some testing of the tool, namely:

* Extensive logging to a file. This will allow easier debugging when it is running in the server
* Better events handling. We make sure that the issue or comment exists before doing any operation. This will allow to include issues/comments that are not in jira yet, due to the impasse between exalate expiring and this tool being ready
* Webhooks event are now being handled sequentially. It seems that when creating a github issue with some labels generate two webhooks, one for the issue and one for the label added. If we don't run those sequentially, we may end up with two issues being created. (This didn't happen in my machine but it did happen in the server :()
* Add a retry mechanism in case jira is down. When a webhook fail with a server error, we save the webhook in a file and retry later. For now it retries every hour (it seemed a reasonable time, since jira it is not usually down and when it is down it is not too much time) 

There is already a version deployed and listening for hooks from yesterday :)

Let me know what do you think