### PR TITLE
feat(npm-scripts): add --experimental-standalone flag when calling format and lint, this ensures that the eslint plugins are collected from root of @liferay/npm-scripts instead of where it is called.

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/config/eslint.config.js
+++ b/projects/npm-tools/packages/npm-scripts/src/config/eslint.config.js
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/projects/npm-tools/packages/npm-scripts/src/config/npmscripts.config.js
+++ b/projects/npm-tools/packages/npm-scripts/src/config/npmscripts.config.js
@@ -6,6 +6,7 @@
 const path = require('path');
 
 const CHECK_AND_FIX_GLOBS = [
+	'**/*.{html,js,jsx,json,css,scss,ts,tsx}',
 	'/*.{js,ts}',
 	'/{dev,extra,src,test}/**/*.{js,scss,ts,tsx}',
 	'/src/**/*.{jsp,jspf}',

--- a/projects/npm-tools/packages/npm-scripts/src/prettier/index.js
+++ b/projects/npm-tools/packages/npm-scripts/src/prettier/index.js
@@ -27,6 +27,7 @@ const {ID_END, ID_START} = require('../jsp/getPaddedReplacement');
 const {SCRIPTLET_CONTENT} = require('../jsp/substituteTags');
 const {BLOCK_CLOSE, BLOCK_OPEN} = require('../jsp/tagReplacements');
 const {FILLER_CHAR, SPACE_CHAR, TAB_CHAR} = require('../jsp/toFiller');
+const resolvePluginsRelativeTo = require('../utils/resolveEslintPluginsRelativeTo');
 const rule = require('./rules/newline-before-block-statements');
 
 const EXTENSIONS = {
@@ -67,6 +68,7 @@ const cli = new CLIEngine({
 		...eslintConfig.parserOptions,
 		sourceType: 'module',
 	},
+	resolvePluginsRelativeTo,
 	rules: {
 		'lines-around-comment': [
 			'error',

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/lint.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/lint.js
@@ -14,6 +14,7 @@ const getMergedConfig = require('../utils/getMergedConfig');
 const getPaths = require('../utils/getPaths');
 const inCurrentWorkingDirectory = require('../utils/inCurrentWorkingDirectory');
 const log = require('../utils/log');
+const resolvePluginsRelativeTo = require('../utils/resolveEslintPluginsRelativeTo');
 const {SpawnError} = require('../utils/spawnSync');
 const isSCSS = require('./lint/stylelint/isSCSS');
 const lintSCSS = require('./lint/stylelint/lintSCSS');
@@ -83,6 +84,7 @@ async function lint(options = {}) {
 			// default. Use a negated ignore pattern ... to override"
 
 			ignorePattern: '!*',
+			resolvePluginsRelativeTo,
 		});
 
 		const {default: jsPaths, jspPaths, scssPaths} = partitionArray(paths, {

--- a/projects/npm-tools/packages/npm-scripts/src/utils/resolveEslintPluginsRelativeTo.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/resolveEslintPluginsRelativeTo.js
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const path = require('path');
+
+const ARGS_ARRAY = process.argv.slice(2);
+
+const experimentalStandalone = ARGS_ARRAY.slice(1).includes(
+	'--experimental-standalone'
+);
+
+module.exports = experimentalStandalone
+	? path.join(__dirname, '..', '..')
+	: undefined;


### PR DESCRIPTION
This is a quick temporary solution for [this ticket](https://issues.liferay.com/browse/LPS-173225). By adding this flag, it allows for developers to call our prettier/eslint scripts anywhere with npx. 

For example:

```sh
npx liferay-npm-scripts prettier --write "**/*.{js,jsx,json,md,ts,tsx,yml}" "**/.*.{js,ts,yml}" --experimental-standalone
npx liferay-npm-scripts format --experimental-standalone
npx liferay-npm-scripts lint --experimental-standalone
```

This shoudl be able to be run in any project and not require that there are any root node_modules or package.json available.



Long term solution is still TBD, but might involve moving format/lint tasks to their own package and allow both internal and external devs to use it on liferay related code.