### PR TITLE
fix(theme-tasks): update liferay-frontend-theme-styled, liferay-frontend-theme-unstyled

### DIFF
--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/devDependencies.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/devDependencies.js
@@ -77,8 +77,8 @@ module.exports = {
 				'compass-mixins': strict('0.12.10'),
 				'gulp': gulpVersion,
 				'liferay-frontend-css-common': strict('6.0.4'),
-				'liferay-frontend-theme-styled': strict('6.0.38'),
-				'liferay-frontend-theme-unstyled': strict('6.0.33'),
+				'liferay-frontend-theme-styled': strict('6.0.52'),
+				'liferay-frontend-theme-unstyled': strict('6.0.45'),
 				'liferay-theme-tasks': themeTasksVersion,
 			},
 			optional: {


### PR DESCRIPTION
Hi Team.

could you please check my fix?

The fix upgrades the liferay-frontend-theme-styled, liferay-frontend-theme-unstyled to the @liferay_frontend["icon-options"] taglib instead of the depreceted @liferay_portlet["icon-options"] 

Thanks, Roland

https://issues.liferay.com/browse/LPS-172679