### PR TITLE
fix(alloy-ui): Append nodeContainer to boundingBox

### DIFF
--- a/third-party/projects/alloy-ui/src/aui-tree/js/aui-tree-node.js
+++ b/third-party/projects/alloy-ui/src/aui-tree/js/aui-tree-node.js
@@ -573,9 +573,8 @@ var TreeNode = A.Component.create({
                 if (!instance.get('expanded')) {
                     nodeContainer.hide();
                 }
-                if (instance.hasChildNodes()) {
-                    boundingBox.append(nodeContainer);
-                }
+
+                boundingBox.append(nodeContainer);
             }
 
             return boundingBox;


### PR DESCRIPTION
Fixes https://github.com/liferay/liferay-frontend-projects/issues/936
https://issues.liferay.com/browse/LPS-153679

Appending nodeContainer to boundingBox results in Wiki Tree to render from top to bottom. Building aui-tree, I was able to see it does not affect the behavior.

If there are any questions or comments please let me know.
Thank you.