### PR TITLE
revert: AUI-1947 Fix odd behavior on Autosize iframe

### DIFF
--- a/third-party/projects/alloy-ui/src/aui-autosize/js/aui-autosize-iframe.js
+++ b/third-party/projects/alloy-ui/src/aui-autosize/js/aui-autosize-iframe.js
@@ -404,7 +404,7 @@ A.mix(AutosizeIframe, {
         if (iframeDoc && iframeWin.location.href !== 'about:blank') {
             var docEl = iframeDoc.documentElement;
 
-            var docOffsetHeight = (docEl && Math.max(docEl.offsetHeight, docEl.scrollHeight)) || 0;
+            var docOffsetHeight = (docEl && docEl.offsetHeight) || 0;
 
             var standardsMode = (iframeDoc.compatMode === 'CSS1Compat');
 


### PR DESCRIPTION
Dear Team,
Our customer finds out an issue related to the autosize iframe, this PR is to fix that issue.
The original request is https://issues.liferay.com/browse/LPP-46052 and the PTR is https://issues.liferay.com/browse/PTR-3286
AUI ticket to fix the issue:
https://issues.liferay.com/browse/AUI-3215
Please help me to verify this and leave comments if any.
Thank you very much,
Chi
