### PR TITLE
fix(alloy-font-awesome): Add missing "main" field inside the package.json

### DIFF
--- a/third-party/projects/alloy-font-awesome/package.json
+++ b/third-party/projects/alloy-font-awesome/package.json
@@ -58,5 +58,6 @@
   ],
   "devDependencies": {
     "less": "1.4.1"
-  }
+  },
+  "main": "index.js"
 }


### PR DESCRIPTION
Fixes #818 

For some reason, I do not know why, `liferay-font-awesome (alloy-font-awesome)` started failing when its version got updated to 3.5.0, but I found the culprit. The `main` field was missing inside its `package.json` meaning Node could not find the module.

I've tested this by adding the field to the `liferay-font-awesome/package.json` inside the generated theme and running the Node's `require.resolve('liferay-font-awesome')`.

I couldn't figure out how to `yarn link` these properly so that it uses my local `alloy-font-awesome` instead. Maybe @izaera you can give me a pointer, do I have to run `yarn link` from the `alloy-font-awesome` folder instead of `liferay-theme-tasks`?