### PR TITLE
fix: enable building JS files in src child directories, e.g. src/test/Test.js

### DIFF
--- a/projects/js-toolkit/packages/portal-base/src/build.ts
+++ b/projects/js-toolkit/packages/portal-base/src/build.ts
@@ -78,6 +78,10 @@ function runBabel(): void {
 				}
 			);
 
+			fs.mkdirSync(buildDir.join(srcDirRelJsFile).dirname().asNative, {
+				recursive: true,
+			});
+
 			fs.writeFileSync(
 				buildDir.join(srcDirRelJsFile).asNative,
 				code,


### PR DESCRIPTION
Fixes following problem in @liferay/portal-base v1.0.0.

Steps to reproduce:
```shell
liferay new temp
cd temp
mkdir -p src/test
touch src/test/Test.js
npm run build
```

```
> temp@1.0.0 build /home/ktor/development/projects/lukreo/liferay/modules/application/temp
> liferay build

Building project for target platform: @liferay/portal-7.4
ℹ️ Copying 0 assets...
ℹ️ Running sass on 1 files...
ℹ️ Running babel on 3 files...
Error: ENOENT: no such file or directory, open 'build/test/Test.js'
    at Object.openSync (fs.js:497:3)
    at Object.writeFileSync (fs.js:1528:35)
    at /home/ktor/development/projects/lukreo/liferay/modules/application/temp/node_modules/@liferay/portal-base/lib/build.js:82:26
    at Array.forEach (<anonymous>)
    at runBabel (/home/ktor/development/projects/lukreo/liferay/modules/application/temp/node_modules/@liferay/portal-base/lib/build.js:74:13)
    at runCompiler (/home/ktor/development/projects/lukreo/liferay/modules/application/temp/node_modules/@liferay/portal-base/lib/build.js:97:9)
    at Object.build (/home/ktor/development/projects/lukreo/liferay/modules/application/temp/node_modules/@liferay/portal-base/lib/build.js:48:5)
    at run (/home/ktor/development/projects/lukreo/liferay/modules/application/temp/node_modules/@liferay/portal-base/lib/index.js:28:25)
    at Object.<anonymous> (/home/ktor/development/projects/lukreo/liferay/modules/application/temp/node_modules/@liferay/portal-7.4/liferay.js:10:1)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
❌ Build failed
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! temp@1.0.0 build: `liferay build`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the temp@1.0.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/ktor/.npm/_logs/2022-01-21T18_14_42_660Z-debug.log
```