### PR TITLE
feat(eslint-plugin): add ESLint rule to disable non-wrapped web storage API

### DIFF
--- a/projects/eslint-plugin/README.md
+++ b/projects/eslint-plugin/README.md
@@ -238,6 +238,7 @@ The bundled `@liferay/portal` plugin includes the following [rules](./rules/port
 -   [@liferay/portal/no-document-cookie](./rules/portal/docs/rules/no-document-cookie.md): Prevents saving and reading cookies without user consent.
 -   [@liferay/portal/no-explicit-extend](./rules/portal/docs/rules/no-explicit-extend.md): Prevents unnecessary extensions in ESLint and Babel configuration files.
 -   [@liferay/portal/no-global-fetch](./rules/portal/docs/rules/no-global-fetch.md): Prevents usage of unwrapped fetch to avoid possible issues related to security misconfiguration.
+-   [@liferay/portal/no-global-storage](./rules/portal/docs/rules/no-global-storage.md): Prevents usage of unwrapped local/sessionStorage to avoid storing data without consent.
 -   [@liferay/portal/no-loader-import-specifier](./rules/portal/docs/rules/no-loader-import-specifier.md): Ensures that ".scss" files imported via the loader are used only for side-effects.
 -   [@liferay/portal/no-localhost-reference](./rules/portal/docs/rules/no-localhost-reference.md): Enforces that no code should explicitly reference `localhost` as a literal value.
 -   [@liferay/portal/no-metal-plugins](./rules/portal/docs/rules/no-metal-plugins.md): Prevents usage of deprecated `metal-*` plugins and utilities.

--- a/projects/eslint-plugin/configs/portal.js
+++ b/projects/eslint-plugin/configs/portal.js
@@ -13,6 +13,7 @@ const config = {
 		'@liferay/portal/no-document-cookie': 'error',
 		'@liferay/portal/no-explicit-extend': 'error',
 		'@liferay/portal/no-global-fetch': 'error',
+		'@liferay/portal/no-global-storage': 'error',
 		'@liferay/portal/no-loader-import-specifier': 'error',
 		'@liferay/portal/no-localhost-reference': 'error',
 		'@liferay/portal/no-metal-plugins': 'error',

--- a/projects/eslint-plugin/rules/portal/docs/rules/no-global-storage.md
+++ b/projects/eslint-plugin/rules/portal/docs/rules/no-global-storage.md
@@ -8,11 +8,11 @@ Examples of **incorrect** code for this rule:
 
 ```js
 function doSomething() {
-	return localStorage.setItem("key", "value");
+	return localStorage.setItem('key', 'value');
 }
 
 function doSomething() {
-	return sessionStorage.setItem("key", "value");
+	return sessionStorage.setItem('key', 'value');
 }
 ```
 
@@ -22,15 +22,19 @@ Examples of **correct** code for this rule:
 import {localStorage, sessionStorage} from 'frontend-js-web';
 
 function doSomething() {
-	return localStorage.setItem("key", "value", localStorage.TYPES.NECESSARY);
+	return localStorage.setItem('key', 'value', localStorage.TYPES.NECESSARY);
 }
 
 function doSomethingElse() {
-	return sessionStorage.getItem("key", sessionStorage.TYPES.FUNCTIONAL)
+	return sessionStorage.getItem('key', sessionStorage.TYPES.FUNCTIONAL);
 }
 
 function doSomethingElse() {
-	return Liferay.Util.LocalStorage.setItem("key", "value", Liferay.Util.LocalStorage.TYPES.NECESSARY);
+	return Liferay.Util.LocalStorage.setItem(
+		'key',
+		'value',
+		Liferay.Util.LocalStorage.TYPES.NECESSARY
+	);
 }
 ```
 
@@ -38,4 +42,3 @@ function doSomethingElse() {
 
 -   [LPS-155901 Manage local and session storage from the cookie manager](https://issues.liferay.com/browse/LPS-155901)
 -   [Technical Draft](https://liferay.atlassian.net/l/cp/sWhsAp11)
-

--- a/projects/eslint-plugin/rules/portal/docs/rules/no-global-storage.md
+++ b/projects/eslint-plugin/rules/portal/docs/rules/no-global-storage.md
@@ -1,0 +1,41 @@
+# Disallow use of global web storage (no-global-storage)
+
+This rule guards against the direct use of the web storage API (`localStorage` and `sessionStorage`). To comply with data protection regulations, Liferay users can disable storing data that is not fundamental for the main purpose of the site to work, and that applies to web storage. Both the global Liferay object and the `frontend-js-web` module offer a thin wrapper around this API with added user consent enforcement.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+function doSomething() {
+	return localStorage.setItem("key", "value");
+}
+
+function doSomething() {
+	return sessionStorage.setItem("key", "value");
+}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import {localStorage, sessionStorage} from 'frontend-js-web';
+
+function doSomething() {
+	return localStorage.setItem("key", "value", localStorage.TYPES.NECESSARY);
+}
+
+function doSomethingElse() {
+	return sessionStorage.getItem("key", sessionStorage.TYPES.FUNCTIONAL)
+}
+
+function doSomethingElse() {
+	return Liferay.Util.LocalStorage.setItem("key", "value", Liferay.Util.LocalStorage.TYPES.NECESSARY);
+}
+```
+
+## Further Reading
+
+-   [LPS-155901 Manage local and session storage from the cookie manager](https://issues.liferay.com/browse/LPS-155901)
+-   [Technical Draft](https://liferay.atlassian.net/l/cp/sWhsAp11)
+

--- a/projects/eslint-plugin/rules/portal/index.js
+++ b/projects/eslint-plugin/rules/portal/index.js
@@ -9,6 +9,7 @@ module.exports = {
 	'portal/no-document-cookie': require('./lib/rules/no-document-cookie'),
 	'portal/no-explicit-extend': require('./lib/rules/no-explicit-extend'),
 	'portal/no-global-fetch': require('./lib/rules/no-global-fetch'),
+	'portal/no-global-storage': require('./lib/rules/no-global-storage'),
 	'portal/no-loader-import-specifier': require('./lib/rules/no-loader-import-specifier'),
 	'portal/no-localhost-reference': require('./lib/rules/no-localhost-reference'),
 	'portal/no-metal-plugins': require('./lib/rules/no-metal-plugins'),

--- a/projects/eslint-plugin/rules/portal/lib/rules/no-global-storage.js
+++ b/projects/eslint-plugin/rules/portal/lib/rules/no-global-storage.js
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const DESCRIPTION =
+	'Direct usage of the Web Storage APIs is discouraged in favour of our wrapped version that checks user consent status; import `localStorage` or `sessionStorage` from frontend-js-web instead';
+
+module.exports = {
+	create(context) {
+		let foundStorageImport = false;
+
+		const isStorageIdentifier = (node) => {
+			return (
+				node.type === 'Identifier' &&
+				(node.name === 'localStorage' || node.name === 'sessionStorage')
+			);
+		};
+
+		const isValidDefaultImport = (node) => {
+			return (
+				(node.source.value.endsWith('/local_storage') ||
+					node.source.value.endsWith('/session_storage')) &&
+				node.specifiers.find(
+					(specifier) => specifier.type === 'ImportDefaultSpecifier'
+				)
+			);
+		};
+
+		const isValidNamedImport = (node) => {
+			return (
+				node.source.value === 'frontend-js-web' &&
+				node.specifiers.find((specifier) => {
+					return (
+						specifier.imported &&
+						(specifier.imported.name === 'localStorage' ||
+							specifier.imported.name === 'sessionStorage')
+					);
+				})
+			);
+		};
+
+		return {
+			Identifier(node) {
+				if (
+					isStorageIdentifier(node) &&
+					!foundStorageImport
+				) {
+					context.report({
+						messageId: 'noGlobalStorage',
+						node,
+					});
+				}
+			},
+			ImportDeclaration(node) {
+				if (
+					node.source &&
+					node.source.type === 'Literal' &&
+					(isValidDefaultImport(node) || isValidNamedImport(node))
+				) {
+					foundStorageImport = true;
+				}
+			},
+		};
+	},
+
+	meta: {
+		docs: {
+			category: 'Best Practices',
+			description: DESCRIPTION,
+			recommended: false,
+			url: 'https://issues.liferay.com/browse/LPS-155901',
+		},
+		fixable: null,
+		messages: {
+			noGlobalStorage: DESCRIPTION,
+		},
+		schema: [],
+		type: 'problem',
+	},
+};

--- a/projects/eslint-plugin/rules/portal/lib/rules/no-global-storage.js
+++ b/projects/eslint-plugin/rules/portal/lib/rules/no-global-storage.js
@@ -42,10 +42,7 @@ module.exports = {
 
 		return {
 			Identifier(node) {
-				if (
-					isStorageIdentifier(node) &&
-					!foundStorageImport
-				) {
+				if (isStorageIdentifier(node) && !foundStorageImport) {
 					context.report({
 						messageId: 'noGlobalStorage',
 						node,

--- a/projects/eslint-plugin/rules/portal/tests/lib/rules/no-global-storage.js
+++ b/projects/eslint-plugin/rules/portal/tests/lib/rules/no-global-storage.js
@@ -18,6 +18,7 @@ const ruleTester = new MultiTester(parserOptions);
 ruleTester.run('no-global-storage', rule, {
 	invalid: [
 		{
+
 			// As a global localStorage without an import.
 
 			code: `
@@ -33,6 +34,7 @@ ruleTester.run('no-global-storage', rule, {
 			],
 		},
 		{
+
 			// As a global sessionStorage without an import.
 
 			code: `
@@ -51,6 +53,7 @@ ruleTester.run('no-global-storage', rule, {
 
 	valid: [
 		{
+
 			// Named import from frontend-js-web
 
 			code: `
@@ -62,6 +65,7 @@ ruleTester.run('no-global-storage', rule, {
              `,
 		},
 		{
+
 			// Named import from frontend-js-web
 
 			code: `
@@ -73,6 +77,7 @@ ruleTester.run('no-global-storage', rule, {
              `,
 		},
 		{
+
 			// Unnamed import from '../local_storage'
 
 			code: `
@@ -84,6 +89,7 @@ ruleTester.run('no-global-storage', rule, {
              `,
 		},
 		{
+
 			// Unnamed import from '../session_storage'
 
 			code: `
@@ -95,6 +101,7 @@ ruleTester.run('no-global-storage', rule, {
              `,
 		},
 		{
+
 			// Unnamed import from './util/local_storage'
 
 			code: `
@@ -106,6 +113,7 @@ ruleTester.run('no-global-storage', rule, {
              `,
 		},
 		{
+
 			// Unnamed import from './util/session_storage'
 
 			code: `
@@ -117,6 +125,7 @@ ruleTester.run('no-global-storage', rule, {
              `,
 		},
 		{
+
 			// Namespaced from Liferay.Util
 
 			code: `
@@ -126,6 +135,7 @@ ruleTester.run('no-global-storage', rule, {
              `,
 		},
 		{
+
 			// Namespaced from Liferay.Util
 
 			code: `

--- a/projects/eslint-plugin/rules/portal/tests/lib/rules/no-global-storage.js
+++ b/projects/eslint-plugin/rules/portal/tests/lib/rules/no-global-storage.js
@@ -1,0 +1,138 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const MultiTester = require('../../../../../scripts/MultiTester');
+const rule = require('../../../lib/rules/no-global-storage');
+
+const parserOptions = {
+	parserOptions: {
+		ecmaVersion: 6,
+		sourceType: 'module',
+	},
+};
+
+const ruleTester = new MultiTester(parserOptions);
+
+ruleTester.run('no-global-storage', rule, {
+	invalid: [
+		{
+			// As a global localStorage without an import.
+
+			code: `
+                function doSomething() {
+                    return localStorage.setItem("key", "value");
+                }
+             `,
+			errors: [
+				{
+					messageId: 'noGlobalStorage',
+					type: 'Identifier',
+				},
+			],
+		},
+		{
+			// As a global sessionStorage without an import.
+
+			code: `
+                function doSomething() {
+                    return sessionStorage.setItem("key", "value");
+                }
+             `,
+			errors: [
+				{
+					messageId: 'noGlobalStorage',
+					type: 'Identifier',
+				},
+			],
+		},
+	],
+
+	valid: [
+		{
+			// Named import from frontend-js-web
+
+			code: `
+                import {localStorage} from 'frontend-js-web';
+
+                function doSomething() {
+                    return localStorage.setItem("key", "value", localStorage.TYPES.NECESSARY);
+                }
+             `,
+		},
+		{
+			// Named import from frontend-js-web
+
+			code: `
+                import {sessionStorage} from 'frontend-js-web';
+                
+                function doSomething() {
+                    return sessionStorage.getItem("key", sessionStorage.TYPES.FUNCTIONAL)
+                }
+             `,
+		},
+		{
+			// Unnamed import from '../local_storage'
+
+			code: `
+                 import localStorage from '../local_storage';
+ 
+                 function doSomething() {
+                     return localStorage.setItem("key", "value", localStorage.TYPES.NECESSARY);
+                 }
+             `,
+		},
+		{
+			// Unnamed import from '../session_storage'
+
+			code: `
+                 import sessionStorage from '../session_storage';
+ 
+                 function doSomething() {
+                     return sessionStorage.setItem("key", "value", sessionStorage.TYPES.NECESSARY);
+                 }
+             `,
+		},
+		{
+			// Unnamed import from './util/local_storage'
+
+			code: `
+                 import localStorage from './util/local_storage';
+ 
+                 function doSomething() {
+                     return localStorage.setItem("key", "value", localStorage.TYPES.NECESSARY);
+                 }
+             `,
+		},
+		{
+			// Unnamed import from './util/session_storage'
+
+			code: `
+                 import sessionStorage from './util/session_storage';
+ 
+                 function doSomething() {
+                     return sessionStorage.setItem("key", "value", sessionStorage.TYPES.NECESSARY);
+                 }
+             `,
+		},
+		{
+			// Namespaced from Liferay.Util
+
+			code: `
+                 function doSomething() {
+                     return Liferay.Util.LocalStorage.getItem("key", Liferay.Util.LocalStorage.TYPES.NECESSARY);
+                 }
+             `,
+		},
+		{
+			// Namespaced from Liferay.Util
+
+			code: `
+                 function doSomething() {
+                     return Liferay.Util.SessionStorage.setItem("key", "value", Liferay.Util.SessionStorage.TYPES.NECESSARY);
+                 }
+             `,
+		},
+	],
+});


### PR DESCRIPTION
### References
- [LPS-158441](https://issues.liferay.com/browse/LPS-158441)

### What is the goal?
* Add an ESLint rule to prevent usages of `localStorage` and `sessionStorage`
   * In [LPS-155901](https://issues.liferay.com/browse/LPS-155901), we added a JS API to enforce user consent when managing web storage in DXP. This PR adds an ESLint rule to prevent using the global `localStorage` and `sessionStorage` objects, redirecting devs to the new wrapped ones.
   
### What does it look like?

![](https://user-images.githubusercontent.com/6642927/192503666-c07c8e3f-541b-4f0b-9d98-4c8479212bfd.png)

### How to replicate
* Tested this in DXP following these steps:
   * Run `yarn link` in `liferay-frontend-projects/projects/eslint-plugin`
   * Run `yarn link “@liferay/eslint-plugin”` in `liferay-portal/modules`
   * Run `yarn checkFormat`