### PR TITLE
fix(liferay-npm-bundler): getBundleVersionAndClassifier was called twice for the bundle-version when generating the jar manifest 

### DIFF
--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/index.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/index.js
@@ -12,7 +12,6 @@ import path from 'path';
 
 import * as ddm from './ddm';
 import Manifest from './manifest';
-import * as osgi from './osgi';
 import * as xml from './xml';
 
 const pkgJson = project.pkgJson;
@@ -106,12 +105,12 @@ function addLocalizationFiles(zip) {
  * @param {JSZip} zip the ZIP file
  */
 function addManifest(zip) {
-	const bundleVersion = osgi.getBundleVersionAndClassifier(pkgJson.version);
-
 	const manifest = new Manifest();
 
 	manifest.bundleSymbolicName = pkgJson.name;
-	manifest.bundleVersion = bundleVersion;
+	manifest.bundleVersion = pkgJson.version;
+	const bundleVersion = manifest.bundleVersion;
+
 	if (pkgJson.description) {
 		manifest.bundleName = pkgJson.description;
 	}


### PR DESCRIPTION
Fixed a bug with the re-call of bundle-version normalization.
For example, for the version 1.2.3-alpha-SNAPSHOT
Before fix: 1.2.3.alpha.SNAPSHOT
After fix: 1.2.3.alpha-SNAPSHOT
according to the [osgi-core](https://github.com/osgi/osgi/blob/r6-core-spec-final/org.osgi.framework/src/org/osgi/framework/Version.java#L182-L206) - the first option is incorrect