### PR TITLE
fix(dev-server): watcher directory lookup

### DIFF
--- a/projects/js-toolkit/packages/dev-server/src/server.ts
+++ b/projects/js-toolkit/packages/dev-server/src/server.ts
@@ -55,6 +55,9 @@ function findPortalRoot(directory: string): string {
 			if (base === 'modules') {
 				return join(directory, '..');
 			}
+			else {
+				return directory;
+			}
 		}
 
 		if (dirname(directory) === directory) {


### PR DESCRIPTION
Before fix. Unexpected behavior happens in liferay workspace: directory loopup iterates up until `/` because directory containing `yarn.lock` is not called `modules`. Standard situation in Liferay workspace where `yarn.lock` is places in workspace root directory. `WD` is in computed correctly:
```
Liferay Dev Server is ready at http:127.0.0.1:3000
Watching changes at /modules/**/*.{css,js,jsx,scss,ts,tsx}
```
After the fix:
```
Liferay Dev Server is ready at http:127.0.0.1:3000
Watching changes at /home/ktor/development/projects/lukreo/liferay/modules/**/*.{css,js,jsx,scss,ts,tsx}
```