### PR TITLE
fix(npm-scripts): add aspect-ratio as known property to stylelint

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/config/stylelint.json
+++ b/projects/npm-tools/packages/npm-scripts/src/config/stylelint.json
@@ -44,7 +44,14 @@
 		"number-leading-zero": "always",
 		"number-no-trailing-zeros": true,
 		"property-case": "lower",
-		"property-no-unknown": true,
+		"property-no-unknown": [
+			true,
+			{
+				"ignoreProperties": [
+					"aspect-ratio"
+				]
+			}
+		],
 		"selector-pseudo-class-no-unknown": true,
 		"selector-pseudo-element-no-unknown": true,
 		"selector-type-no-unknown": true,

--- a/projects/npm-tools/packages/npm-scripts/src/config/stylelint.json
+++ b/projects/npm-tools/packages/npm-scripts/src/config/stylelint.json
@@ -47,9 +47,7 @@
 		"property-no-unknown": [
 			true,
 			{
-				"ignoreProperties": [
-					"aspect-ratio"
-				]
+				"ignoreProperties": ["aspect-ratio"]
 			}
 		],
 		"selector-pseudo-class-no-unknown": true,


### PR DESCRIPTION
I'm adding the `aspect-ratio` property to the list of known properties here, but I'm not sure if maybe upgrading stylelint would fix it too :thinking: 

Also, I haven't tested it, I wanted to first check if this would be the real solution.

![yolo](https://media.giphy.com/media/FuvVKU8Jxq1CE/giphy.gif)
