### PR TITLE
fix: LPS-167272 Multiple events are being read in reverse order

### DIFF
--- a/third-party/projects/alloy-ui/src/aui-scheduler/js/aui-scheduler-view-day.js
+++ b/third-party/projects/alloy-ui/src/aui-scheduler/js/aui-scheduler-view-day.js
@@ -955,7 +955,7 @@ var SchedulerDayView = A.Component.create({
                         var evtParentNode = evtNode.get('parentNode');
 
                         if (evtParentNode) {
-                            evtParentNode.insert(evtNode, i);
+                            evtParentNode.append(evtNode, i);
                         }
 
                         evt._filtered = true;


### PR DESCRIPTION
### References

- [LPS-167272 HR_45 Multiple events are being read in reverse order](https://issues.liferay.com/browse/LPS-167272)
- Related: https://github.com/liferay/yui3/pull/32

### What is the goal of this PR?

This change fixes part of the ticket, an incorrect order of tabs in a day.

In PR, we are changing the order of nodes in DOM. With this change, nodes are accessed through keyboard navigation in chronological order. Order in DOM is irrelevant for display, as the positioning is absolute.

### What does it look like?

#### Before PR

https://user-images.githubusercontent.com/5435511/207394804-926dd0a5-fbf3-46ee-b68f-1b0aebb644d8.mp4


#### After PR

https://user-images.githubusercontent.com/5435511/207394780-75b79717-c1a7-4830-a2c7-78e1940dac8f.mp4

