### PR TITLE
fix: Bundle-Version incorrectly generated in JAR manifest if semver classifiers are used

### DIFF
--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/__tests__/__fixtures__/project-extended-classifier/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/__tests__/__fixtures__/project-extended-classifier/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "project-extended-classifier",
+	"version": "1.0.0-classifier-1-2-3"
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/__tests__/__fixtures__/project-simple-classifier/package.json
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/__tests__/__fixtures__/project-simple-classifier/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "project-simple-classifier",
+	"version": "1.0.0-classifier"
+}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/__tests__/index.test.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/__tests__/index.test.js
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import JSZip from 'jszip';
+import project from 'liferay-npm-build-tools-common/lib/project';
+import path from 'path';
+
+import {addManifest} from '../index';
+
+describe('addManifest', () => {
+	it('includes Bundle-Version with valid simple classifier when provided', async () => {
+		project.loadFrom(
+			path.join(__dirname, '__fixtures__', 'project-simple-classifier')
+		);
+
+		const zip = new JSZip();
+
+		addManifest(zip);
+
+		const manifest = await zip
+			.folder('META-INF')
+			.file('MANIFEST.MF')
+			.async('string');
+
+		const bundleVersionLine = manifest
+			.split('\n')
+			.find((line) => line.startsWith('Bundle-Version: '));
+
+		expect(bundleVersionLine).toEqual('Bundle-Version: 1.0.0.classifier');
+	});
+
+	it('includes Bundle-Version with valid extended classifier when provided', async () => {
+		project.loadFrom(
+			path.join(__dirname, '__fixtures__', 'project-extended-classifier')
+		);
+
+		const zip = new JSZip();
+
+		addManifest(zip);
+
+		const manifest = await zip
+			.folder('META-INF')
+			.file('MANIFEST.MF')
+			.async('string');
+
+		const bundleVersionLine = manifest
+			.split('\n')
+			.find((line) => line.startsWith('Bundle-Version: '));
+
+		expect(bundleVersionLine).toEqual(
+			'Bundle-Version: 1.0.0.classifier-1-2-3'
+		);
+	});
+});

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/__tests__/manifest.test.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/__tests__/manifest.test.js
@@ -45,34 +45,6 @@ Tool: liferay-npm-bundler-${version}
 	);
 });
 
-it('includes Bundle-Version with valid simple classifier when provided', () => {
-	const manifest = new Manifest();
-
-	manifest.bundleVersion = '1.0.0-classifier';
-
-	expect(manifest.content).toEqual(
-		`Manifest-Version: 1.0
-Bundle-ManifestVersion: 2
-Bundle-Version: 1.0.0.classifier
-Tool: liferay-npm-bundler-${version}
-`
-	);
-});
-
-it('includes Bundle-Version with valid extended classifier when provided', () => {
-	const manifest = new Manifest();
-
-	manifest.bundleVersion = '1.0.0-classifier-1-2-3';
-
-	expect(manifest.content).toEqual(
-		`Manifest-Version: 1.0
-Bundle-ManifestVersion: 2
-Bundle-Version: 1.0.0.classifier-1-2-3
-Tool: liferay-npm-bundler-${version}
-`
-	);
-});
-
 it('includes Bundle-Name when provided', () => {
 	const manifest = new Manifest();
 

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/index.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/index.js
@@ -12,6 +12,7 @@ import path from 'path';
 
 import * as ddm from './ddm';
 import Manifest from './manifest';
+import * as osgi from './osgi';
 import * as xml from './xml';
 
 const pkgJson = project.pkgJson;
@@ -104,12 +105,15 @@ function addLocalizationFiles(zip) {
  * Add the manifest file to the ZIP archive
  * @param {JSZip} zip the ZIP file
  */
-function addManifest(zip) {
+export function addManifest(zip) {
+	const {pkgJson} = project;
+
+	const bundleVersion = osgi.getBundleVersionAndClassifier(pkgJson.version);
+
 	const manifest = new Manifest();
 
 	manifest.bundleSymbolicName = pkgJson.name;
-	manifest.bundleVersion = pkgJson.version;
-	const bundleVersion = manifest.bundleVersion;
+	manifest.bundleVersion = bundleVersion;
 
 	if (pkgJson.description) {
 		manifest.bundleName = pkgJson.description;

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/index.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/index.js
@@ -15,8 +15,6 @@ import Manifest from './manifest';
 import * as osgi from './osgi';
 import * as xml from './xml';
 
-const pkgJson = project.pkgJson;
-
 /**
  * Create an OSGi bundle with build's output
  * @return {Promise}
@@ -168,6 +166,8 @@ export function addManifest(zip) {
  * @param {JSZip} zip the ZIP file
  */
 function addSystemConfigurationFiles(zip) {
+	const {pkgJson} = project;
+
 	const systemConfigJson = getSystemConfigurationJson();
 
 	if (!systemConfigJson) {

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/index.js
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/index.js
@@ -12,7 +12,6 @@ import path from 'path';
 
 import * as ddm from './ddm';
 import Manifest from './manifest';
-import * as osgi from './osgi';
 import * as xml from './xml';
 
 const pkgJson = project.pkgJson;
@@ -106,12 +105,12 @@ function addLocalizationFiles(zip) {
  * @param {JSZip} zip the ZIP file
  */
 function addManifest(zip) {
-	const bundleVersion = osgi.getBundleVersionAndClassifier(pkgJson.version);
-
 	const manifest = new Manifest();
 
 	manifest.bundleSymbolicName = pkgJson.name;
-	manifest.bundleVersion = bundleVersion;
+	manifest.bundleVersion = pkgJson.version;
+	const bundleVersion = manifest.bundleVersion;
+
 	if (pkgJson.description) {
 		manifest.bundleName = pkgJson.description;
 	}

--- a/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/manifest.ts
+++ b/maintenance/projects/js-toolkit/packages/liferay-npm-bundler/src/jar/manifest.ts
@@ -5,8 +5,6 @@
 
 import project from 'liferay-npm-build-tools-common/lib/project';
 
-import * as osgi from './osgi';
-
 const FORBIDDEN_CUSTOM_HEADERS = new Set([
 	'Bundle-ManifestVersion',
 	'Bundle-Name',
@@ -28,11 +26,20 @@ export default class Manifest {
 		this._bundleSymbolicName = bundleSymbolicName;
 	}
 
+	/**
+	 * Set `bundleVersion` field of manifest.
+	 *
+	 * @remarks
+	 * There are some differences in the ways OSGi and npm handle semver
+	 * classifiers, so you may want/need to pass any `package.json`'s `version`
+	 * field through `getBundleVersionAndClassifier()` in module `osgi.js`
+	 * before passing it to this function.
+	 */
 	set bundleVersion(bundleVersion: string) {
 		if (this._bundleVersion) {
 			throw new Error('BundleVersion can only be set once');
 		}
-		this._bundleVersion = osgi.getBundleVersionAndClassifier(bundleVersion);
+		this._bundleVersion = bundleVersion;
 	}
 
 	set bundleName(bundleName: string) {


### PR DESCRIPTION
This is https://github.com/liferay/liferay-frontend-projects/pull/1045 with some refactors on top.