### PR TITLE
fix(npm-scripts): fix exports when explicit symbols are used for ESM

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/utils/runWebpackAsBundler.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/runWebpackAsBundler.js
@@ -180,6 +180,10 @@ function getEntryImportDescriptor(exportsItem) {
 
 				return module;
 			}, {});
+
+			if (exportsItem.format === 'esm') {
+				module.__esModule = true;
+			}
 		}
 
 		const nonDefaultFields = Object.keys(module)
@@ -207,10 +211,7 @@ const {
 ${nonDefaultFields}
 } = x;
 
-const __esModule = true;
-
 export {
-	__esModule,
 	def as default,
 ${nonDefaultFields}
 };


### PR DESCRIPTION
If we export symbols explicitly by configuring this in npmscripts.config.js:

```
module.exports = {
	build: {
		exports: [
			{
				name: 'metal-component',
				symbols: [
					'Component',
					'ComponentDataManager',
					'ComponentRegistry',
					'ComponentRenderer',
					'addListenersFromObj',
					'getComponentFn',
				],
			},
		],
	},
};
```

We need to differentiate if the module exports things in ESM or plain CommonJS format. This is important because it makes the treatment of __esModule and default fields different.