### PR TITLE
fix(npm-scripts): Updates getPathContext to DXP's default value

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/jest/mocks/Liferay.js
+++ b/projects/npm-tools/packages/npm-scripts/src/jest/mocks/Liferay.js
@@ -108,7 +108,7 @@ const ThemeDisplay = {
 	/**
 	 * https://github.com/liferay/liferay-portal/blob/a4866af62eb89c69ee00d0e69dbe7ff092b50048/portal-web/docroot/html/common/themes/top_js.jspf#L226
 	 */
-	getPathContext: jest.fn(() => '/'),
+	getPathContext: jest.fn(() => ''),
 
 	/**
 	 * https://github.com/liferay/liferay-portal/blob/31073fb75fb0d3b309f9e0f921cb7a469aa2703d/portal-web/docroot/html/common/themes/top_js.jspf#L235


### PR DESCRIPTION
When running Liferay.ThemeDisplay.getPathContext() inside a DXP instance where we don't change pathContext, it returns an empty string instead of a slash :)

Context: https://github.com/liferay-frontend/liferay-portal/pull/2190#issuecomment-1124230621
Fixes https://github.com/liferay/liferay-frontend-projects/issues/929