### PR TITLE
feat: bring ESM support to AMD loader

### DIFF
--- a/projects/amd-loader/src/loader/loader.js
+++ b/projects/amd-loader/src/loader/loader.js
@@ -361,6 +361,10 @@ export default class Loader {
 						moduleProperties.esModule = true;
 					}
 
+					if (moduleFlags.useESM) {
+						moduleProperties.useESM = true;
+					}
+
 					config.addModule(moduleName, moduleProperties);
 				});
 

--- a/projects/amd-loader/src/loader/module.js
+++ b/projects/amd-loader/src/loader/module.js
@@ -18,6 +18,7 @@ export default class Module {
 		this._dependencies = undefined;
 		this._factory = undefined;
 		this._implementation = {};
+		this._useESM = false;
 
 		this._map = undefined;
 
@@ -129,6 +130,16 @@ export default class Module {
 	}
 
 	/**
+	 * Flag informing that this module needs to be loaded using
+	 * <script type="module"> as opposed to plain <script>.
+	 *
+	 * This is necessary mainly for liferay-portal's ESM -> AMD bridges.
+	 */
+	get useESM() {
+		return this._useESM;
+	}
+
+	/**
 	 * Name of module
 	 * @param {string} name
 	 */
@@ -196,5 +207,15 @@ export default class Module {
 			value: esModule,
 			writable: true,
 		});
+	}
+
+	/**
+	 * Whether to load the module using <script type="module"> or plain regular
+	 * <script>.
+	 *
+	 * @param {useESM} boolean
+	 */
+	set useESM(useESM) {
+		this._useESM = useESM;
 	}
 }

--- a/projects/amd-loader/src/loader/script-loader.js
+++ b/projects/amd-loader/src/loader/script-loader.js
@@ -53,6 +53,7 @@ export default class ScriptLoader {
 	 * @param {object} modulesURL an object with two properties:
 	 * 					- modules: list of the modules which should be loaded
 	 * 					- url: the URL from which the modules should be loaded
+	 * 					- useESM: whether to use ESM semantics in the <script>
 	 * @return {Promise} a Promise which will be resolved as soon as the script
 	 * 						is loaded
 	 */
@@ -67,7 +68,10 @@ export default class ScriptLoader {
 
 			script.src = modulesURL.url;
 			script.async = false;
-			script.type = 'module';
+
+			if (modulesURL.useESM) {
+				script.type = 'module';
+			}
 
 			script.onload = script.onreadystatechange = () => {
 				if (

--- a/projects/amd-loader/src/loader/url-builder.js
+++ b/projects/amd-loader/src/loader/url-builder.js
@@ -26,6 +26,41 @@ export default class URLBuilder {
 	build(moduleNames) {
 		const config = this._config;
 
+		let result = [];
+
+		const jsModuleNames = moduleNames.filter((moduleName) => {
+			const module = config.getModule(moduleName);
+
+			return !module.useESM;
+		});
+
+		result = result.concat(this._build(jsModuleNames));
+
+		const esModuleNames = moduleNames.filter((moduleName) => {
+			const module = config.getModule(moduleName);
+
+			return module.useESM;
+		});
+
+		const esModulesURLs = this._build(esModuleNames).map((modulesURL) => ({
+			...modulesURL,
+			useESM: true,
+		}));
+
+		result = result.concat(esModulesURLs);
+
+		return result;
+	}
+
+	/**
+	 * Same as build() but doesn't split moduleNames into JS and ES modules.
+	 * @param {array} moduleNames list of modules for which URLs should be
+	 * 								created
+	 * @return {array} list of URLs
+	 */
+	_build(moduleNames) {
+		const config = this._config;
+
 		const bufferURL = [];
 		const modulesURL = [];
 		let result = [];

--- a/projects/npm-tools/packages/npm-scripts/src/utils/createEsm2AmdExportsBridges.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/createEsm2AmdExportsBridges.js
@@ -108,24 +108,25 @@ Liferay.Loader.define(
 			'utf8'
 		);
 
-		manifest.packages[srcPkgId] = manifest.packages[srcPkgId] || {
+		manifest.packages[pkgId] = manifest.packages[pkgId] || {
 			dest: {
 				dir: '.',
 				id: pkgId,
 				name: pkgJson.name,
 				version: pkgJson.version,
 			},
-			modules: {},
+			modules: {
+				'index.js': {
+					flags: {
+						esModule: true,
+						useESM: true,
+					},
+				},
+			},
 			src: {
 				id: srcPkgId,
 				name: srcPkgJson.name,
 				version: srcPkgJson.version,
-			},
-		};
-
-		manifest.packages[srcPkgId].modules['index.js'] = {
-			flags: {
-				esModule: true,
 			},
 		};
 	});

--- a/projects/npm-tools/packages/npm-scripts/src/utils/createEsm2AmdIndexBridge.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/createEsm2AmdIndexBridge.js
@@ -53,6 +53,7 @@ Liferay.Loader.define(
 	manifest.packages['/'].modules['index.js'] = {
 		flags: {
 			esModule: true,
+			useESM: true,
 		},
 	};
 }


### PR DESCRIPTION
This adds a new module flag named `useESM` that, when interpreted by the AMD loader, lets JS scripts be loaded with `<script type="module">`.

It is needed to fix [this error](https://github.com/liferay-frontend/liferay-portal/pull/2080#issuecomment-1090195656).