### PR TITLE
feat: use portlet category "Client Extensions" by default, for new projects

### DIFF
--- a/projects/js-toolkit/packages/js-toolkit-core/src/project/liferayCli/Build.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/project/liferayCli/Build.ts
@@ -26,6 +26,7 @@ export interface CustomElementBuildOptions {
 	externals: {[bareIdentifier: string]: string};
 	htmlElementName: string | null;
 	minify: boolean;
+	portletCategoryName: string;
 }
 
 type OptionValue = boolean | number | string;
@@ -137,6 +138,8 @@ export default class Build {
 			externals: config.externals || {},
 			htmlElementName: config.htmlElementName,
 			minify: process.env.NODE_ENV !== 'development',
+			portletCategoryName:
+				config.portletCategoryName || 'category.remote-apps',
 		};
 
 		// Remove externals mapped to null

--- a/projects/js-toolkit/packages/js-toolkit-core/src/schema/LiferayJson.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/schema/LiferayJson.ts
@@ -23,4 +23,5 @@ export type Bundler2BuildConfig = {};
 export interface CustomElementBuildConfig {
 	externals: {[bareIdentifier: string]: string} | string[];
 	htmlElementName?: string;
+	portletCategoryName?: string;
 }

--- a/projects/js-toolkit/packages/js-toolkit-core/src/schema/RemoteAppManifestJson.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/schema/RemoteAppManifestJson.ts
@@ -7,6 +7,7 @@
 export default interface RemoteAppManifestJson {
 	cssURLs: string[];
 	htmlElementName: string;
+	portletCategoryName?: string;
 	type: 'customElement';
 	urls: string[];
 	useESM: boolean;

--- a/projects/js-toolkit/packages/liferay-cli/src/new/target-remote-app/templates/liferay.json.ejs
+++ b/projects/js-toolkit/packages/liferay-cli/src/new/target-remote-app/templates/liferay.json.ejs
@@ -1,5 +1,8 @@
 {
 	"build": {
-		"type": "customElement"
+		"type": "customElement",
+		"options": {
+			"portletCategoryName": "category.client-extensions"
+		}
 	}
 }

--- a/projects/js-toolkit/packages/portal-base/src/build/customElement.ts
+++ b/projects/js-toolkit/packages/portal-base/src/build/customElement.ts
@@ -124,7 +124,7 @@ async function makeZip(project: Project): Promise<void> {
 				`cssURLs=${manifest.cssURLs.join('\n')}`,
 				`htmlElementName=${manifest.htmlElementName}`,
 				'instanceable=true',
-				'portletCategoryName=category.remote-apps',
+				`portletCategoryName=${manifest.portletCategoryName}`,
 				`urls=${manifest.urls.join('\n')}`,
 				`useESM=${manifest.useESM}`,
 			],

--- a/projects/js-toolkit/packages/portal-base/src/prepareStart.ts
+++ b/projects/js-toolkit/packages/portal-base/src/prepareStart.ts
@@ -107,7 +107,7 @@ async function deployZip(project: Project): Promise<FilePath> {
 				`cssURLs=${manifest.cssURLs.join('\n')}`,
 				`htmlElementName=${manifest.htmlElementName}`,
 				'instanceable=true',
-				'portletCategoryName=category.remote-apps',
+				`portletCategoryName=${manifest.portletCategoryName}`,
 				`urls=${manifest.urls.join('\n')}`,
 				`useESM=${manifest.useESM}`,
 			],

--- a/projects/js-toolkit/packages/portal-base/src/util/createManifest.ts
+++ b/projects/js-toolkit/packages/portal-base/src/util/createManifest.ts
@@ -16,7 +16,7 @@ export default function createManifest(
 	project: Project
 ): RemoteAppManifestJson {
 	const options = project.build.options as CustomElementBuildOptions;
-	const {htmlElementName} = options;
+	const {htmlElementName, portletCategoryName} = options;
 
 	if (!htmlElementName) {
 		abort(
@@ -35,6 +35,7 @@ Please configure it using {build.options.htmlElementName} in the {liferay.json} 
 				.asPosix.replace(/\.scss$/i, '.css')
 		),
 		htmlElementName,
+		portletCategoryName,
 		type: 'customElement',
 		urls: [
 			project.srcDir.relative(project.mainModuleFile).toDotRelative()


### PR DESCRIPTION
See https://issues.liferay.com/browse/LPS-172978.

The goal of this PR is to keep using `category.remote-apps` for old projects (that's detected because `liferay.json` is empty for them) but use `category.client-extensions` from now on.