### PR TITLE
feat(amd-loader): load scripts as browser modules (i.e.: type='module')

### DIFF
--- a/projects/amd-loader/src/loader/script-loader.js
+++ b/projects/amd-loader/src/loader/script-loader.js
@@ -67,6 +67,7 @@ export default class ScriptLoader {
 
 			script.src = modulesURL.url;
 			script.async = false;
+			script.type = 'module';
 
 			script.onload = script.onreadystatechange = () => {
 				if (


### PR DESCRIPTION
see #858 