### PR TITLE
feat(npm-scripts): add support for internal modules in esm builds

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/utils/runWebpackAsBundler.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/runWebpackAsBundler.js
@@ -277,8 +277,28 @@ function getImportsWebpackConfigs(buildConfig) {
 
 		delete externals[pkgName];
 
+		const entries = exportsItem.includeInternalPaths
+			? exportsItem.includeInternalPaths.reduce(
+					(acc, internalPath) => ({
+						...acc,
+						[`__liferay__/exports/${flatPkgName}${path.normalize(
+							internalPath
+						)}`]: {
+							import: path.join(
+								importPath,
+								internalPath.includes('.')
+									? internalPath
+									: internalPath + '.js'
+							),
+						},
+					}),
+					{}
+			  )
+			: {};
+
 		const webpackConfig = {
 			entry: {
+				...entries,
 				[`__liferay__/exports/${flatPkgName}`]: {
 					import: importPath,
 				},
@@ -302,6 +322,10 @@ function getImportsWebpackConfigs(buildConfig) {
 								],
 							},
 						},
+					},
+					{
+						test: /\.css$/i,
+						use: ['style-loader', 'css-loader'],
 					},
 				],
 			},


### PR DESCRIPTION
I think I will release an alpha so that I can send a PR to dxp testing CI. So far I think this works though.

If you want to include internal modules for an npm module, you need to add `includeInternalPaths` which is an array of paths to include, this when generates a bundle for each of those files and makes them accessible via ESM and AMD(via bridge) in DXP