### PR TITLE
feat: create a tool to be able to generate the AMD to ESM bridges automatically

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
@@ -8,6 +8,7 @@ const path = require('path');
 
 let buildSass = require('../sass/build');
 let runTSC = require('../typescript/runTSC');
+const createExportsBridges = require('../utils/createExportsBridges');
 const createTempFile = require('../utils/createTempFile');
 const getMergedConfig = require('../utils/getMergedConfig');
 const instrument = require('../utils/instrument');
@@ -132,6 +133,14 @@ module.exports = async function (...args) {
 
 		if (fs.existsSync(path.join(CWD, '.npmbridgerc'))) {
 			runBridge();
+		}
+
+		if (BUILD_CONFIG.exports) {
+			createExportsBridges(
+				CWD,
+				BUILD_CONFIG.output,
+				BUILD_CONFIG.exports
+			);
 		}
 
 		if (useSoy) {

--- a/projects/npm-tools/packages/npm-scripts/src/utils/createExportsBridges.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/createExportsBridges.js
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const {
+	addNamespace,
+	joinModuleName,
+	splitModuleName,
+} = require('@liferay/js-toolkit-core');
+const fs = require('fs');
+const path = require('path');
+const resolve = require('resolve');
+
+/* eslint-disable @liferay/no-dynamic-require */
+
+/**
+ * Create .js files to make Liferay-AMD modules available as browser ESM
+ * modules.
+ *
+ * @param {string} projectDir path to project's directory
+ * @param {string} outDir path to output directory
+ * @param {object} exportsMap
+ * Map of ESM exports, where keys are bare identifiers, and values are a valid
+ * npm module path.
+ */
+function createExportsBridges(projectDir, outDir, exportsMap) {
+	Object.entries(exportsMap).forEach(([bareIdentifier, moduleName]) => {
+		const {modulePath, pkgName, scope} = splitModuleName(moduleName);
+
+		const rootPkgJson = require(path.join(projectDir, 'package.json'));
+		const pkgJson = require(resolve.sync(
+			joinModuleName(scope, pkgName, '/package.json'),
+			{
+				basedir: projectDir,
+			}
+		));
+
+		const nsModuleName = addNamespace(
+			joinModuleName(
+				scope,
+				`${pkgJson.name}@${pkgJson.version}`,
+				modulePath
+			),
+			rootPkgJson
+		);
+
+		const module = require(resolve.sync(moduleName, {basedir: projectDir}));
+		const fields = Object.keys(module)
+			.map((field) => `	${field}`)
+			.join(',\n');
+
+		const bridgeSource = `const amdModule = await new Promise((resolve, reject) => {
+	Liferay.Loader.require(
+		'${nsModuleName}',
+		resolve,
+		reject
+	);
+});
+
+const {
+${fields}
+} = amdModule;
+
+export {
+${fields}
+};
+
+export default amdModule;
+`;
+
+		const bridgePath = path.join(
+			outDir,
+			'__liferay__',
+			'amd2esm',
+			`${bareIdentifier}.js`
+		);
+
+		fs.mkdirSync(path.dirname(bridgePath), {recursive: true});
+
+		fs.writeFileSync(bridgePath, bridgeSource);
+	});
+}
+
+module.exports = createExportsBridges;

--- a/projects/npm-tools/packages/npm-scripts/src/utils/createExportsBridges.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/createExportsBridges.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+/* eslint-disable @liferay/no-dynamic-require */
+
 const {
 	addNamespace,
 	joinModuleName,
@@ -11,8 +13,6 @@ const {
 const fs = require('fs');
 const path = require('path');
 const resolve = require('resolve');
-
-/* eslint-disable @liferay/no-dynamic-require */
 
 /**
  * Create .js files to make Liferay-AMD modules available as browser ESM


### PR DESCRIPTION
[ [https://issues.liferay.com/browse/IFI-2977](https://issues.liferay.com/browse/IFI-2977) ]

This modifies `npm-scripts` so that if a project declares `exports` in `npmscripts.config.js`, like this:

```javascript
module.exports = {
	build: {
		exports: {
			'react': 'react/index',
			'react-dom': 'react-dom/index',
		}
	},
};
```

The `npm-scripts` generate ESM modules that provide a bridge between AMD and ESM worlds, like this:

![image](https://user-images.githubusercontent.com/3273630/149751131-d4c34d1b-7332-48e2-b428-7446e460fee5.png)

Where `react.js`, for example, contains:

```javascript
const amdModule = await new Promise((resolve, reject) => {
	Liferay.Loader.require(
		'liferay!frontend-js-react-web$react@16.12.0/index',
		resolve,
		reject
	);
});

const {
	Children,
	createRef,
	...
	version,
	__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
} = amdModule;

export {
	Children,
	createRef,
	...
	version,
	__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
};

export default amdModule;
```

We then combine these bridges with importmaps so that anyone can do this in an ESM module and it works without any transpiling or bundling:

```javascript
import react from 'react';
```
