### PR TITLE
fix(npm-scripts): update ts generation

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/config/tsconfig-base.json
+++ b/projects/npm-tools/packages/npm-scripts/src/config/tsconfig-base.json
@@ -18,7 +18,7 @@
 		"tsBuildInfoFile": "tmp/tsconfig.tsbuildinfo",
 		"typeRoots": []
 	},
-	"include": ["src/**/*"],
 	"exclude": ["test/**/*", "**/__tests__/**"],
+	"include": ["src/**/*"],
 	"references": []
 }

--- a/projects/npm-tools/packages/npm-scripts/src/config/tsconfig-base.json
+++ b/projects/npm-tools/packages/npm-scripts/src/config/tsconfig-base.json
@@ -18,6 +18,7 @@
 		"tsBuildInfoFile": "tmp/tsconfig.tsbuildinfo",
 		"typeRoots": []
 	},
-	"include": ["src/**/*", "test/**/*"],
+	"include": ["src/**/*"],
+	"exclude": ["test/**/*", "**/__tests__/**"],
 	"references": []
 }

--- a/projects/npm-tools/packages/npm-scripts/src/typescript/runTSC.js
+++ b/projects/npm-tools/packages/npm-scripts/src/typescript/runTSC.js
@@ -71,9 +71,9 @@ async function runTSC() {
 }
 
 /**
- * Removes stale defintion files when the source file no longer exists.
+ * Removes stale definition files when the source file no longer exists.
  * For example, if you rename or remove a file, we need to make sure and
- * remove the old stale defintions.
+ * remove the old stale definitions.
  */
 function removeStaleFile(filepath, baseDir) {
 	const relativePath = filepath.replace(path.normalize(baseDir) + '/', '');
@@ -94,6 +94,7 @@ function removeStaleFile(filepath, baseDir) {
 			? sourceFileTS
 			: sourceFileTSX;
 
+		// eslint-disable-next-line no-console
 		console.log('Source file does not exist. Removing: ', sourceFilePath);
 
 		fs.unlinkSync(sourceFilePath);

--- a/projects/npm-tools/packages/npm-scripts/test/typescript/configureTypeScript.js
+++ b/projects/npm-tools/packages/npm-scripts/test/typescript/configureTypeScript.js
@@ -165,7 +165,7 @@ describe('configureTypeScript()', () => {
 		it('returns the config', () => {
 			const config = {
 				...BASE_CONFIG,
-				'@generated': 'bcba4b119d3cf7bdcb52b5d3d5a71d24f5290ca2',
+				'@generated': '3d2807d09e607faff97806d68355e6f9a8c32674',
 				'compilerOptions': {
 					...BASE_CONFIG.compilerOptions,
 					typeRoots: [


### PR DESCRIPTION
- Removes stale .d.ts files that don't have a source file
- Removes generating types for files in unit tests