### PR TITLE
fix(local-npm): fix override of @liferay/npm-scripts once more

### DIFF
--- a/support/packages/local-npm/lib/index.js
+++ b/support/packages/local-npm/lib/index.js
@@ -100,9 +100,15 @@ function install(packageName) {
 			pkgJson.devDependencies[packageName] ||
 			'latest';
 
-		run('yarn', 'add', `${packageName}@${version}`, '--force', '-O', '-W');
-
-		run('yarn', 'install', '--update-checksums');
+		run(
+			'yarn',
+			'add',
+			`${packageName}@${version}`,
+			'--force',
+			'-O',
+			'-W',
+			'--update-checksums'
+		);
 	}
 	else {
 		console.log(`  👊 Forcing reinstallation of ${packageName}\n`);


### PR DESCRIPTION
Still trying to know what would be the correct sequence to make yarn
reinstall an existing version.

Note that this is forcing yarn to install a newer version with a different
checksum (to make the developer life easier) so it's natural that it
refuses to do it unless forced. That's why I've needed to change this so
many times.

Let's hope this is the last time...