### PR TITLE
fix(alloy-ui): Fix LPS-157062 Calendar event date picker is messy and fail to publish

### DIFF
--- a/third-party/projects/alloy-ui/src/aui-datepicker/js/aui-datepicker-delegate.js
+++ b/third-party/projects/alloy-ui/src/aui-datepicker/js/aui-datepicker-delegate.js
@@ -168,6 +168,12 @@ DatePickerDelegate.prototype = {
     useInputNodeOnce: function(node) {
         var instance = this;
 
+        var popover = instance.getPopover();
+
+        if (!popover._getAttr('rendered') && node._node) {
+            popover.render(node._node.parentElement);
+        }
+
         if (!instance._userInteractionInProgress) {
             instance.useInputNode(node);
         }

--- a/third-party/projects/alloy-ui/src/aui-datepicker/js/aui-datepicker-popover.js
+++ b/third-party/projects/alloy-ui/src/aui-datepicker/js/aui-datepicker-popover.js
@@ -200,6 +200,7 @@ A.mix(DatePickerPopover.prototype, {
                 }
             ],
             position: 'bottom',
+            render: false,
             triggerShowEvent: 'click',
             triggerToggleEvent: null,
             visible: false

--- a/third-party/projects/alloy-ui/src/aui-datepicker/js/aui-datepicker.js
+++ b/third-party/projects/alloy-ui/src/aui-datepicker/js/aui-datepicker.js
@@ -256,10 +256,6 @@ A.mix(DatePickerBase.prototype, {
 
         popover.set('trigger', node);
 
-        if (node._node) {
-            popover.render(node._node.parentElement);
-        }
-
         if (!popover.get('visible')) {
             instance.set('activeInput', node);
 


### PR DESCRIPTION
fix(alloy-ui): Fix LPS-157062 Calendar event date picker is messy and fail to publish caused by LPS-153254 Render popover inside input parent node for better accessibility

Previous pull https://github.com/liferay/liferay-frontend-projects/pull/960

@bryceosterhaus We need to release a new version, in order to fix LPS-157062 Calendar event date picker is messy and fail to publish. Thanks!
