### PR TITLE
feat(npm-scripts): support .scss files

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/utils/convertImportsToExternals.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/convertImportsToExternals.js
@@ -24,7 +24,7 @@ module.exports = function convertImportsToExternals(imports, backDirCount) {
 		packages.forEach((pkgName) => {
 			externals[
 				pkgName
-			] = `${backDirs}${provider}/__liferay__/exports/${flattenPkgName(
+			] = `${backDirs}${webContextPath}/__liferay__/exports/${flattenPkgName(
 				pkgName
 			)}.js`;
 		});

--- a/projects/npm-tools/packages/npm-scripts/src/utils/createEsm2AmdExportsBridges.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/createEsm2AmdExportsBridges.js
@@ -27,7 +27,7 @@ const getBndWebContextPath = require('./getBndWebContextPath');
 function createEsm2AmdExportsBridges(projectDir, buildConfig, manifest) {
 	const rootPkgJson = require(path.join(projectDir, 'package.json'));
 
-	const webContextPath = getBndWebContextPath() || `/${rootPkgJson.name}`;
+	const webContextPath = getBndWebContextPath(projectDir);
 
 	const {exports, output} = buildConfig;
 

--- a/projects/npm-tools/packages/npm-scripts/src/utils/createEsm2AmdIndexBridge.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/createEsm2AmdIndexBridge.js
@@ -21,7 +21,7 @@ function createEsm2AmdIndexBridge(projectDir, buildConfig, manifest) {
 
 	const {output} = buildConfig;
 
-	const webContextPath = getBndWebContextPath() || `/${pkgJson.name}`;
+	const webContextPath = getBndWebContextPath(projectDir);
 
 	//
 	// Compute the relative position of the bridge related to the real ES

--- a/projects/npm-tools/packages/npm-scripts/src/utils/getBndWebContextPath.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/getBndWebContextPath.js
@@ -6,8 +6,8 @@
 const fs = require('fs');
 const path = require('path');
 
-function getBndWebContextPath() {
-	const bndFile = path.resolve('bnd.bnd');
+function getBndWebContextPath(projectDir) {
+	const bndFile = path.resolve(projectDir, 'bnd.bnd');
 
 	if (fs.existsSync(bndFile)) {
 		const bnd = fs.readFileSync(bndFile, 'utf8');

--- a/projects/npm-tools/packages/npm-scripts/src/utils/runWebpackAsBundler.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/runWebpackAsBundler.js
@@ -94,6 +94,19 @@ function getIndexWebpackConfig(projectDir, buildConfig, babelConfig) {
 				},
 				{
 					exclude: /node_modules/,
+					test: /\.scss$/,
+					use: [
+						{
+							loader: require.resolve('./webpackScssLoader'),
+							options: {
+								buildConfig,
+								projectDir,
+							},
+						},
+					],
+				},
+				{
+					exclude: /node_modules/,
 					test: /\.tsx?/,
 					use: {
 						loader: require.resolve('babel-loader'),

--- a/projects/npm-tools/packages/npm-scripts/src/utils/webpackScssLoader.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/webpackScssLoader.js
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* eslint-disable @liferay/no-dynamic-require */
+
+const path = require('path');
+
+const getBndWebContextPath = require('./getBndWebContextPath');
+
+module.exports = function (_content, _map, _meta) {
+	const {resourcePath} = this;
+	const {buildConfig, projectDir} = this.getOptions();
+
+	const webContextPath = getBndWebContextPath(projectDir);
+
+	let urlPath = path.relative(buildConfig.input, resourcePath);
+
+	urlPath = urlPath.replace(/scss$/, 'css');
+
+	return `
+const link = document.createElement('link');
+link.setAttribute('rel', 'stylesheet');
+link.setAttribute('type', 'text/css');
+link.setAttribute(
+	'href', 
+	Liferay.ThemeDisplay.getPathContext() + '/o${webContextPath}/${urlPath}'
+);
+document.querySelector('head').appendChild(link);
+`;
+};


### PR DESCRIPTION
We need this to be able to migrate frontend-taglib-clay, for example. It includes source like:

```javascript
import from './perico.scss';
```

Which was previously handled by the bundler. Now we support it with a webpack loader.