### PR TITLE
chore: disable automatic execution of new portal release workflow

### DIFF
--- a/.github/workflows/new-portal-release.yml
+++ b/.github/workflows/new-portal-release.yml
@@ -1,9 +1,6 @@
 name: New Portal Release
 
 on:
-    schedule:
-        # This happens daily
-        - cron: '0 0 * * *'
     workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
As per
https://liferay.slack.com/archives/C3JBR21HA/p1649757130879989?thread_ts=1649671231.502619&cid=C3JBR21HA
since we have adopted the new weekly release lifecycle, we will only
release new artifacts when needed, so there's no point in checking this
automatically for now.