### PR TITLE
fix(npm-scripts): don't fail when there's no main entry in build config

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
@@ -205,7 +205,9 @@ module.exports = async function (...args) {
 				};
 			}
 
-			createEsm2AmdIndexBridge(CWD, BUILD_CONFIG, manifest);
+			if (BUILD_CONFIG.main) {
+				createEsm2AmdIndexBridge(CWD, BUILD_CONFIG, manifest);
+			}
 
 			createEsm2AmdExportsBridges(CWD, BUILD_CONFIG, manifest);
 

--- a/projects/npm-tools/packages/npm-scripts/src/utils/createEsm2AmdIndexBridge.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/createEsm2AmdIndexBridge.js
@@ -50,6 +50,10 @@ Liferay.Loader.define(
 
 	fs.writeFileSync(path.resolve(output, 'index.js'), bridgeSource, 'utf8');
 
+	manifest.packages = manifest.packages ?? {};
+	manifest.packages['/'] = manifest.packages['/'] ?? {};
+	manifest.packages['/'].modules = manifest.packages['/'].modules ?? {};
+
 	manifest.packages['/'].modules['index.js'] = {
 		flags: {
 			esModule: true,


### PR DESCRIPTION
This is needed for https://issues.liferay.com/browse/LPS-165925