### PR TITLE
feat: make liferay-cli use relative imports to obtain React from portal

### DIFF
--- a/target-platforms/packages/dxp-7.4/liferay.json
+++ b/target-platforms/packages/dxp-7.4/liferay.json
@@ -1,15 +1,15 @@
 {
 	"build": {
 		"options": {
-			"externals": [
-				"classnames",
-				"formik",
-				"prop-types",
-				"react",
-				"react-dnd",
-				"react-dnd-html5-backend",
-				"react-dom"
-			]
+			"externals": {
+				"classnames": "/o/frontend-js-react-web/__liferay__/exports/classnames.js",
+				"formik": "/o/frontend-js-react-web/__liferay__/exports/formik.js",
+				"prop-types": "/o/frontend-js-react-web/__liferay__/exports/prop-types.js",
+				"react": "/o/frontend-js-react-web/__liferay__/exports/react.js",
+				"react-dnd": "/o/frontend-js-react-web/__liferay__/exports/react-dnd.js",
+				"react-dnd-html5-backend": "/o/frontend-js-react-web/__liferay__/exports/react-dnd-html5-backend.js",
+				"react-dom": "/o/frontend-js-react-web/__liferay__/exports/react-dom.js"
+			}
 		}
 	}
 }

--- a/target-platforms/packages/portal-7.4/liferay.json
+++ b/target-platforms/packages/portal-7.4/liferay.json
@@ -1,15 +1,15 @@
 {
 	"build": {
 		"options": {
-			"externals": [
-				"classnames",
-				"formik",
-				"prop-types",
-				"react",
-				"react-dnd",
-				"react-dnd-html5-backend",
-				"react-dom"
-			]
+			"externals": {
+				"classnames": "/o/frontend-js-react-web/__liferay__/exports/classnames.js",
+				"formik": "/o/frontend-js-react-web/__liferay__/exports/formik.js",
+				"prop-types": "/o/frontend-js-react-web/__liferay__/exports/prop-types.js",
+				"react": "/o/frontend-js-react-web/__liferay__/exports/react.js",
+				"react-dnd": "/o/frontend-js-react-web/__liferay__/exports/react-dnd.js",
+				"react-dnd-html5-backend": "/o/frontend-js-react-web/__liferay__/exports/react-dnd-html5-backend.js",
+				"react-dom": "/o/frontend-js-react-web/__liferay__/exports/react-dom.js"
+			}
 		}
 	}
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-164784

----

In the future we may want to let the user choose, but for now this should be OK.

The goal of this task is to get rid of needing to use importmaps to make the project work at runtime. This way, we don't need to rely on the importmaps shim and we can ship it turned off by default.

We want to do this because, when using the ES module shims, all ES modules must be routed through the shim to avoid double execution problems like the ones described in https://github.com/liferay-frontend/liferay-portal/pull/2749#issuecomment-1261813605.
