### PR TITLE
fix(npm-scripts): remove json from default fix/check glob

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/config/npmscripts.config.js
+++ b/projects/npm-tools/packages/npm-scripts/src/config/npmscripts.config.js
@@ -6,7 +6,7 @@
 const path = require('path');
 
 const CHECK_AND_FIX_GLOBS = [
-	'**/*.{html,js,jsx,json,css,scss,ts,tsx}',
+	'**/*.{html,js,jsx,css,scss,ts,tsx}',
 	'/*.{js,ts}',
 	'/{dev,extra,src,test}/**/*.{js,scss,ts,tsx}',
 	'/src/**/*.{jsp,jspf}',


### PR DESCRIPTION
Our gradle format tasks handle json