### PR TITLE
feat(npm-scripts): add customBridges support

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
@@ -11,6 +11,7 @@ const path = require('path');
 let buildSass = require('../sass/build');
 let runTSC = require('../typescript/runTSC');
 const createAmd2EsmExportsBridges = require('../utils/createAmd2EsmExportsBridges');
+const createEsm2AmdCustomBridges = require('../utils/createEsm2AmdCustomBridges');
 const createEsm2AmdExportsBridges = require('../utils/createEsm2AmdExportsBridges');
 const createEsm2AmdIndexBridge = require('../utils/createEsm2AmdIndexBridge');
 const createTempFile = require('../utils/createTempFile');
@@ -207,6 +208,8 @@ module.exports = async function (...args) {
 			createEsm2AmdIndexBridge(CWD, BUILD_CONFIG, manifest);
 
 			createEsm2AmdExportsBridges(CWD, BUILD_CONFIG, manifest);
+
+			createEsm2AmdCustomBridges(CWD, BUILD_CONFIG, manifest);
 
 			fs.writeFileSync(
 				path.join(BUILD_CONFIG.output, 'manifest.json'),

--- a/projects/npm-tools/packages/npm-scripts/src/utils/createEsm2AmdCustomBridges.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/createEsm2AmdCustomBridges.js
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* eslint-disable @liferay/no-dynamic-require */
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Create .js files to make ES modules available as Liferay-AMD modules.
+ *
+ * @param {string} projectDir path to project's directory
+ * @param {object} buildConfig
+ * @param {object} manifest
+ */
+function createEsm2AmdCustomBridges(projectDir, buildConfig, manifest) {
+	const {customBridges, output} = buildConfig;
+
+	if (!customBridges) {
+		return;
+	}
+
+	const pkgJson = require(path.join(projectDir, 'package.json'));
+
+	Object.entries(customBridges).forEach(([amdModule, esModule]) => {
+		const bridgeSource = `
+import * as esModule from "${esModule}";
+
+Liferay.Loader.define(
+	"${pkgJson.name}@${pkgJson.version}/${amdModule}",
+	['module'], 
+	function (module) {
+		module.exports = esModule;
+	}
+);
+`;
+
+		const jsFilePath = amdModule + '.js';
+
+		fs.writeFileSync(
+			path.resolve(output, ...jsFilePath.split('/')),
+			bridgeSource,
+			'utf8'
+		);
+
+		manifest.packages['/'].modules[jsFilePath] = {
+			flags: {
+				esModule: true,
+				useESM: true,
+			},
+		};
+	});
+}
+
+module.exports = createEsm2AmdCustomBridges;


### PR DESCRIPTION
Custom bridges are (hopefully) temporary bridges from ESM to AMD that are
needed by legacy pre-AMD code to work.

So, once we remove the pre-AMD code and the AMD code, I guess we can remove
these...