### PR TITLE
fix(portal-base): remove logic that checks for typescript

### DIFF
--- a/guidelines/dxp/liferay_global_event_bus.md
+++ b/guidelines/dxp/liferay_global_event_bus.md
@@ -128,19 +128,20 @@ Liferay.fire('someEvent', {
 ```
 
 ## Full Example
+
 Let's say you have two modules on the same page, A & B. In module A, you have the following code in your Javascript.
 
 ```jsx
 // Module A
 Liferay.on('my-custom-event', (data) => {
-    alert(data);
+	alert(data);
 });
 ```
 
 And then, in module B, we render a button with the code below
 
 ```jsx
-// JSX in Module B 
+// JSX in Module B
 <button onClick={() => Liferay.fire('my-custom-event', 'Hello!')}>
 	Say Hello!
 </button>

--- a/projects/js-toolkit/packages/portal-base/src/build/bundler2.ts
+++ b/projects/js-toolkit/packages/portal-base/src/build/bundler2.ts
@@ -97,15 +97,7 @@ function runBabel(project: Project): void {
 }
 
 function runCompiler(project: Project): void {
-	const dependencies = project.pkgJson['dependencies'] || {};
-	const devDependencies = project.pkgJson['devDependencies'] || {};
-
-	if (devDependencies['typescript'] || dependencies['typescript']) {
-		runTsc();
-	}
-	else {
-		runBabel(project);
-	}
+	runBabel(project);
 }
 
 function runBundler(): void {
@@ -124,10 +116,4 @@ function runBundler(): void {
 	print(info`Running {liferay-npm-bundler}...`);
 
 	spawn('node', [bundlerPath]);
-}
-
-function runTsc(): void {
-	print(info`Running {tsc} compiler...`);
-
-	spawn('npx', ['tsc']);
 }


### PR DESCRIPTION
Removing these bits as they didn't actually do anything for us.

We added it here, https://github.com/liferay/liferay-frontend-projects/commit/85b566505d4d0da05490857841b5f5c9082094a6, but I'm not sure we had a use case for adding.