### PR TITLE
fix(npm-scripts): temporary work around for grabbing rules config at both the root and module level

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/utils/collectDefinedDependencies.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/collectDefinedDependencies.js
@@ -3,10 +3,26 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const getUserConfig = require('./getUserConfig');
+const path = require('path');
+
+const findRoot = require('./findRoot');
 
 function collectDefinedDependencies() {
-	const rootConfig = getUserConfig('npmscripts');
+	const rootDir = findRoot();
+
+	let rootConfig = {};
+
+	if (!rootDir) {
+		return new Set();
+	}
+
+	try {
+		/* eslint-disable-next-line @liferay/no-dynamic-require */
+		rootConfig = require(path.join(rootDir, 'npmscripts.config'));
+	}
+	catch (error) {
+		return new Set();
+	}
 
 	const amdImports = new Set(
 		Object.entries(rootConfig.build.bundler.config.imports).reduce(

--- a/projects/npm-tools/packages/npm-scripts/src/utils/getMergedConfig.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/getMergedConfig.js
@@ -201,6 +201,10 @@ function getMergedConfig(type, property) {
 				mergedConfig = deepMerge(
 					[
 						require('../config/npmscripts.config'),
+
+						// Temporary workaround until we re-evaluate global key
+
+						{rules: rootConfig.global?.rules || {}},
 						rootConfig,
 						getUserConfig('npmscripts'),
 					],


### PR DESCRIPTION
This is temporary until we provide a full solution in https://issues.liferay.com/browse/LPS-172749