### PR TITLE
fix(js-toolkit): stop throwing an error and instead return empty json

### DIFF
--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/__tests__/alias.test.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/__tests__/alias.test.ts
@@ -75,10 +75,10 @@ describe('loadAliases', () => {
 		).not.toThrow();
 	});
 
-	it('throws when package.json is not valid JSON', () => {
-		expect(() =>
+	it('returns empty json when package.json is not valid JSON', () => {
+		expect(
 			loadAliases(fixturesDir.join('invalid.json'), ['browser'])
-		).toThrow();
+		).toMatchObject({});
 	});
 
 	it('caches calls correctly', () => {

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/alias.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-build-tools-common/src/alias.ts
@@ -154,10 +154,9 @@ function safeReadJsonSync(pkgJsonFile: FilePath): object {
 		return readJsonSync(pkgJsonFile.asNative);
 	}
 	catch (err) {
-		if (err.code === 'ENOENT') {
-			return {};
-		}
 
-		throw err;
+		// Always return some sort of JSON if reading the file fails
+
+		return {};
 	}
 }


### PR DESCRIPTION
Fixes issue where bundler parses all package.json, even invalid ones.

See internal convo for context: https://liferay.slack.com/archives/C3JBR21HA/p1664782682850919