### PR TITLE
fix(npm-scripts): update path to node_modules in prettier script

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/contrib/prettier/prettier.js
+++ b/projects/npm-tools/packages/npm-scripts/contrib/prettier/prettier.js
@@ -1119,7 +1119,13 @@ function prepare(filepath) {
 		getPortalRoot(filepath) || getWorkspaceRoot(filepath);
 
 	if (portalOrWorkspaceRoot) {
-		const modules = path.join(portalRoot || workspaceRoot, 'node_modules');
+		const nodeModulesRoot = portalRoot ? 'modules' : '';
+
+		const modules = path.join(
+			portalRoot || workspaceRoot,
+			nodeModulesRoot,
+			'node_modules'
+		);
 
 		let scripts = path.join(modules, '@liferay/npm-scripts');
 


### PR DESCRIPTION
Looks like we had created a bug in a previous fix when we did some source formatting.

cc @kresimir-coko can you verify this works as expected for both workspaces and liferay-portal?