### PR TITLE
feat(local-npm): add "get registry --bash-prompt" option

### DIFF
--- a/support/packages/local-npm/bin/local-npm.js
+++ b/support/packages/local-npm/bin/local-npm.js
@@ -23,7 +23,17 @@ const {argv} = yargs
 		'Set/get the current npm and yarn configured registries',
 		(yargs) =>
 			yargs
-				.command(['get', 'g'], 'Print current npm/yarn registry')
+				.command(
+					['get', 'g'],
+					'Print current npm/yarn registry',
+					(yargs) =>
+						yargs.option('bash-prompt', {
+							default: false,
+							describe:
+								'Get registry in a bash prompt friendly manner',
+							type: 'boolean',
+						})
+				)
 				.command(
 					['set', 's'],
 					'Set the npm/yarn repo to use',


### PR DESCRIPTION
This is to be able to use local-npm from bash's PROMPT_COMMAND to show an
emoji indicating which repo is active.

To use this from your .bashrc, simply configure PROMPT_COMMAND to something
like this:

export PROMPT_COMMAND='"$(local-npm registry get --bash-prompt) \u@\h:\w" " \\\$ "'