### PR TITLE
docs(gh-jira-sync): update user mapping

### DIFF
--- a/support/packages/github-to-jira-synchronization-tool/mapping-config.json
+++ b/support/packages/github-to-jira-synchronization-tool/mapping-config.json
@@ -17,7 +17,6 @@
 		"eduardoallegrini": "Eduardo.allegrini",
 		"izaera": "ivan.zaera",
 		"javierdearcos": "javier.dearcos",
-		"julien": "julien.castelain",
 		"kresimir-coko": "kresimir.coko",
 		"LuismiBarcos": "luismiguel.barco",
 		"marcoscv-work": "marcos.castro",


### PR DESCRIPTION
Remove Julien from the user mapping. This can be merged now and will hav effect the next time the tool is deployed. We don't need to do it now.