### PR TITLE
feat(@liferay/npm-scripts): Give Liferay Workspaces ability to use our Prettier setup with the VSC extension

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/contrib/prettier/prettier.js
+++ b/projects/npm-tools/packages/npm-scripts/contrib/prettier/prettier.js
@@ -1108,37 +1108,22 @@ function prepare(filepath) {
 	let file = 'prettier';
 
 	const workspaceRoot = getWorkspaceRoot(filepath);
-
-	if (workspaceRoot) {
-		const modules = path.join(workspaceRoot, 'node_modules');
-
-		let scripts = path.join(modules, '@liferay/npm-scripts');
-
-		let wrapper = path.join(scripts, 'src/scripts/prettier.js');
-
-		if (!fs.existsSync(wrapper)) {
-			scripts = path.join(modules, 'liferay-npm-scripts');
-
-			wrapper = path.join(scripts, 'src/scripts/prettier.js');
-		}
-
-		const fallback = path.join(modules, 'prettier/bin-prettier.js');
-
-		if (fs.existsSync(wrapper)) {
-			dir = scripts;
-			file = wrapper;
-		}
-		else if (fs.existsSync(fallback)) {
-			dir = modules;
-			file = fallback;
-		}
-	}
-
 	const portalRoot = getPortalRoot(filepath);
 
-	if (portalRoot) {
-		const modules = path.join(portalRoot, 'modules/node_modules');
+	const portalOrWorkspaceRoot =
+		getPortalRoot(filepath) || getWorkspaceRoot(filepath);
 
+	let modules;
+
+	if (workspaceRoot) {
+		modules = path.join(workspaceRoot, 'node_modules');
+	}
+
+	if (portalRoot) {
+		modules = path.join(portalRoot, 'modules/node_modules');
+	}
+
+	if (portalOrWorkspaceRoot) {
 		let scripts = path.join(modules, '@liferay/npm-scripts');
 
 		let wrapper = path.join(scripts, 'src/scripts/prettier.js');

--- a/projects/npm-tools/packages/npm-scripts/contrib/prettier/prettier.js
+++ b/projects/npm-tools/packages/npm-scripts/contrib/prettier/prettier.js
@@ -1000,7 +1000,12 @@ function getWorkspaceRoot(filepath) {
 
 		const candidate = path.join(parent, 'settings.gradle');
 
-		if (fs.existsSync(candidate)) {
+		if (
+			fs.existsSync(candidate) &&
+			fs
+				.readFileSync(candidate)
+				.includes('apply plugin: "com.liferay.workspace"')
+		) {
 			current = candidate;
 
 			break;
@@ -1110,8 +1115,7 @@ function prepare(filepath) {
 	const workspaceRoot = getWorkspaceRoot(filepath);
 	const portalRoot = getPortalRoot(filepath);
 
-	const portalOrWorkspaceRoot =
-		getPortalRoot(filepath) || getWorkspaceRoot(filepath);
+	const portalOrWorkspaceRoot = portalRoot || workspaceRoot;
 
 	let modules;
 
@@ -1145,30 +1149,31 @@ function prepare(filepath) {
 			file = fallback;
 		}
 	}
-
-	const frontendProjectsRoot = getFrontendProjectsRoot(filepath);
-
-	if (frontendProjectsRoot) {
-		const scripts = path.join(
-			frontendProjectsRoot,
-			'projects/npm-tools/packages/npm-scripts'
-		);
-
-		const wrapper = path.join(scripts, 'src/scripts/prettier.js');
-
-		if (fs.existsSync(wrapper)) {
-			dir = scripts;
-			file = wrapper;
-		}
-	}
 	else {
-		const extension = require('vscode').extensions.getExtension(
-			'esbenp.prettier-vscode'
-		);
+		const frontendProjectsRoot = getFrontendProjectsRoot(filepath);
 
-		if (extension) {
-			dir = path.join(extension.extensionPath);
-			file = path.join(dir, 'node_modules/prettier');
+		if (frontendProjectsRoot) {
+			const scripts = path.join(
+				frontendProjectsRoot,
+				'projects/npm-tools/packages/npm-scripts'
+			);
+
+			const wrapper = path.join(scripts, 'src/scripts/prettier.js');
+
+			if (fs.existsSync(wrapper)) {
+				dir = scripts;
+				file = wrapper;
+			}
+		}
+		else {
+			const extension = require('vscode').extensions.getExtension(
+				'esbenp.prettier-vscode'
+			);
+
+			if (extension) {
+				dir = path.join(extension.extensionPath);
+				file = path.join(dir, 'node_modules/prettier');
+			}
 		}
 	}
 

--- a/projects/npm-tools/packages/npm-scripts/contrib/prettier/prettier.js
+++ b/projects/npm-tools/packages/npm-scripts/contrib/prettier/prettier.js
@@ -1164,28 +1164,26 @@ function prepare(filepath) {
 	const frontendProjectsRoot = getFrontendProjectsRoot(filepath);
 
 	if (frontendProjectsRoot) {
-		if (frontendProjectsRoot) {
-			const scripts = path.join(
-				frontendProjectsRoot,
-				'projects/npm-tools/packages/npm-scripts'
-			);
+		const scripts = path.join(
+			frontendProjectsRoot,
+			'projects/npm-tools/packages/npm-scripts'
+		);
 
-			const wrapper = path.join(scripts, 'src/scripts/prettier.js');
+		const wrapper = path.join(scripts, 'src/scripts/prettier.js');
 
-			if (fs.existsSync(wrapper)) {
-				dir = scripts;
-				file = wrapper;
-			}
+		if (fs.existsSync(wrapper)) {
+			dir = scripts;
+			file = wrapper;
 		}
-		else {
-			const extension = require('vscode').extensions.getExtension(
-				'esbenp.prettier-vscode'
-			);
+	}
+	else {
+		const extension = require('vscode').extensions.getExtension(
+			'esbenp.prettier-vscode'
+		);
 
-			if (extension) {
-				dir = path.join(extension.extensionPath);
-				file = path.join(dir, 'node_modules/prettier');
-			}
+		if (extension) {
+			dir = path.join(extension.extensionPath);
+			file = path.join(dir, 'node_modules/prettier');
 		}
 	}
 

--- a/projects/npm-tools/packages/npm-scripts/contrib/prettier/prettier.js
+++ b/projects/npm-tools/packages/npm-scripts/contrib/prettier/prettier.js
@@ -1115,19 +1115,12 @@ function prepare(filepath) {
 	const workspaceRoot = getWorkspaceRoot(filepath);
 	const portalRoot = getPortalRoot(filepath);
 
-	const portalOrWorkspaceRoot = portalRoot || workspaceRoot;
-
-	let modules;
-
-	if (workspaceRoot) {
-		modules = path.join(workspaceRoot, 'node_modules');
-	}
-
-	if (portalRoot) {
-		modules = path.join(portalRoot, 'modules/node_modules');
-	}
+	const portalOrWorkspaceRoot =
+		getPortalRoot(filepath) || getWorkspaceRoot(filepath);
 
 	if (portalOrWorkspaceRoot) {
+		const modules = path.join(portalRoot || workspaceRoot, 'node_modules');
+
 		let scripts = path.join(modules, '@liferay/npm-scripts');
 
 		let wrapper = path.join(scripts, 'src/scripts/prettier.js');


### PR DESCRIPTION
Fixes #51 

This one was a long journey on my part, getting the Workspace working and then Prettier started causing me issues, etc.

To get this done, I utilized the [debug](https://github.com/kresimir-coko/liferay-frontend-projects/blob/2bcdc8175c4b8c4f8862dfdc8c2253264e2feaab/projects/npm-tools/packages/npm-scripts/contrib/prettier/prettier.js#L20-L35) function in order to get some logging happening which was helpful but took a little bit of figuring out. After I made sure this works in the local Liferay Workspace, I also tested it in this repository and in `liferay-portal` to make sure it properly works since I did split up the conditioning.