### PR TITLE
docs(gh-jira-sync): update user mapping

### DIFF
--- a/support/packages/github-to-jira-synchronization-tool/mapping-config.json
+++ b/support/packages/github-to-jira-synchronization-tool/mapping-config.json
@@ -10,24 +10,22 @@
 		"brunofernandezg": "bruno.fernandez",
 		"bryceosterhaus": "bryce.osterhaus",
 		"carloslancha": "carlos.lancha",
+		"ccorreagg": "carlos.correa",
 		"default": "support-lep@liferay.com",
 		"diegonvs": "diego.nascimento",
 		"dsanz": "daniel.sanz",
 		"eduardoallegrini": "Eduardo.allegrini",
 		"izaera": "ivan.zaera",
 		"javierdearcos": "javier.dearcos",
-		"jbalsas": "jose.balsas",
 		"julien": "julien.castelain",
 		"kresimir-coko": "kresimir.coko",
 		"LuismiBarcos": "luismiguel.barco",
 		"marcoscv-work": "marcos.castro",
 		"markocikos": "marko.cikos",
 		"matuzalemsteles": "matuzalem.teles",
-		"nhpatt": "javier.gamarra",
 		"pablo-agulla": "pablo.agulla",
 		"pat270": "patrick.yeo",
 		"sergiojimcos": "sergio.jdelcoso",
-		"tinycarol": "carolina.alonso",
-		"victorg1991": "victor.galan"
+		"tinycarol": "carolina.alonso"
 	}
 }


### PR DESCRIPTION
Add Carlos Correa and remove Victor Galán, Chema and Javi Gamarra

This change doesn't need to redeploy the application. I will update it manually following the instructions here
https://liferay.atlassian.net/wiki/spaces/ENGFRONTENDINFRA/pages/1954447876/Github+to+Jira+synchronization+tool#How-to-modify-the-configuration
but sent this PR is to update the repo so we don't overwrite the configuration next time we redeploy