### PR TITLE
docs(liferay-font-awesome): Update readme and contributing pages

### DIFF
--- a/third-party/projects/alloy-font-awesome/CONTRIBUTING.md
+++ b/third-party/projects/alloy-font-awesome/CONTRIBUTING.md
@@ -1,112 +1,33 @@
-# Contributing to Font Awesome
+# Release process
 
-Looking to contribute something to Font Awesome? **Here's how you can help.**
+1.  Confirm that you have a clean worktree.
 
-## Reporting issues
+    `git status` should show no changed, staged, or untracked files.
 
-We only accept issues that are icon requests, bug reports, or feature requests. Bugs must be isolated and reproducible problems that we can fix within the Font Awesome core. Please read the following guidelines to ensure you are the paragon of bug reporting.
+2.  Update [CHANGELOG.md](./CHANGELOG.md).
 
-1. **Search for existing issues.** We get a lot of duplicate issues, and you'd help us out a lot by first checking if someone else has reported the same issue. Moreover, the issue may have already been resolved with a fix available.
-2. **Create an isolated and reproducible test case.** Be sure the problem exists in Font Awesome's code with a [reduced test case](http://css-tricks.com/reduced-test-cases/) that should be included in each bug report.
-3. **Include a live example.** Make use of jsFiddle, jsBin, or Codepen to share your isolated test cases.
-4. **Share as much information as possible.** Include operating system and version, browser and version, version of Font Awesome, etc. where appropriate. Also include steps to reproduce the bug.
+    Run [`@liferay/changelog-generator`](https://www.npmjs.com/package/@liferay/changelog-generator):
 
-## Key branches
+        yarn run liferay-changelog-generator --interactive
 
-- `master` is the latest, deployed version (not to be used for pull requests)
-- `gh-pages` is the hosted docs (not to be used for pull requests)
-- `*-wip` branches are the official work in progress branches for the next releases. All pull requests should be submitted against the appropriate branch
+    This will show a preview of the changes, prompt you to enter a release type (eg. major, minor etc, or a specific version), and then stage the changes for inclusion in the release commit.
 
-## Notes on the repo
+    Feel free to edit if you want to make improvements; if you do, remember to stage the changes:
 
-As of v3.2.0, Font Awesome's CSS, LESS, SCSS, and documentation are all powered by Jekyll templates and built before each commit and release.
+        git add CHANGELOG.md
 
-- `_config.yml` - much of the site is driven off variables from this file, including Font Awesome and Bootstrap versions
-- `src/` - All edits to documentation, LESS, SCSS, and CSS should be made to files and templates in this directory
-- `src/icons.yml` - all LESS, SCSS, and CSS icon definitions are driven off this single file
+3.  Tag and publish the new release.
 
-## Pull requests
+    Run `yarn version --minor` (or `--major`, or `--patch`, using the same release type that you selected in the previous step).
 
-- Submit all pull requests against the appropriate `*-wip` branch for easier merging
-- Any changes to the docs must be made to the Liquid templates in the `src` directory
-- CSS changes must be done in .less and .scss files first, never the compiled files
-- If modifying the .less and .scss files, always recompile and commit the compiled files
-- Try not to pollute your pull request with unintended changes--keep them simple and small
-- Try to share which browsers your code has been tested in before submitting a pull request
+    This will update the package.json and create a tagged commit, including the updates to the CHANGELOG that you previously made.
 
-## Style Guides
+        We use [@liferay/js-publish](https://github.com/liferay/liferay-frontend-projects/tree/master/projects/npm-tools/packages/js-publish) from the "postversion" script to take care of pushing to the repo, and actually publishing to the NPM registry; just follow the prompts.
 
-### Git Commit Messages
+4.  Update the release notes.
 
-This section shows you how to write commit messages. Follow these guidelines to help us maintain order and make it easier to locate your changes.
+    Take the new section from the top of the CHANGELOG and add it to [the release page](https://github.com/liferay/liferay-frontend-projects/releases) on GitHub.
 
-Each commit message consists of a header, a body and a footer. The header has a special format that includes a type, a scope and a subject:
+5.  Sanity check [the liferay-font-awesome page](https://www.npmjs.com/package/liferay-font-awesome) on npmjs.com
 
-```
-<type>(<scope>): <subject>
-```
-
-The header is mandatory and the scope of the header is optional.
-
-> This repository follows the "[Conventional Commits](https://www.conventionalcommits.org/)" specification.
-
-### Coding standards: HTML
-
-- Two spaces for indentation, never tabs
-- Double quotes only, never single quotes
-- Always use proper indentation
-- Use tags and elements appropriate for an HTML5 doctype (e.g., self-closing tags)
-
-### Coding standards: CSS
-
-- Adhere to the [Recess CSS property order](http://markdotto.com/2011/11/29/css-property-order/)
-- Multiple-line approach (one property and value per line)
-- Always a space after a property's colon (.e.g, `display: block;` and not `display:block;`)
-- End all lines with a semi-colon
-- For multiple, comma-separated selectors, place each selector on it's own line
-- Attribute selectors, like `input[type="text"]` should always wrap the attribute's value in double quotes, for consistency and safety (see this [blog post on unquoted attribute values](http://mathiasbynens.be/notes/unquoted-attribute-values) that can lead to XSS attacks)
-
-## Release process
-
-To publish a new version, follow these steps:
-
-```bash
-# Confirm you are logged in on Github and NPM
-ssh -T git@github.com
-yarn login
-
-# Checkout the latest code
-git checkout master
-
-# Update the CHANGELOG. With the `--interactive` flag, `changelog-generator`
-# will propose a semantic version. If you wish to manually set the version,
-# see `--help` for options.
-npx @liferay/changelog-generator --interactive
-
-# Confirm a staged CHANGELOG.md file. Review it and update if needed.
-
-# Update version. The version was determined in the last step.
-yarn version --new-version $VERSION
-
-# Confirm a tagged commit was created. It should contain CHANGELOG.md and the
-# version increase in package.json.
-
-# Change commit message
-git commit --amend -m "chore: prepare v$VERSION release"
-
-# Push to Git
-git push --follow-tags
-
-# Publish to NPM
-yarn publish
-```
-
-## License
-
-By contributing your code, you agree to license your contribution under the terms of the MIT License:
-
-- http://opensource.org/licenses/mit-license.html
-
-## Thanks
-
-Thanks to Bootstrap for their wonderful CONTRIBUTING.MD doc. It was modified to create this one.
+    Specifically, you should see the version you just released under the "Versions" tab on that page.

--- a/third-party/projects/alloy-font-awesome/README.md
+++ b/third-party/projects/alloy-font-awesome/README.md
@@ -1,62 +1,11 @@
-#[Font Awesome v3.2.1](http://fontawesome.io)
-###the iconic font designed for Bootstrap
+# liferay-font-awesome
 
-Font Awesome is a full suite of 361 pictographic icons for easy scalable vector graphics on websites, created and
-maintained by [Dave Gandy](http://twitter.com/davegandy). Stay up to date [@fontawesome](http://twitter.com/fontawesome).
+> Liferay's wrapper of the Internet's icon library and toolkit, used by millions of designers, developers, and content creators.
 
-Get started at http://fontawesome.io!
+# Overview
 
-##License
-- The Font Awesome font is licensed under the SIL OFL 1.1:
-  - http://scripts.sil.org/OFL
-- Font Awesome CSS, LESS, and SASS files are licensed under the MIT License:
-  - http://opensource.org/licenses/mit-license.html
-- The Font Awesome documentation is licensed under the CC BY 3.0 License:
-  - http://creativecommons.org/licenses/by/3.0/
-- Attribution is no longer required as of Font Awesome 3.0, but much appreciated:
-  - `Font Awesome by Dave Gandy - http://fontawesome.io`
-- Full details: http://fontawesome.io/license
-
-##Changelog
-- v3.0.0 - all icons redesigned from scratch, optimized for Bootstrap's 14px default
-- v3.0.1 - much improved rendering in webkit, various bug fixes
-- v3.0.2 - much improved rendering and alignment in IE7
-- v3.1.0 - Added 54 icons, icon stacking styles, flipping and rotating icons, removed SASS support
-- [v3.1.1 GitHub milestones](https://github.com/FortAwesome/Font-Awesome/issues?milestone=4&page=1&state=closed)
-- [v3.2.0 GitHub milestones](https://github.com/FortAwesome/Font-Awesome/issues?milestone=3&page=1&state=closed)
-- [v3.2.1 GitHub milestones](https://github.com/FortAwesome/Font-Awesome/issues?milestone=5&page=1&state=closed)
-
-##Versioning
-
-Font Awesome will be maintained under the Semantic Versioning guidelines as much as possible. Releases will be numbered with the following format:
-
-`<major>.<minor>.<patch>`
-
-And constructed with the following guidelines:
-
-* Breaking backward compatibility bumps the major (and resets the minor and patch)
-* New additions, including new icons, without breaking backward compatibility bumps the minor (and resets the patch)
-* Bug fixes and misc changes bumps the patch
-
-For more information on SemVer, please visit http://semver.org.
-
-##Author
-- Email: dave@fontawesome.io
-- Twitter: http://twitter.com/davegandy
-- GitHub: https://github.com/davegandy
-- Work: Lead Product Designer @ http://kyru.us
-
-## Hacking on Font Awesome
-
-From the root of the repository, install the tools used to develop.
-
-    $ bundle install
-    $ npm install
-
-Build the project and documentation:
-
-    $ bundle exec jekyll build
-
-Or serve it on a local server on http://localhost:7998/Font-Awesome/:
-
-    $ bundle exec jekyll serve
+-   Upstream project: https://github.com/FortAwesome/Font-Awesome
+-   Base version used by Liferay: [font-awesome/v3.2.0](https://github.com/FortAwesome/Font-Awesome/tree/906345058f738c2b931f89754a319ed108e17bd8)
+-   Changelog showing Liferay changes: [`CHANGELOG.md`](./projects/alloy-font-awesome/CHANGELOG.md).
+-   Our package name: `liferay-font-awesome`
+-   Usage site in Liferay DXP: [`frontend-theme-font-awesome-web`](https://github.com/liferay/liferay-portal/tree/master/modules/apps/frontend-theme/frontend-theme-font-awesome-web)


### PR DESCRIPTION
As the title states, this PR updates the three documentation files found under `liferay-font-awesome`.

I've taken some liberties here, removing the (IMO) irrelevant sections of documentation relating to the original font awesome repo.

I have copied over the contributing publishing steps from our other packages, replacing the links with those pointing to liferay-font-awesome testing if it works and it does 💪 