### PR TITLE
feat(github-to-jira-sync-tool): Add the /status page that displays a message if the tool is running

### DIFF
--- a/support/packages/github-to-jira-synchronization-tool/src/Server.js
+++ b/support/packages/github-to-jira-synchronization-tool/src/Server.js
@@ -10,12 +10,30 @@ class Server {
 	constructor(secret, port) {
 		this.port = port;
 		this.webhooks = new Webhooks({secret});
+		this.responseHead = {
+			'Content-Type': 'application/json',
+		};
+
+		this.handleStatusRequest = (req, res) => {
+			if (req.url === '/status' && req.method === 'GET') {
+				res.writeHead(200, this.responseHead);
+				res.write('The server is running!');
+				res.end();
+			}
+			else {
+				res.writeHead(404, this.responseHead);
+				res.end(JSON.stringify({message: 'Route not found'}));
+			}
+		};
+
+		this.middleware = createNodeMiddleware(this.webhooks, {
+			onUnhandledRequest: (req, res) =>
+				this.handleStatusRequest(req, res),
+		});
 	}
 
 	start(events, onEvent) {
-		http.createServer(createNodeMiddleware(this.webhooks)).listen(
-			this.port
-		);
+		http.createServer(this.middleware).listen(this.port);
 
 		events.forEach((event) => {
 			this.webhooks.on(event, onEvent);


### PR DESCRIPTION
Fixes #867 

This PR utilizes [Octokit's middleware onUnhandledRequest](https://github.com/octokit/app.js/#createnodemiddlewareapp-options) to add a check for the `/status` page, displaying a simple message if it finds the url.