### PR TITLE
feat(liferay-npm-bundler): add new configuration "strictGlobalDependencies" which looks at the global bundler config to determine what dependencies to bundle instead of just the module's package.json

### DIFF
--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/index.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/project/index.ts
@@ -33,6 +33,8 @@ export interface PresetInfo {
 	name: string;
 }
 
+type AnyObject = {[key: string]: any};
+
 /**
  * Describes a standard JS Toolkit project.
  */
@@ -103,7 +105,7 @@ export class Project {
 	/**
 	 * Get global plugins configuration.
 	 */
-	get globalConfig(): object {
+	get globalConfig(): AnyObject {
 		const {_npmbundlerrc} = this;
 
 		return prop.get(_npmbundlerrc, 'config', {});
@@ -119,7 +121,7 @@ export class Project {
 	/**
 	 * Get project's parsed package.json file
 	 */
-	get pkgJson(): object {
+	get pkgJson(): AnyObject {
 		return this._pkgJson;
 	}
 
@@ -538,7 +540,11 @@ export class Project {
 	private _configFile: FilePath;
 
 	private _npmbundlerrc: object;
-	private _pkgJson: {dependencies: object; devDependencies: object};
+	private _pkgJson: {
+		dependencies: object;
+		devDependencies: object;
+		name: string;
+	};
 	private _pkgManager: PkgManager;
 
 	/** Info about preset in use */

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/__tests__/.gitignore
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/__tests__/.gitignore
@@ -1,0 +1,1 @@
+!__fixtures__/**/node_modules

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/__tests__/__fixtures__/project-strict-dependencies/.npmbundlerrc
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/__tests__/__fixtures__/project-strict-dependencies/.npmbundlerrc
@@ -1,0 +1,13 @@
+{
+	"config": {
+		"imports": {
+			"test-project-strict-dependencies": {
+				"test-project-dep-0": "*"
+			},
+			"some-other-project": {
+				"test-project-dep-1": "*"
+			}
+		},
+		"strictGlobalDependencies": true
+	}
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/__tests__/__fixtures__/project-strict-dependencies/node_modules/test-project-dep-0/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/__tests__/__fixtures__/project-strict-dependencies/node_modules/test-project-dep-0/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "test-project-dep-0",
+	"version": "1.0.0"
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/__tests__/__fixtures__/project-strict-dependencies/node_modules/test-project-dep-1/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/__tests__/__fixtures__/project-strict-dependencies/node_modules/test-project-dep-1/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "test-project-dep-1",
+	"version": "1.0.0"
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/__tests__/__fixtures__/project-strict-dependencies/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/__tests__/__fixtures__/project-strict-dependencies/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "test-project-strict-dependencies",
+	"version": "1.0.0",
+	"dependencies": {
+		"test-project-dep-0": "1.0.0",
+		"test-project-dep-1": "1.0.0"
+	}
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/__tests__/dependencies.test.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/__tests__/dependencies.test.js
@@ -10,7 +10,7 @@ import path from 'path';
 import {addPackageDependencies} from '../dependencies';
 
 expect.extend({
-	toMatchDependencies(deps, ...pkgIds) {
+	toMatchDependencies(deps, pkgIds, projectBaseName) {
 		const missingDeps = [];
 		const extraDeps = [];
 		const invalidDepFields = {};
@@ -26,7 +26,7 @@ expect.extend({
 				let pkgVersion;
 
 				if (pkgId === PkgDesc.ROOT_ID) {
-					pkgName = 'test-project';
+					pkgName = 'test-' + projectBaseName;
 					pkgVersion = '1.0.0';
 				}
 				else {
@@ -104,31 +104,52 @@ expect.extend({
 	},
 });
 
-beforeAll(() => {
-	project.loadFrom(path.join(__dirname, '__fixtures__', 'project'));
-});
-
 it('loads project dependencies correctly', () => {
+	const projectName = 'project';
+	project.loadFrom(path.join(__dirname, '__fixtures__', projectName));
+
 	const deps = addPackageDependencies({}, project.dir.asNative);
 
 	expect(deps).toMatchDependencies(
-		PkgDesc.ROOT_ID,
-		'test-project-dep-0@1.0.0',
-		'test-project-dep-1@1.0.0',
-		'test-project-dep-0@0.1.0'
+		[
+			PkgDesc.ROOT_ID,
+			'test-project-dep-0@1.0.0',
+			'test-project-dep-1@1.0.0',
+			'test-project-dep-0@0.1.0',
+		],
+		projectName
 	);
 });
 
 it('appends extra dependencies correctly', () => {
+	const projectName = 'project';
+	project.loadFrom(path.join(__dirname, '__fixtures__', projectName));
+
 	const deps = addPackageDependencies({}, project.dir.asNative, [
 		'stale-package',
 	]);
 
 	expect(deps).toMatchDependencies(
-		'stale-package@1.0.0',
-		PkgDesc.ROOT_ID,
-		'test-project-dep-0@1.0.0',
-		'test-project-dep-1@1.0.0',
-		'test-project-dep-0@0.1.0'
+		[
+			'stale-package@1.0.0',
+			PkgDesc.ROOT_ID,
+			'test-project-dep-0@1.0.0',
+			'test-project-dep-1@1.0.0',
+			'test-project-dep-0@0.1.0',
+		],
+		projectName
+	);
+});
+
+it('only bundles dependencies defined in global config', () => {
+	const projectName = 'project-strict-dependencies';
+
+	project.loadFrom(path.join(__dirname, '__fixtures__', projectName));
+
+	const deps = addPackageDependencies({}, project.dir.asNative, []);
+
+	expect(deps).toMatchDependencies(
+		[PkgDesc.ROOT_ID, 'test-project-dep-0@1.0.0'],
+		projectName
 	);
 });

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/dependencies.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/dependencies.js
@@ -56,6 +56,8 @@ export function addPackageDependencies(
 	dependencies = Object.keys(dependencies);
 	dependencies = dependencies.concat(extraDependencies);
 
+	dependencies = project.copy.filterDependencies(dependencies);
+
 	const dependencyDirs = dependencies
 		.filter(
 			(dependency) =>


### PR DESCRIPTION
This would allow us to specify all dependencies in our package.json files in DXP without necessarily having to bundle them.