### PR TITLE
fix(alloy-ui): AUI-3217 Adding alternative text for thumbnails in Image Gallery

### DIFF
--- a/third-party/projects/alloy-ui/src/aui-image-viewer/js/aui-image-viewer-multiple.js
+++ b/third-party/projects/alloy-ui/src/aui-image-viewer/js/aui-image-viewer-multiple.js
@@ -200,7 +200,15 @@ A.ImageViewerMultiple = A.Base.create('image-viewer-multiple', A.ImageViewerBase
          * @default 100
          * @type Number | String
          */
-        height: 100
+        height: 100,
+
+        /**
+        * @attribute links
+        * @type Object
+        */
+        links: {
+            validator: A.Lang.isObject
+        },
     },
 
     /**

--- a/third-party/projects/alloy-ui/src/aui-image-viewer/js/aui-image-viewer.js
+++ b/third-party/projects/alloy-ui/src/aui-image-viewer/js/aui-image-viewer.js
@@ -331,6 +331,7 @@ A.ImageViewer = A.Base.create(
 
             return A.merge({
                 height: 70,
+                links: this.get('links'),
                 showControls: false,
                 sources: this._getThumbnailImageSources(),
                 width: '100%'


### PR DESCRIPTION
Hi guys,

This is an addition to #1065 .

With previous changes we were not adding an alternative text to thumbnails within image gallery, because 'links' object (Where image information is) is not passed to aui-image-viewer-multiple component.

Let me know if you have any questions.

Thanks.

Regards.