### PR TITLE
LPS-153647 Remove IE6 IE7 IE8 hack classes no longer needed

### DIFF
--- a/third-party/projects/alloy-ui/src/aui-datatable/assets/aui-datatable-core-core.css
+++ b/third-party/projects/alloy-ui/src/aui-datatable/assets/aui-datatable-core-core.css
@@ -3,16 +3,6 @@
 */
 
 /* foundational CSS */
-.table-scrollable-x {
-    _overflow-x: hidden;
-    _position: relative;
-}
-
-.table-scrollable-y, .table-scrollable-y .table-x-scroller {
-    _overflow-y: hidden;
-    _position: relative;
-}
-
 .table-y-scroller-container {
     overflow-x: hidden;
     position: relative;

--- a/third-party/projects/alloy-ui/src/aui-datatable/assets/skins/sam/aui-datatable-core-skin.css
+++ b/third-party/projects/alloy-ui/src/aui-datatable/assets/skins/sam/aui-datatable-core-skin.css
@@ -23,7 +23,7 @@
 }
 
 .table-sort-indicator {
-    _background: url(sort-arrow-sprite-ie.png) no-repeat 0 0;
+
     background: url(sort-arrow-sprite.png) no-repeat 0 0;
 }
 

--- a/third-party/projects/alloy-ui/src/aui-scroller-deprecated/assets/aui-scroller-deprecated-core.css
+++ b/third-party/projects/alloy-ui/src/aui-scroller-deprecated/assets/aui-scroller-deprecated-core.css
@@ -17,7 +17,3 @@
 .scroller-horizontal .scroller-item {
     display: inline-block;
 }
-.ie7 .scroller-horizontal .scroller-item, .ie6 .scroller-horizontal .scroller-item {
-    display: inline;
-    zoom: 1;
-}

--- a/third-party/projects/alloy-ui/src/aui-skin-deprecated/css/aui-skin-deprecated.css
+++ b/third-party/projects/alloy-ui/src/aui-skin-deprecated/css/aui-skin-deprecated.css
@@ -27,12 +27,10 @@
     position: absolute !important;
     /* IE11 */
     -ms-transform: scale(0);
-    /*Webkit and IE7 let clipped content change the scroll height of the page*/
     /*Scale webkit to 0*/
     -webkit-transform: scale(0);
     -webkit-transform-origin-x: 0px;
     -webkit-transform-origin-y: 0px;
-    _position: absolute !important;
 }
 .helper-force-offset {
     display: block !important;
@@ -54,10 +52,6 @@
     display: block;
     height: 0;
 }
-.helper-clearfix {
-    /* IE7/IE6 */
-    zoom: 1;
-}
 .helper-zfix {
     width: 100%;
     height: 100%;
@@ -65,10 +59,6 @@
     left: 0;
     position: absolute;
     opacity: 0;
-    /* IE8 */
-    -ms-filter: alpha(opacity=0);
-    /* IE7/IE8(quirks) */
-    filter: alpha(opacity=0);
 }
 /* unselectable */
  .helper-unselectable, .helper-unselectable * {
@@ -89,9 +79,6 @@
 .layout {
     width: 100%;
 }
-.ie6 .layout-content, .ie7 .layout-content {
-    display: block;
-}
 .ltr .column, .rtl .column-last {
     float: left;
 }
@@ -109,10 +96,6 @@
     content:"";
     display: block;
     height: 0;
-}
-.layout-content {
-    /* IE7/IE6 */
-    zoom: 1;
 }
 .w1-20, .w5 {
     width: 5%;
@@ -395,10 +378,6 @@
     content:"";
     display: block;
     height: 0;
-}
-.field-row {
-    /* IE7/IE6 */
-    zoom: 1;
 }
 .button-holder {
     display: block;


### PR DESCRIPTION
I finally cleaned all the IE rules, I guess we should not keep them anymore as we don't support this browsers

I think we should first merge https://github.com/liferay/yui3/pull/26 and then merge this as well and release a new version including the yui3 changes