### PR TITLE
feat(npm-scripts): create caching mechanism for build script

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/__fixtures__/utils/buildArtifacts/modules/apps/some/project/package.json
+++ b/projects/npm-tools/packages/npm-scripts/__fixtures__/utils/buildArtifacts/modules/apps/some/project/package.json
@@ -1,0 +1,3 @@
+{
+	"name": "some-project"
+}

--- a/projects/npm-tools/packages/npm-scripts/__fixtures__/utils/buildArtifacts/modules/yarn.lock
+++ b/projects/npm-tools/packages/npm-scripts/__fixtures__/utils/buildArtifacts/modules/yarn.lock
@@ -1,0 +1,2 @@
+# Not a real yarn.lock, but needed in order for code to identify
+# the top-level "modules/" root.

--- a/projects/npm-tools/packages/npm-scripts/src/sass/build.js
+++ b/projects/npm-tools/packages/npm-scripts/src/sass/build.js
@@ -85,31 +85,6 @@ function copyFile(filePath, baseDir, outputDir) {
 
 const SASS_DIR = '.sass-cache';
 
-function isModified(filePaths, buildDirectory, baseDir) {
-	for (const filePath of filePaths) {
-		const subDirectory = path.dirname(path.relative(baseDir, filePath));
-
-		const cachedFile = path.join(
-			buildDirectory,
-			subDirectory,
-			path.basename(filePath)
-		);
-
-		if (!fs.existsSync(cachedFile)) {
-			return true;
-		}
-
-		const cachedFileStats = fs.statSync(cachedFile);
-		const srcFileStats = fs.statSync(filePath);
-
-		if (cachedFileStats.mtime.getTime() !== srcFileStats.mtime.getTime()) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
 function appendTimestamps(contentBuffer, timestamp) {
 	let contentString = contentBuffer.toString();
 
@@ -164,12 +139,6 @@ function main(
 
 	if (!entryFiles.length) {
 		log(`BUILD SASS: No scss files found.`);
-
-		return;
-	}
-
-	if (!isModified([...entryFiles, ...partials], outputDir, baseDir)) {
-		log(`BUILD SASS: Skipped, no changes detected.`);
 
 		return;
 	}

--- a/projects/npm-tools/packages/npm-scripts/src/utils/buildArtifacts.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/buildArtifacts.js
@@ -1,0 +1,191 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const expandGlobs = require('./expandGlobs');
+const findRoot = require('./findRoot');
+
+const CWD = process.cwd();
+const root = findRoot();
+
+const npmScriptsCacheDir = path.join(root, '.npmscripts', 'build');
+const artifactCache = path.join(npmScriptsCacheDir, 'artifacts');
+
+const BUILD_INFO_FILE_NAME = 'buildinfo.json';
+
+/**
+ * Creates a unique has for the content of a file
+ *
+ * @param {string} filePath path to file
+ * @return {string} hash of file content
+ */
+const hashFile = (filePath) => {
+	const fileBuffer = fs.readFileSync(filePath);
+	const hashSum = crypto.createHash('sha1');
+	hashSum.update(fileBuffer);
+
+	return hashSum.digest('hex');
+};
+
+/**
+ * Determines if the cache found in `modules/.npmscripts/build` is valid
+ *
+ * @param {string} moduleName name found in package.json of module
+ * @param {Array.<string>} srcFiles paths to source files
+ * @return {boolean} whether cache is valid or not
+ */
+function isCacheValid(moduleName, srcFiles) {
+	let moduleBuildInfo;
+
+	const moduleBuildInfoPath = path.join(
+		artifactCache,
+		moduleName,
+		BUILD_INFO_FILE_NAME
+	);
+
+	if (!fs.existsSync(moduleBuildInfoPath)) {
+		return false;
+	}
+
+	try {
+		moduleBuildInfo = JSON.parse(
+			fs.readFileSync(moduleBuildInfoPath, 'utf8')
+		);
+	}
+	catch (error) {
+		return false;
+	}
+
+	if (!moduleBuildInfo) {
+		return false;
+	}
+
+	const previousSrcFiles = Object.keys(moduleBuildInfo.srcFiles);
+
+	// Check if any source files have been added or removed
+
+	if (srcFiles.length !== previousSrcFiles.length) {
+		return false;
+	}
+
+	// Check if source files content has changed
+
+	for (const prevSrcFilePath of previousSrcFiles) {
+		if (
+			!fs.existsSync(prevSrcFilePath) ||
+			moduleBuildInfo.srcFiles[prevSrcFilePath] !==
+				hashFile(prevSrcFilePath)
+		) {
+			return false;
+		}
+	}
+
+	// Check if the built files still exist from last build
+
+	const previousBuiltFiles = Object.keys(moduleBuildInfo.builtFiles);
+
+	for (const prevBuiltFilePath of previousBuiltFiles) {
+		if (
+			!fs.existsSync(prevBuiltFilePath) ||
+			moduleBuildInfo.srcFiles[prevBuiltFilePath] !==
+				hashFile(prevBuiltFilePath)
+		) {
+			restoreBuildArtifact(prevBuiltFilePath, moduleName);
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Sets the cache info and copies over files
+ *
+ * @param {string} moduleName name found in package.json of module
+ * @param {Array.<string>} srcFiles paths to source files
+ * @param {string} output relative path to where the source files are build
+ */
+function setCache(moduleName, srcFiles, output) {
+	const moduleArtifactCachePath = path.join(artifactCache, moduleName);
+
+	if (!fs.existsSync(moduleArtifactCachePath)) {
+		fs.mkdirSync(moduleArtifactCachePath, {recursive: true});
+	}
+
+	const builtFiles = expandGlobs([output + '/**'], []);
+
+	const moduleBuildInfo = {
+		builtFiles: builtFiles.reduce(
+			(acc, filePath) => ({...acc, [filePath]: hashFile(filePath)}),
+			{}
+		),
+		srcFiles: srcFiles.reduce(
+			(acc, filePath) => ({...acc, [filePath]: hashFile(filePath)}),
+			{}
+		),
+	};
+
+	fs.writeFileSync(
+		path.join(moduleArtifactCachePath, BUILD_INFO_FILE_NAME),
+		JSON.stringify(moduleBuildInfo)
+	);
+
+	storeBuildArtifacts(builtFiles, moduleName);
+}
+
+/**
+ * Restores file from the cache to the build directory
+ *
+ * @param {string} filePath path of file in module
+ * @param {string} moduleName name found in package.json of module
+ */
+function restoreBuildArtifact(filePath, moduleName) {
+	const artifactPath = path.join(artifactCache, moduleName, filePath);
+
+	if (fs.existsSync(artifactPath)) {
+		const buildPath = path.join(CWD, filePath);
+
+		const buildDir = path.dirname(buildPath);
+
+		if (!fs.existsSync(buildDir)) {
+			fs.mkdirSync(buildDir, {recursive: true});
+		}
+
+		fs.copyFileSync(artifactPath, buildPath);
+	}
+}
+
+/**
+ * Stores build artifacts to the cache directory
+ *
+ * @param {Array.<string>} files paths to build artifacts
+ * @param {string} moduleName name found in package.json of module
+ */
+function storeBuildArtifacts(files, moduleName) {
+	const artifactDir = path.join(artifactCache, moduleName);
+
+	for (const filePath of files) {
+		const fullFilePath = path.join(CWD, filePath);
+
+		if (fs.existsSync(fullFilePath)) {
+			const artifactPath = path.join(artifactDir, filePath);
+
+			const dir = path.dirname(artifactPath);
+
+			if (!fs.existsSync(dir)) {
+				fs.mkdirSync(dir, {recursive: true});
+			}
+
+			fs.copyFileSync(fullFilePath, artifactPath);
+		}
+	}
+}
+
+module.exports = {
+	isCacheValid,
+	setCache,
+};

--- a/projects/npm-tools/packages/npm-scripts/test/sass/build.js
+++ b/projects/npm-tools/packages/npm-scripts/test/sass/build.js
@@ -15,11 +15,6 @@ jest.mock('../../src/utils/log');
 const FIXTURES = path.resolve(__dirname, '../../__fixtures__/sass');
 const OUTPUT_SASS_DIR = '.sass-cache';
 
-const pause = (ms) =>
-	new Promise((resolve) => {
-		setTimeout(resolve, ms);
-	});
-
 describe('sass', () => {
 	let tempDir;
 	let tempSassDir;
@@ -104,79 +99,79 @@ describe('sass', () => {
 	`);
 	});
 
-	it('rebuilds sass if any file has been modified', async () => {
-		const mainScssFilePath = path.join(tempDir, 'modified.scss');
+	// it('rebuilds sass if any file has been modified', async () => {
+	// 	const mainScssFilePath = path.join(tempDir, 'modified.scss');
 
-		expect(fs.existsSync(mainScssFilePath)).toBe(false);
+	// 	expect(fs.existsSync(mainScssFilePath)).toBe(false);
 
-		buildSass(path.join(FIXTURES, 'modified'), {
-			outputDir: tempDir,
-		});
+	// 	buildSass(path.join(FIXTURES, 'modified'), {
+	// 		outputDir: tempDir,
+	// 	});
 
-		expect(fs.existsSync(mainScssFilePath)).toBe(true);
+	// 	expect(fs.existsSync(mainScssFilePath)).toBe(true);
 
-		const fileCreationTime1 = fs.statSync(mainScssFilePath).ctimeMs;
+	// 	const fileCreationTime1 = fs.statSync(mainScssFilePath).ctimeMs;
 
-		await pause(100);
+	// 	await pause(100);
 
-		buildSass(path.join(FIXTURES, 'modified'), {
-			outputDir: tempDir,
-		});
+	// 	buildSass(path.join(FIXTURES, 'modified'), {
+	// 		outputDir: tempDir,
+	// 	});
 
-		const fileCreationTime2 = fs.statSync(mainScssFilePath).ctimeMs;
+	// 	const fileCreationTime2 = fs.statSync(mainScssFilePath).ctimeMs;
 
-		expect(fileCreationTime2).toBe(fileCreationTime1);
+	// 	expect(fileCreationTime2).toBe(fileCreationTime1);
 
-		fs.unlinkSync(mainScssFilePath);
+	// 	fs.unlinkSync(mainScssFilePath);
 
-		await pause(100);
+	// 	await pause(100);
 
-		buildSass(path.join(FIXTURES, 'modified'), {
-			outputDir: tempDir,
-		});
+	// 	buildSass(path.join(FIXTURES, 'modified'), {
+	// 		outputDir: tempDir,
+	// 	});
 
-		const fileCreationTime3 = fs.statSync(mainScssFilePath).ctimeMs;
+	// 	const fileCreationTime3 = fs.statSync(mainScssFilePath).ctimeMs;
 
-		expect(fileCreationTime3).toBeGreaterThan(fileCreationTime1);
-		expect(fileCreationTime3).toBeGreaterThan(fileCreationTime2);
-	});
+	// 	expect(fileCreationTime3).toBeGreaterThan(fileCreationTime1);
+	// 	expect(fileCreationTime3).toBeGreaterThan(fileCreationTime2);
+	// });
 
-	it('rebuilds sass if partial has been modified', async () => {
-		const mainScssFilePath = path.join(tempDir, 'partial.scss');
+	// it('rebuilds sass if partial has been modified', async () => {
+	// 	const mainScssFilePath = path.join(tempDir, 'partial.scss');
 
-		expect(fs.existsSync(mainScssFilePath)).toBe(false);
+	// 	expect(fs.existsSync(mainScssFilePath)).toBe(false);
 
-		buildSass(path.join(FIXTURES, 'partial'), {
-			outputDir: tempDir,
-		});
+	// 	buildSass(path.join(FIXTURES, 'partial'), {
+	// 		outputDir: tempDir,
+	// 	});
 
-		expect(fs.existsSync(mainScssFilePath)).toBe(true);
+	// 	expect(fs.existsSync(mainScssFilePath)).toBe(true);
 
-		const fileCreationTime1 = fs.statSync(mainScssFilePath).ctimeMs;
+	// 	const fileCreationTime1 = fs.statSync(mainScssFilePath).ctimeMs;
 
-		await pause(100);
+	// 	await pause(100);
 
-		buildSass(path.join(FIXTURES, 'partial'), {
-			outputDir: tempDir,
-		});
+	// 	buildSass(path.join(FIXTURES, 'partial'), {
+	// 		outputDir: tempDir,
+	// 	});
 
-		const fileCreationTime2 = fs.statSync(mainScssFilePath).ctimeMs;
+	// 	const fileCreationTime2 = fs.statSync(mainScssFilePath).ctimeMs;
 
-		expect(fileCreationTime2).toBe(fileCreationTime1);
+	// 	expect(fileCreationTime2).toBe(fileCreationTime1);
 
-		fs.unlinkSync(path.join(tempDir, '_some-partial.scss'));
+	// 	fs.unlinkSync(path.join(tempDir, '_some-partial.scss'));
 
-		await pause(100);
+	// 	await pause(100);
 
-		buildSass(path.join(FIXTURES, 'partial'), {
-			outputDir: tempDir,
-		});
+	// 	buildSass(path.join(FIXTURES, 'partial'), {
+	// 		outputDir: tempDir,
+	// 	});
 
-		const fileCreationTime3 = fs.statSync(mainScssFilePath).ctimeMs;
+	// 	const fileCreationTime3 = fs.statSync(mainScssFilePath).ctimeMs;
 
-		expect(fileCreationTime3).toBeGreaterThan(fileCreationTime1);
-		expect(fileCreationTime3).toBeGreaterThan(fileCreationTime2);
-	});
+	// 	expect(fileCreationTime3).toBeGreaterThan(fileCreationTime1);
+	// 	expect(fileCreationTime3).toBeGreaterThan(fileCreationTime2);
+	// });
 
 	it('logs message if no files found', () => {
 		expect(log).toBeCalledTimes(0);

--- a/projects/npm-tools/packages/npm-scripts/test/utils/__snapshots__/buildArtifacts.js.snap
+++ b/projects/npm-tools/packages/npm-scripts/test/utils/__snapshots__/buildArtifacts.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`caching build artifacts set build cache stores build artifacts in cache 1`] = `"{\\"builtFiles\\":{\\"build/packageRunBuild/index.js\\":\\"ee45f3714a404c5b444eae7cb0d68141389cf331\\"},\\"srcFiles\\":{\\"/Users/bryceosterhaus/repos/liferay-frontend-projects/projects/npm-tools/packages/npm-scripts/__fixtures__/utils/buildArtifacts/modules/apps/some/project/src/index.js\\":\\"b4258b676ee9dc8cbe9adbbbc1bb56efa11aa984\\"}}"`;

--- a/projects/npm-tools/packages/npm-scripts/test/utils/buildArtifacts.js
+++ b/projects/npm-tools/packages/npm-scripts/test/utils/buildArtifacts.js
@@ -1,0 +1,239 @@
+/* eslint-disable @liferay/imports-first */
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const findRoot = require('../../src/utils/findRoot');
+const getFixturePath = require('../../support/getFixturePath');
+
+const FIXTURES = getFixturePath('utils', 'buildArtifacts');
+const MODULES = path.join(FIXTURES, 'modules');
+const PUBLIC_PROJECT = path.join(MODULES, 'apps', 'some', 'project');
+
+const CACHE_PATH = path.join(MODULES, '.npmscripts');
+const MODULE_NAME = 'some-module';
+const SRC_FILES = [path.join(PUBLIC_PROJECT, 'src', 'index.js')];
+
+jest.mock('../../src/utils/findRoot', () => jest.fn());
+
+findRoot.mockImplementation(() => MODULES);
+
+const buildFileDir = path.join(PUBLIC_PROJECT, 'build', 'packageRunBuild');
+const srcFileDir = path.join(PUBLIC_PROJECT, 'src');
+
+const buildFilePath = path.join(buildFileDir, 'index.js');
+const srcFilePath = path.join(srcFileDir, 'index.js');
+
+const setupFixtures = () => {
+	if (!fs.existsSync(buildFileDir)) {
+		fs.mkdirSync(buildFileDir, {recursive: true});
+	}
+
+	fs.writeFileSync(buildFilePath, 'module.exports = "build"');
+
+	if (!fs.existsSync(srcFileDir)) {
+		fs.mkdirSync(srcFileDir, {recursive: true});
+	}
+
+	fs.writeFileSync(srcFilePath, 'module.exports = "src"');
+};
+
+const tearDownFixtures = () => {
+	fs.rmdirSync(buildFileDir, {recursive: true});
+	fs.rmdirSync(srcFileDir, {recursive: true});
+};
+
+describe('caching build artifacts', () => {
+	const cwd = process.cwd();
+
+	process.chdir(PUBLIC_PROJECT);
+
+	// In order for this test to work, this require must be inside the describe block
+	// because it relies on the findRoot function to be mocked before importing
+
+	const {isCacheValid, setCache} = require('../../src/utils/buildArtifacts');
+
+	const setTestCache = () => {
+		setCache(MODULE_NAME, SRC_FILES, 'build');
+	};
+	const clearTestCache = () => {
+		if (fs.existsSync(CACHE_PATH)) {
+			fs.rmdirSync(CACHE_PATH, {recursive: true});
+		}
+	};
+
+	beforeEach(() => {
+		setupFixtures();
+	});
+
+	afterEach(() => {
+		clearTestCache();
+		tearDownFixtures();
+	});
+
+	afterAll(() => {
+		process.chdir(cwd);
+
+		clearTestCache();
+	});
+
+	describe('set build cache', () => {
+		it('stores build artifacts in cache', () => {
+			setTestCache();
+
+			expect(
+				fs.existsSync(
+					path.join(CACHE_PATH, 'build', 'artifacts', MODULE_NAME)
+				)
+			).toBe(true);
+
+			expect(
+				fs.readFileSync(
+					path.join(
+						CACHE_PATH,
+						'build',
+						'artifacts',
+						MODULE_NAME,
+						'buildinfo.json'
+					),
+					'utf8'
+				)
+			).toMatchSnapshot();
+
+			expect(
+				fs.readFileSync(
+					path.join(
+						CACHE_PATH,
+						'build',
+						'artifacts',
+						MODULE_NAME,
+						'build',
+						'packageRunBuild',
+						'index.js'
+					)
+				)
+			).toEqual(
+				fs.readFileSync(
+					path.join(
+						PUBLIC_PROJECT,
+						'build',
+						'packageRunBuild',
+						'index.js'
+					)
+				)
+			);
+		});
+	});
+
+	describe('checks if cache is valid', () => {
+		it('returns false if no build info exists', () => {
+			expect(isCacheValid(MODULE_NAME, SRC_FILES)).toBe(false);
+		});
+
+		it('returns false if build info is malformed', () => {
+			const buildInfoPath = path.join(
+				CACHE_PATH,
+				'build',
+				'artifacts',
+				MODULE_NAME,
+				'buildinfo.json'
+			);
+
+			fs.mkdirSync(path.dirname(buildInfoPath), {recursive: true});
+
+			fs.writeFileSync(buildInfoPath, '{');
+
+			expect(isCacheValid(MODULE_NAME, SRC_FILES)).toBe(false);
+
+			fs.rmdirSync(CACHE_PATH, {recursive: true});
+		});
+
+		it('returns false if number or source files changed', () => {
+			setTestCache();
+
+			expect(isCacheValid(MODULE_NAME, [...SRC_FILES, 'foo/nar'])).toBe(
+				false
+			);
+		});
+
+		it('returns false if content of source file changes', () => {
+			setTestCache();
+
+			expect(isCacheValid(MODULE_NAME, SRC_FILES)).toBe(true);
+
+			const prevContent = fs.readFileSync(SRC_FILES[0], 'utf8');
+
+			fs.writeFileSync(SRC_FILES[0], 'test');
+
+			expect(isCacheValid(MODULE_NAME, SRC_FILES)).toBe(false);
+
+			fs.writeFileSync(SRC_FILES[0], prevContent);
+		});
+
+		it("checks if build file doesn't exist then copy previous build from cache", () => {
+			setTestCache();
+
+			const builtFilePath = path.join(
+				PUBLIC_PROJECT,
+				'build',
+				'packageRunBuild',
+				'index.js'
+			);
+			const builtFileContent = fs.readFileSync(builtFilePath, 'utf8');
+
+			fs.rmdirSync(
+				path.join(PUBLIC_PROJECT, 'build', 'packageRunBuild'),
+				{recursive: true}
+			);
+
+			expect(fs.existsSync(builtFilePath)).toBe(false);
+
+			expect(isCacheValid(MODULE_NAME, SRC_FILES)).toBe(true);
+
+			expect(fs.existsSync(builtFilePath)).toBe(true);
+
+			expect(fs.readFileSync(builtFilePath, 'utf8')).toBe(
+				builtFileContent
+			);
+		});
+
+		it('checks if build file is different from cache and restores cached version', () => {
+			setTestCache();
+
+			const builtFilePath = path.join(
+				PUBLIC_PROJECT,
+				'build',
+				'packageRunBuild',
+				'index.js'
+			);
+
+			const cacheFilePath = path.join(
+				CACHE_PATH,
+				'build',
+				'artifacts',
+				MODULE_NAME,
+				'build',
+				'packageRunBuild',
+				'index.js'
+			);
+
+			const builtFileContent = fs.readFileSync(builtFilePath, 'utf8');
+			const cacheFileContent = fs.readFileSync(cacheFilePath, 'utf8');
+
+			expect(isCacheValid(MODULE_NAME, SRC_FILES)).toBe(true);
+			expect(builtFileContent).toBe(cacheFileContent);
+
+			fs.writeFileSync(builtFilePath, 'changed');
+
+			expect(isCacheValid(MODULE_NAME, SRC_FILES)).toBe(true);
+
+			const newBuiltFileContent = fs.readFileSync(builtFilePath, 'utf8');
+
+			expect(newBuiltFileContent).toBe(cacheFileContent);
+		});
+	});
+});


### PR DESCRIPTION
~Copies our css logic and only builds js if files have been modified more recently than the built files~

Re-did the whole thing. Here is how it works

First build:
- Stores built files at `./modules/.npmscripts/build/artifacts/${MODULE_NAME}/build/**`
- Hashes src and built files at `./modules/.npmscripts/build/artifacts/${MODULE_NAME}/buildinfo.json`

- Before running babel, bundler, webpack, etc. we check if any previous build exists
    - Checks `./modules/.npmscripts/build/artifacts/${MODULE_NAME}/buildinfo.json`
    - Checks `./modules/.npmscripts/build/artifacts/${MODULE_NAME}/build/**` ()

Subsequent builds:
Check...
- previous build info doesn't exist -> REBUILD
- can't read previous build info -> REBUILD
- number of source files change -> REBUILD
- src files content changes -> REBUILD
- src files content doesn't change
    - build file doesn't exist -> copy previous build from cache
    - previous build files exist
         - file is same as last build -> DO NOTHING
         - file has changed -> REBUILD

Use can also force a build with `yarn build --force` or by deleting the `./modules/.npmscripts` directory.

The only change needed in DXP is adding `./modules/.npmscripts` to .gitignore and also excluding it from `ant clean`.