### PR TITLE
feat(eslint-plugin): add new rule against A.Url

### DIFF
--- a/projects/eslint-plugin/README.md
+++ b/projects/eslint-plugin/README.md
@@ -234,6 +234,7 @@ The bundled `@liferay/aui` plugin includes the following [rules](./rules/aui/doc
 -   [@liferay/aui/no-node](./rules/aui/docs/rules/no-node.md): Prevents usage of `A.Node()`
 -   [@liferay/aui/no-object](./rules/aui/docs/rules/no-object.md): Prevents usage of `A.Object`
 -   [@liferay/aui/no-one](./rules/aui/docs/rules/no-one.md): Prevents usage of `A.one()`
+-   [@liferay/aui/no-url](./rules/aui/docs/rules/no-url.md): Prevents usage of `A.Url()`
 
 ## License
 

--- a/projects/eslint-plugin/configs/general.js
+++ b/projects/eslint-plugin/configs/general.js
@@ -93,6 +93,7 @@ const config = {
 		'@liferay/aui/no-node': 'error',
 		'@liferay/aui/no-object': 'error',
 		'@liferay/aui/no-one': 'error',
+		'@liferay/aui/no-url': 'error',
 		'@liferay/destructure-requires': 'error',
 		'@liferay/empty-line-between-elements': 'error',
 		'@liferay/expect-assert': 'error',

--- a/projects/eslint-plugin/rules/aui/docs/rules/no-url.md
+++ b/projects/eslint-plugin/rules/aui/docs/rules/no-url.md
@@ -1,0 +1,17 @@
+# Avoid using `new A.Url('url')`
+
+This rule warns against using `A.Url`, and suggests use of the native `URL` class.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+var url = A.Url('url');
+```
+
+Examples of **correct** code for this rule:
+
+```js
+const url = new URL('url');
+```

--- a/projects/eslint-plugin/rules/aui/docs/rules/no-url.md
+++ b/projects/eslint-plugin/rules/aui/docs/rules/no-url.md
@@ -7,6 +7,10 @@ This rule warns against using `A.Url`, and suggests use of the native `URL` clas
 Examples of **incorrect** code for this rule:
 
 ```js
+var url = new A.Url('url');
+```
+
+```js
 var url = A.Url('url');
 ```
 

--- a/projects/eslint-plugin/rules/aui/index.js
+++ b/projects/eslint-plugin/rules/aui/index.js
@@ -14,4 +14,5 @@ module.exports = {
 	'aui/no-node': require('./lib/rules/no-node'),
 	'aui/no-object': require('./lib/rules/no-object'),
 	'aui/no-one': require('./lib/rules/no-one'),
+	'aui/no-url': require('./lib/rules/no-url'),
 };

--- a/projects/eslint-plugin/rules/aui/lib/rules/no-url.js
+++ b/projects/eslint-plugin/rules/aui/lib/rules/no-url.js
@@ -8,11 +8,29 @@ const message = 'use the vanilla URL class instead of A.Url';
 module.exports = {
 	create(context) {
 		return {
-			NewExpression(node) {
+			CallExpression(node) {
+				const {callee} = node;
+
 				if (
-					node.callee.object &&
-					node.callee.object.name === 'A' &&
-					node.callee.property.name === 'Url'
+					callee &&
+					callee.property &&
+					callee.object.name === 'A' &&
+					callee.property.name === 'Url'
+				) {
+					context.report({
+						message,
+						node,
+					});
+				}
+			},
+			NewExpression(node) {
+				const {callee} = node;
+
+				if (
+					callee &&
+					callee.object &&
+					callee.object.name === 'A' &&
+					callee.property.name === 'Url'
 				) {
 					context.report({
 						message,

--- a/projects/eslint-plugin/rules/aui/lib/rules/no-url.js
+++ b/projects/eslint-plugin/rules/aui/lib/rules/no-url.js
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const message = 'use the vanilla URL class instead of A.Url';
+
+module.exports = {
+	create(context) {
+		return {
+			NewExpression(node) {
+				if (
+					node.callee.object &&
+					node.callee.object.name === 'A' &&
+					node.callee.property.name === 'Url'
+				) {
+					context.report({
+						message,
+						node,
+					});
+				}
+			},
+		};
+	},
+	meta: {
+		docs: {
+			category: 'Best Practices',
+			description: message,
+			recommended: false,
+			url:
+				'https://github.com/liferay/liferay-frontend-projects/issues/652',
+		},
+		fixable: 'code',
+		schema: [],
+		type: 'problem',
+	},
+};

--- a/projects/eslint-plugin/rules/aui/tests/lib/rules/no-url.js
+++ b/projects/eslint-plugin/rules/aui/tests/lib/rules/no-url.js
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const MultiTester = require('../../../../../scripts/MultiTester');
+const rule = require('../../../lib/rules/no-url');
+
+const parserOptions = {
+	parserOptions: {
+		ecmaVersion: 6,
+		sourceType: 'module',
+	},
+};
+
+const ruleTester = new MultiTester(parserOptions);
+
+ruleTester.run('no-url', rule, {
+	invalid: [
+		{
+			code: `var url = new A.Url('url');`,
+			errors: [
+				{
+					message: 'use the vanilla URL class instead of A.Url',
+					type: 'NewExpression',
+				},
+			],
+		},
+	],
+	valid: [
+		{
+			code: `const url = new URL('url');`,
+		},
+	],
+});

--- a/projects/eslint-plugin/rules/aui/tests/lib/rules/no-url.js
+++ b/projects/eslint-plugin/rules/aui/tests/lib/rules/no-url.js
@@ -26,6 +26,15 @@ ruleTester.run('no-url', rule, {
 				},
 			],
 		},
+		{
+			code: `var url = A.Url('url');`,
+			errors: [
+				{
+					message: 'use the vanilla URL class instead of A.Url',
+					type: 'CallExpression',
+				},
+			],
+		},
 	],
 	valid: [
 		{


### PR DESCRIPTION
Pretty straightforward, this PR adds a new rule that throws an error when `new A.Url()` is added to the code.

I didn't go with an autofix solution because we don't have any preexisting mentions, and because the returned object has different methods on it compared to the vanilla URL object.