### PR TITLE
LPS-153647 Remove rules that start with *

### DIFF
--- a/third-party/projects/alloy-ui/src/aui-button-item-deprecated/assets/aui-button-item-deprecated-core.css
+++ b/third-party/projects/alloy-ui/src/aui-button-item-deprecated/assets/aui-button-item-deprecated-core.css
@@ -6,22 +6,15 @@
     white-space: nowrap;
     width: auto;
     overflow: visible;
-    *padding: 2px 5px 2px 4px;
-    *width: 1;
 }
 .buttonitem-icon {
     display: inline-block;
     margin-top: -3px;
     vertical-align: middle;
-    /* IE6/7 */
-    *text-indent: 0;
-    *margin-top: 1px;
 }
 .buttonitem-label {
     line-height: 1em;
     display: inline-block;
-    /* IE6/7 */
-    *line-height: 1.4em;
 }
 .buttonitem-label {
     padding: 0 5px;
@@ -35,15 +28,9 @@
     box-sizing: content-box;
     -moz-box-sizing: content-box;
     -webkit-box-sizing: content-box;
-    /* IE6/7 */
-    *height: 24px;
-    *width: 24px;
 }
 .buttonitem-icon-only .buttonitem-icon {
     margin-top: 0;
-    /* IE6/7 */
-    *margin-top: -1px;
-    *margin-left: -1px;
 }
 .gecko .buttonitem-icon-only .buttonitem-icon {
     margin-top: -3px;

--- a/third-party/projects/alloy-ui/src/aui-skin-deprecated/css/aui-skin-deprecated.css
+++ b/third-party/projects/alloy-ui/src/aui-skin-deprecated/css/aui-skin-deprecated.css
@@ -32,9 +32,6 @@
     -webkit-transform: scale(0);
     -webkit-transform-origin-x: 0px;
     -webkit-transform-origin-y: 0px;
-    /*Change IE7 to using fixed*/
-    *position: fixed !important;
-    /*...And reset back to absolute for IE6*/
     _position: absolute !important;
 }
 .helper-force-offset {
@@ -414,10 +411,6 @@
     cursor: pointer;
     font-weight: bold;
     padding: 5px 10px 6px 7px;
-}
-/* IE7 and below */
- .button-input {
-    *padding: 4px 10px 3px 7px;
 }
 .field-content:after, .button-holder:after {
     clear: both;


### PR DESCRIPTION
LPS-153647 Remove rules that start with *, these rules are fixes for IE7 that we don't support anymore, and it should be removed as we have clients that complain about their accessibility tests failing cause of it