### PR TITLE
chore: script to check theme dependency versions against npm registry

### DIFF
--- a/projects/js-themes-toolkit/package.json
+++ b/projects/js-themes-toolkit/package.json
@@ -18,6 +18,8 @@
 		"lint": "liferay-workspace-scripts lint",
 		"lint:fix": "liferay-workspace-scripts lint:fix",
 		"qa": "node scripts/qa.js",
-		"test": "liferay-workspace-scripts test"
+		"test": "liferay-workspace-scripts test",
+		"themeDeps:check": "node scripts/updateThemeDeps.js --check",
+		"themeDeps:update": "node scripts/updateThemeDeps.js"
 	}
 }

--- a/projects/js-themes-toolkit/scripts/updateThemeDeps.js
+++ b/projects/js-themes-toolkit/scripts/updateThemeDeps.js
@@ -1,0 +1,164 @@
+const fs = require('fs');
+const https = require('https');
+
+const DEV_DEPENDENCIES_PATH = require.resolve(
+	'../packages/liferay-theme-tasks/lib/devDependencies.js'
+);
+const SIGNIFICANT_DEPS = [
+	'liferay-frontend-css-common',
+	'liferay-frontend-theme-styled',
+	'liferay-frontend-theme-unstyled',
+];
+
+async function main(argv) {
+	const {theme: themeDeps} = require(DEV_DEPENDENCIES_PATH);
+
+	const currentVersions = {};
+	const wantedVersions = {};
+
+	for (const dxpVersion of Object.keys(themeDeps)) {
+		const {default: depVersions} = themeDeps[dxpVersion];
+
+		console.log('');
+		console.log('');
+		console.log(`== DXP ${dxpVersion} ========`);
+
+		currentVersions[dxpVersion] = {};
+		wantedVersions[dxpVersion] = {};
+
+		for (const dep of SIGNIFICANT_DEPS) {
+			const depVersion = depVersions[dep];
+
+			if (!depVersion) {
+				continue;
+			}
+
+			const versionSeries = depVersion.replace(/\..*/, '');
+
+			console.log('');
+			console.log(dep);
+			console.log('    Current version:', depVersion);
+			console.log('    Versions series:', versionSeries);
+			process.stdout.write('    Latest version:  ');
+
+			const npmVersions = await getNpmVersions(dep);
+
+			const latestVersion = getLatestVersion(npmVersions, versionSeries);
+
+			console.log(latestVersion);
+
+			currentVersions[dxpVersion][dep] = depVersion;
+			wantedVersions[dxpVersion][dep] = latestVersion;
+		}
+	}
+
+	console.log('');
+	console.log('');
+
+	if (argv[2] === '--check' || argv[2] === '-c') {
+		let rc = 0;
+
+		for (const dxpVersion of Object.keys(themeDeps)) {
+			for (const dep of SIGNIFICANT_DEPS) {
+				const current = currentVersions[dxpVersion][dep];
+
+				if (!current) {
+					continue;
+				}
+
+				const wanted = wantedVersions[dxpVersion][dep];
+
+				if (current !== wanted) {
+					rc = 1;
+				}
+			}
+		}
+
+		if (rc === 0) {
+			console.log(`No obsolete dependencies found 🎉`);
+		}
+		else {
+			console.log(`Some obsolete dependencies were found 😭`);
+		}
+
+		console.log('');
+		console.log('');
+
+		process.exit(rc);
+	}
+	else {
+		let jsCode = fs.readFileSync(DEV_DEPENDENCIES_PATH, 'utf-8');
+
+		for (const dxpVersion of Object.keys(themeDeps)) {
+			for (const dep of SIGNIFICANT_DEPS) {
+				const current = currentVersions[dxpVersion][dep];
+
+				if (!current) {
+					continue;
+				}
+
+				const wanted = wantedVersions[dxpVersion][dep];
+
+				const regexp = `'${dep}': strict[(]'${current}'[)]`;
+				const replacement = `'${dep}': strict('${wanted}')`;
+
+				jsCode = jsCode.replace(new RegExp(regexp), replacement);
+			}
+		}
+
+		fs.writeFileSync(DEV_DEPENDENCIES_PATH, jsCode);
+
+		console.log('Patched liferay-theme-tasks 💪');
+
+		console.log('');
+		console.log('');
+	}
+}
+
+function getLatestVersion(versions, versionSeries) {
+	return Object.keys(versions)
+		.filter((version) => version.startsWith(`${versionSeries}.`))
+		.sort((a, b) => {
+			const aparts = a.split('.');
+			const bparts = b.split('.');
+
+			for (let i = 0; ; i++) {
+				if (aparts[i] !== undefined && bparts[i] !== undefined) {
+					return -1;
+				}
+				else if (aparts[i] === undefined && bparts[i] !== undefined) {
+					return 1;
+				}
+				else if (aparts[i] > bparts[i]) {
+					return -1;
+				}
+				else if (aparts[i] < bparts[i]) {
+					return 1;
+				}
+
+				return 0;
+			}
+		})[0];
+}
+
+async function getNpmVersions(pkgName) {
+	return new Promise((resolve, reject) => {
+		https
+			.get(`https://registry.npmjs.com/${pkgName}`, (res) => {
+				res.setEncoding('utf8');
+
+				let data = '';
+
+				res.on('data', (chunk) => {
+					data += chunk.toString();
+				});
+
+				res.on('end', () => {
+					resolve(JSON.parse(data)['versions']);
+				});
+			})
+			.on('error', reject);
+	});
+}
+
+main(process.argv).catch(console.error);


### PR DESCRIPTION
This script will be used to maintain Themes Toolkit's dependency versions up to date.

For now it can only be run locally, but we can use the --check option of the script to create a GH workflow to check for new versions daily and notify the team accordingly.