### PR TITLE
refactor(portal-base): don't rely on bundler2 Project for clean task

### DIFF
--- a/projects/js-toolkit/packages/portal-base/src/clean.ts
+++ b/projects/js-toolkit/packages/portal-base/src/clean.ts
@@ -3,24 +3,21 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-import {FilePath, format} from '@liferay/js-toolkit-core';
+import {Project, format} from '@liferay/js-toolkit-core';
 import fs from 'fs';
-import project from 'liferay-npm-build-tools-common/lib/project';
 
 const {print, success} = format;
-
-const buildDir = new FilePath(project.buildDir.asNative);
-const distDir = new FilePath(project.jar.outputDir.asNative);
+const rmSync = fs['rmSync'] || fs.rmdirSync;
 
 export default async function clean(): Promise<void> {
-	const rmSync = fs['rmSync'] || fs.rmdirSync;
+	const project = new Project('.');
 
-	if (fs.existsSync(buildDir.asNative)) {
-		rmSync(buildDir.asNative, {recursive: true});
+	if (fs.existsSync(project.build.dir.asNative)) {
+		rmSync(project.build.dir.asNative, {recursive: true});
 	}
 
-	if (fs.existsSync(distDir.asNative)) {
-		rmSync(distDir.asNative, {recursive: true});
+	if (fs.existsSync(project.dist.dir.asNative)) {
+		rmSync(project.dist.dir.asNative, {recursive: true});
 	}
 
 	print(success`{Removed output directories}`);


### PR DESCRIPTION
This removes technical debt.