### PR TITLE
feat(npm-scripts): fall back to checking for index.d.ts if *.ts does not exist

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/apps/frontend-js/frontend-js-react-web/package.json
+++ b/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/apps/frontend-js/frontend-js-react-web/package.json
@@ -2,6 +2,6 @@
 	"dependencies": {
 		"@liferay/frontend-js-state-web": "*"
 	},
-	"main": "js/index.js",
+	"main": "index.js",
 	"name": "@liferay/frontend-js-react-web"
 }

--- a/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/index.d.ts
@@ -1,0 +1,1 @@
+/* eslint-disable notice/notice */

--- a/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/index.js
+++ b/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/index.js
@@ -1,0 +1,1 @@
+/* eslint-disable notice/notice */

--- a/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/apps/frontend-js/frontend-js-state-web/package.json
+++ b/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/apps/frontend-js/frontend-js-state-web/package.json
@@ -1,4 +1,4 @@
 {
-	"main": "index.js",
+	"main": "js/index.js",
 	"name": "@liferay/frontend-js-state-web"
 }

--- a/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/apps/frontend-js/frontend-js-state-web/src/main/resources/META-INF/resources/js/index.ts
+++ b/projects/npm-tools/packages/npm-scripts/__fixtures__/typescript/modules/apps/frontend-js/frontend-js-state-web/src/main/resources/META-INF/resources/js/index.ts
@@ -1,0 +1,1 @@
+/* eslint-disable notice/notice */

--- a/projects/npm-tools/packages/npm-scripts/src/typescript/configureTypeScript.js
+++ b/projects/npm-tools/packages/npm-scripts/src/typescript/configureTypeScript.js
@@ -66,8 +66,21 @@ function configureTypeScript(graph) {
 		// Note that "main" fields usually end with ".js" so that the loader can
 		// find built files at runtime, but we actually care about source files
 		// (which will have a ".ts" extension instead).
+		//
+		// If the ".ts" file is not found, we fall back using "index.d.ts"
 
 		const main = dependency.main.replace(/\.js$/, '.ts');
+
+		const resourceDirectory = path.join(
+			dependency.directory,
+			'src',
+			'main',
+			'resources',
+			'META-INF',
+			'resources'
+		);
+
+		const mainPath = path.join(resourceDirectory, main);
 
 		paths[name] = [
 
@@ -77,15 +90,13 @@ function configureTypeScript(graph) {
 			toPosix(
 				path.relative(
 					'',
-					path.join(
-						dependency.directory,
-						'src',
-						'main',
-						'resources',
-						'META-INF',
-						'resources',
-						main
-					)
+					fs.existsSync(mainPath)
+						? mainPath
+						: path.join(
+								resourceDirectory,
+								path.dirname(main),
+								'index.d.ts'
+						  )
 				)
 			),
 		];

--- a/projects/npm-tools/packages/npm-scripts/test/typescript/configureTypeScript.js
+++ b/projects/npm-tools/packages/npm-scripts/test/typescript/configureTypeScript.js
@@ -310,7 +310,7 @@ describe('configureTypeScript()', () => {
 					...BASE_CONFIG.compilerOptions,
 					paths: {
 						'@liferay/frontend-js-state-web': [
-							'../frontend-js-state-web/src/main/resources/META-INF/resources/index.ts',
+							'../frontend-js-state-web/src/main/resources/META-INF/resources/js/index.ts',
 						],
 					},
 					typeRoots: [
@@ -340,10 +340,10 @@ describe('configureTypeScript()', () => {
 					...BASE_CONFIG.compilerOptions,
 					paths: {
 						'@liferay/frontend-js-react-web': [
-							'../frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts',
+							'../frontend-js-react-web/src/main/resources/META-INF/resources/index.d.ts',
 						],
 						'@liferay/frontend-js-state-web': [
-							'../frontend-js-state-web/src/main/resources/META-INF/resources/index.ts',
+							'../frontend-js-state-web/src/main/resources/META-INF/resources/js/index.ts',
 						],
 					},
 					typeRoots: [


### PR DESCRIPTION
fixes #825

This adds support for TS so that if no main *.ts file exists, we fall back to to an index. d.ts file for the path reference