### PR TITLE
fix(portal-base): create directory stucture before writing file

### DIFF
--- a/projects/js-toolkit/packages/portal-base/src/build.ts
+++ b/projects/js-toolkit/packages/portal-base/src/build.ts
@@ -78,11 +78,11 @@ function runBabel(): void {
 				}
 			);
 
-			fs.writeFileSync(
-				buildDir.join(srcDirRelJsFile).asNative,
-				code,
-				'utf8'
-			);
+			const filePath = buildDir.join(srcDirRelJsFile).asNative;
+
+			fs.mkdirSync(path.dirname(filePath), {recursive: true});
+
+			fs.writeFileSync(filePath, code, 'utf8');
 
 			fs.writeFileSync(
 				buildDir.join(`${srcDirRelJsFile}.map`).asNative,


### PR DESCRIPTION
fixes #828

I think we just forgot to create the directory stucture first.