### PR TITLE
feat(js-toolkit): adds support for building theme spritemap client extensions

### DIFF
--- a/projects/js-toolkit/packages/js-toolkit-core/src/index.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/index.ts
@@ -34,6 +34,7 @@ export {default as Project} from './project/liferayCli/Project';
 export {
 	Bundler2BuildOptions,
 	CustomElementBuildOptions,
+	ThemeSpritemapBuildOptions,
 } from './project/liferayCli/Build';
 
 // Format library

--- a/projects/js-toolkit/packages/js-toolkit-core/src/project/liferayCli/Build.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/project/liferayCli/Build.ts
@@ -8,15 +8,17 @@ import fs from 'fs';
 import FilePath from '../../file/FilePath';
 import LiferayJson, {
 	BuildConfig,
+	BuildType,
 	Bundler2BuildConfig,
 	CustomElementBuildConfig,
 } from '../../schema/LiferayJson';
 import Project from './Project';
 import persist, {Location} from './persist';
 
-type BuildType = 'bundler2' | 'customElement';
-
-type BuildOptions = Bundler2BuildOptions | CustomElementBuildOptions;
+type BuildOptions =
+	| Bundler2BuildOptions
+	| CustomElementBuildOptions
+	| ThemeSpritemapBuildOptions;
 
 export interface Bundler2BuildOptions {
 	minify: boolean;
@@ -27,6 +29,11 @@ export interface CustomElementBuildOptions {
 	htmlElementName: string | null;
 	minify: boolean;
 	portletCategoryName: string;
+}
+
+export interface ThemeSpritemapBuildOptions {
+	enableSVG4Everybody: boolean;
+	extendClay: boolean;
 }
 
 type OptionValue = boolean | number | string;
@@ -49,6 +56,11 @@ export default class Build {
 					project,
 					config as CustomElementBuildConfig
 				);
+				break;
+			case 'themeSpritemap':
+				this.type = 'themeSpritemap';
+				this.dir = project.dir.join('build');
+				this.options = config as ThemeSpritemapBuildOptions;
 				break;
 
 			case 'bundler2': {

--- a/projects/js-toolkit/packages/js-toolkit-core/src/project/liferayCli/Build.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/project/liferayCli/Build.ts
@@ -8,12 +8,13 @@ import fs from 'fs';
 import FilePath from '../../file/FilePath';
 import LiferayJson, {
 	BuildConfig,
-	BuildType,
 	Bundler2BuildConfig,
 	CustomElementBuildConfig,
 } from '../../schema/LiferayJson';
 import Project from './Project';
 import persist, {Location} from './persist';
+
+type BuildType = 'bundler2' | 'customElement' | 'themeSpritemap';
 
 type BuildOptions =
 	| Bundler2BuildOptions

--- a/projects/js-toolkit/packages/js-toolkit-core/src/project/liferayCli/Dist.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/project/liferayCli/Dist.ts
@@ -31,6 +31,8 @@ export default class Dist {
 				break;
 			}
 			case 'themeSpritemap':
+				this.dir = project.dir.join('dist');
+				this.file = this.dir.join(`${project.dir.basename()}.zip`);
 				break;
 
 			default:

--- a/projects/js-toolkit/packages/js-toolkit-core/src/project/liferayCli/Dist.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/project/liferayCli/Dist.ts
@@ -30,6 +30,8 @@ export default class Dist {
 				this.file = this.dir.join(bundler2Project.jar.outputFilename);
 				break;
 			}
+			case 'themeSpritemap':
+				break;
 
 			default:
 				throw new Error(

--- a/projects/js-toolkit/packages/js-toolkit-core/src/schema/ClientExtensionConfigJson.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/schema/ClientExtensionConfigJson.ts
@@ -9,7 +9,7 @@ export default interface ClientExtensionConfigJson {
 		description: string;
 		name: string;
 		sourceCodeURL: string;
-		type: 'customElement';
+		type: 'customElement' | 'themeSpritemap';
 		typeSettings: string[];
 	};
 }

--- a/projects/js-toolkit/packages/js-toolkit-core/src/schema/ClientExtensionYaml.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/schema/ClientExtensionYaml.ts
@@ -4,7 +4,6 @@
  */
 
 import type {
-	BuildType,
 	Bundler2BuildConfig,
 	CustomElementBuildConfig,
 	ThemeSpritemapBuildConfig,
@@ -18,5 +17,5 @@ export default interface ClientExtensionYaml
 	description: string;
 	name: string;
 	sourceCodeURL: string;
-	type: BuildType;
+	type: 'bundler2' | 'customElement' | 'themeSpritemap';
 }

--- a/projects/js-toolkit/packages/js-toolkit-core/src/schema/ClientExtensionYaml.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/schema/ClientExtensionYaml.ts
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import type {
+	BuildType,
+	Bundler2BuildConfig,
+	CustomElementBuildConfig,
+	ThemeSpritemapBuildConfig,
+} from './LiferayJson';
+
+export default interface ClientExtensionYaml
+	extends Bundler2BuildConfig,
+		CustomElementBuildConfig,
+		ThemeSpritemapBuildConfig {
+	baseURL: string;
+	description: string;
+	name: string;
+	sourceCodeURL: string;
+	type: BuildType;
+}

--- a/projects/js-toolkit/packages/js-toolkit-core/src/schema/LiferayJson.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/schema/LiferayJson.ts
@@ -3,12 +3,10 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-export type BuildType = 'bundler2' | 'customElement' | 'themeSpritemap';
-
 export default interface LiferayJson {
 	build?: {
 		options?: BuildConfig;
-		type?: BuildType;
+		type?: 'bundler2' | 'customElement' | 'themeSpritemap';
 	};
 	deploy?: {
 		path?: string;

--- a/projects/js-toolkit/packages/js-toolkit-core/src/schema/LiferayJson.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/schema/LiferayJson.ts
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
+export type BuildType = 'bundler2' | 'customElement' | 'themeSpritemap';
+
 export default interface LiferayJson {
 	build?: {
 		options?: BuildConfig;
-		type?: 'bundler2' | 'customElement';
+		type?: BuildType;
 	};
 	deploy?: {
 		path?: string;

--- a/projects/js-toolkit/packages/js-toolkit-core/src/schema/LiferayJson.ts
+++ b/projects/js-toolkit/packages/js-toolkit-core/src/schema/LiferayJson.ts
@@ -18,7 +18,10 @@ export default interface LiferayJson {
 	};
 }
 
-export type BuildConfig = Bundler2BuildConfig | CustomElementBuildConfig;
+export type BuildConfig =
+	| Bundler2BuildConfig
+	| CustomElementBuildConfig
+	| ThemeSpritemapBuildConfig;
 
 export type Bundler2BuildConfig = {};
 
@@ -26,4 +29,9 @@ export interface CustomElementBuildConfig {
 	externals: {[bareIdentifier: string]: string} | string[];
 	htmlElementName?: string;
 	portletCategoryName?: string;
+}
+
+export interface ThemeSpritemapBuildConfig {
+	enableSvg4everybody?: boolean;
+	extendClay?: boolean;
 }

--- a/projects/js-toolkit/packages/portal-base/src/build/index.ts
+++ b/projects/js-toolkit/packages/portal-base/src/build/index.ts
@@ -8,6 +8,7 @@ import {Project, format} from '@liferay/js-toolkit-core';
 import abort from '../util/abort';
 import bundler2 from './bundler2';
 import customElement from './customElement';
+import themeSpritemap from './themeSpritemap';
 
 const {print, success} = format;
 
@@ -22,6 +23,10 @@ export default async function build(): Promise<void> {
 
 			case 'bundler2':
 				await bundler2(project);
+				break;
+
+			case 'themeSpritemap':
+				await themeSpritemap(project);
 				break;
 
 			default:

--- a/projects/js-toolkit/packages/portal-base/src/build/themeSpritemap.ts
+++ b/projects/js-toolkit/packages/portal-base/src/build/themeSpritemap.ts
@@ -25,8 +25,8 @@ const HEADER_REGEXP = /<!--(.*)-->/s;
 
 const SPRITEMAP_FILE_NAME = 'spritemap.svg';
 
-export default async function customElement(project: Project): Promise<void> {
-	const {enableSVG4Everybody = false, extendClay = false} = project.build
+export default async function themeSpritemap(project: Project): Promise<void> {
+	const {enableSVG4Everybody, extendClay} = project.build
 		.options as ThemeSpritemapBuildOptions;
 
 	fs.mkdirSync(project.build.dir.asNative, {recursive: true});
@@ -43,15 +43,15 @@ export default async function customElement(project: Project): Promise<void> {
 		'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">';
 
 	if (extendClay) {
-		const clayPath = require.resolve('@clayui/css');
+		const clayPath = project.resolve('@clayui/css');
 
-		if (!clayPath) {
+		if (!fs.existsSync(clayPath)) {
 			print(
 				error` @clay/css package not found. Add as a dependency to your client extension via npm.`
 			);
 		}
 
-		const claySpritemapPath = require.resolve(
+		const claySpritemapPath = project.resolve(
 			'@clayui/css/lib/images/icons/icons.svg'
 		);
 

--- a/projects/js-toolkit/packages/portal-base/src/build/themeSpritemap.ts
+++ b/projects/js-toolkit/packages/portal-base/src/build/themeSpritemap.ts
@@ -1,0 +1,172 @@
+/**
+ * SPDX-FileCopyrightText: © 2021 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/* eslint-disable @liferay/no-dynamic-require */
+
+import {
+	ClientExtensionConfigJson,
+	FilePath,
+	Project,
+	ThemeSpritemapBuildOptions,
+	format,
+} from '@liferay/js-toolkit-core';
+import fs from 'fs';
+import globby from 'globby';
+import JSZip from 'jszip';
+import path from 'path';
+
+import abort from '../util/abort';
+
+const {error, info, print} = format;
+
+const HEADER_REGEXP = /<!--(.*)-->/s;
+
+const SPRITEMAP_FILE_NAME = 'spritemap.svg';
+
+export default async function customElement(project: Project): Promise<void> {
+	const {enableSVG4Everybody = false, extendClay = false} = project.build
+		.options as ThemeSpritemapBuildOptions;
+
+	fs.mkdirSync(project.build.dir.asNative, {recursive: true});
+
+	print(info` Generating Spritemap:`);
+
+	if (!fs.existsSync(project.srcDir.asNative)) {
+		abort(`Source directory, (${project.srcDir.asNative}), doesn't exist.`);
+	}
+
+	let svgContent =
+		'<?xml version="1.0" encoding="UTF-8"?>' +
+		'<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">' +
+		'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">';
+
+	if (extendClay) {
+		const clayPath = require.resolve('@clayui/css');
+
+		if (!clayPath) {
+			print(
+				error` @clay/css package not found. Add as a dependency to your client extension via npm.`
+			);
+		}
+
+		const claySpritemapPath = require.resolve(
+			'@clayui/css/lib/images/icons/icons.svg'
+		);
+
+		const claySpritemapContent = fs.readFileSync(claySpritemapPath, 'utf8');
+
+		svgContent = claySpritemapContent
+			.replace('</svg>', '')
+			.replace(/\n/gm, '')
+			.replace(/\t/gm, '');
+	}
+
+	const filePaths = globby
+		.sync(['**/*.svg'], {
+			cwd: project.srcDir.asNative,
+		})
+		.map((posixPath) => new FilePath(posixPath, {posix: true}))
+		.map((file) => path.join(project.srcDir.asNative, file.asNative));
+
+	if (!filePaths.length) {
+		abort(`No icon(.svg) files found.`);
+	}
+
+	const iconsReplaced = [];
+
+	for (const filePath of filePaths) {
+		const fileName = path.basename(filePath, '.svg').toLowerCase();
+
+		const data = fs.readFileSync(filePath, 'utf8');
+
+		// Remove existing Clay icons that duplicate our new icon names
+
+		if (extendClay) {
+			const existingSymbolRegex = new RegExp(
+				`<symbol id="${fileName}".*?</symbol>`,
+				'gm'
+			);
+
+			if (existingSymbolRegex.test(svgContent)) {
+				svgContent = svgContent.replace(existingSymbolRegex, '');
+
+				iconsReplaced.push(fileName);
+			}
+		}
+
+		svgContent += data
+			.replace(HEADER_REGEXP, '')
+			.replace(/<svg/gm, '<symbol')
+			.replace(
+				/xmlns="http:\/\/www\.w3\.org\/2000\/svg"/gm,
+				`id="${fileName}"`
+			)
+			.replace(/<\/svg/gm, '</symbol')
+			.replace(/\n/gm, '')
+			.replace(/\t/gm, '');
+	}
+
+	const iconsAdded = filePaths.length - iconsReplaced.length;
+
+	if (iconsAdded) {
+		print(info` ${iconsAdded} new icons added.`);
+	}
+
+	if (extendClay) {
+		print(
+			info` Extended Clay spritemap and replaced ${
+				iconsReplaced.length
+			} icons: ${iconsReplaced.join(', ')}.`
+		);
+	}
+
+	svgContent += '</svg>';
+
+	fs.writeFileSync(
+		path.join(project.build.dir.asNative, SPRITEMAP_FILE_NAME),
+		svgContent
+	);
+
+	const configurationPid =
+		'com.liferay.client.extension.type.configuration.CETConfiguration~' +
+		project.pkgJson.name;
+
+	const clientExtensionConfigJson: ClientExtensionConfigJson = {
+		[configurationPid]: {
+			baseURL: `\${portalURL}/o/${project.pkgJson.name}`,
+			description: project.pkgJson.description || '',
+			name: project.pkgJson.name,
+			sourceCodeURL: '',
+			type: 'themeSpritemap',
+			typeSettings: [
+				`enableSVG4Everybody=${enableSVG4Everybody}`,
+				`url=${SPRITEMAP_FILE_NAME}`,
+			],
+		},
+	};
+
+	const zip = new JSZip();
+
+	zip.file(
+		`${project.pkgJson.name}.client-extension-config.json`,
+		JSON.stringify(clientExtensionConfigJson, null, '\t')
+	);
+
+	const staticFolder = zip.folder('static');
+
+	staticFolder.file(SPRITEMAP_FILE_NAME, svgContent);
+
+	const buffer = await zip.generateAsync({
+		compression: 'DEFLATE',
+		compressionOptions: {
+			level: 6,
+		},
+		type: 'nodebuffer',
+	});
+
+	fs.mkdirSync(project.dist.dir.asNative, {recursive: true});
+
+	fs.writeFileSync(project.dist.file.asNative, buffer);
+}

--- a/projects/js-toolkit/packages/portal-base/src/util/runSass.ts
+++ b/projects/js-toolkit/packages/portal-base/src/util/runSass.ts
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-import {FilePath, Project, format} from '@liferay/js-toolkit-core';
+import {
+	Bundler2BuildOptions,
+	FilePath,
+	Project,
+	format,
+} from '@liferay/js-toolkit-core';
 import fs from 'fs';
 import {sync as resolve} from 'resolve';
 import sass from 'sass';
@@ -18,7 +23,7 @@ export default function runSass(project: Project): FilePath[] {
 		return;
 	}
 
-	const options = project.build.options;
+	const options = project.build.options as Bundler2BuildOptions;
 
 	const scssFiles = findFiles(project.srcDir, (dirent) => {
 		const lowerCaseName = dirent.name.toLowerCase();


### PR DESCRIPTION
Config for this CET looks like

```json
{
	"build": {
		"type": "themeSpritemap",
		"options": {
			"extendClay": true
		}
	}
}
```

Icons are placed in the `./src` of your project.

package.json looks like
```json
{
  "name": "sample-theme-spritemap-3",
  "version": "1.0.0",
  "description": "Sample Theme Spritemap 3",
  "dependencies": {
    "@liferay/dxp-7.4": "*"
  },
  "scripts": {
    "build": "liferay build",
    "clean": "liferay clean",
    "deploy": "liferay deploy"
  }
}
```