### PR TITLE
feat(liferay-cli): add new 'theme spritemap' target type

### DIFF
--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -22,7 +22,7 @@ on:
 
 env:
     CI: true
-    yarn-cache-name: yarn-cache-4
+    yarn-cache-name: yarn-cache-1
     yarn-cache-path: .yarn
 
 jobs:

--- a/projects/js-toolkit/packages/liferay-cli/src/dependencies.json
+++ b/projects/js-toolkit/packages/liferay-cli/src/dependencies.json
@@ -67,5 +67,11 @@
 			"portal-7.4": "Liferay Portal CE 7.4",
 			"dxp-7.4": "Liferay DXP 7.4"
 		}
+	},
+	"target-theme-spritemap": {
+		"platforms": {
+			"portal-7.4": "Liferay Portal CE 7.4",
+			"dxp-7.4": "Liferay DXP 7.4"
+		}
 	}
 }

--- a/projects/js-toolkit/packages/liferay-cli/src/new/target-theme-spritemap/index.ts
+++ b/projects/js-toolkit/packages/liferay-cli/src/new/target-theme-spritemap/index.ts
@@ -1,0 +1,120 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import {
+	FilePath,
+	TRANSFORM_OPERATIONS,
+	TemplateRenderer,
+	format,
+	transformJsonFile,
+} from '@liferay/js-toolkit-core';
+
+import dependencies from '../../dependencies.json';
+import ensureOutputFile from '../../util/ensureOutputFile';
+import prompt from '../../util/prompt';
+import facetBuildable from '../facet-buildable';
+import facetDeployable from '../facet-deployable';
+import facetProject from '../facet-project';
+
+import type {Facet, Options, Target} from '..';
+
+export type RemoteAppTargetFacet = Facet;
+
+const {
+	PkgJson: {addDependencies},
+} = TRANSFORM_OPERATIONS;
+const {info, print, success, text} = format;
+
+const TARGET_ID = 'target-theme-spritemap';
+
+const platforms = dependencies[TARGET_ID]['platforms'];
+
+const target: Target = {
+	name: 'Liferay Theme Spritemap Client Extension (Experimental)',
+
+	async prompt(useDefaults: boolean, options: Options): Promise<Options> {
+		options = await facetProject.prompt(useDefaults, options);
+
+		options = await prompt(useDefaults, options, [
+			{
+				choices: Object.entries(platforms).map(([value, name]) => ({
+					name,
+					value,
+				})),
+				default: Object.entries(platforms)[0][0],
+				defaultDescription: `Using target platform: {${
+					Object.entries(platforms)[0][0]
+				}}`,
+				message: 'Which will be your target platform?',
+				name: 'platform',
+				type: 'list',
+			},
+			{
+				default: true,
+				defaultDescription: 'Extend Clay:',
+				message: 'Do you want to extend the original Clay spritemap?',
+				name: 'extendClay',
+				type: 'confirm',
+			},
+		]);
+
+		options = await facetBuildable.prompt(true, options);
+		options = await facetDeployable.prompt(true, options);
+
+		return options;
+	},
+
+	async render(options: Options): Promise<void> {
+		await facetProject.render(options);
+
+		const renderer = new TemplateRenderer(
+			new FilePath(__dirname).join('templates'),
+			options.outputPath
+		);
+
+		await renderer.render('liferay.json', options);
+
+		print(info`Configuring target platform...`);
+
+		const platform = `@liferay/${options.platform}`;
+
+		print(info`  Adding {${platform}} as a dependency`);
+
+		const pkgJsonFile = ensureOutputFile(options, 'package.json');
+
+		await transformJsonFile(
+			pkgJsonFile,
+			pkgJsonFile,
+			addDependencies({
+				[platform]: '*',
+			})
+		);
+
+		await renderer.render('src/foo.svg', options);
+
+		await facetBuildable.render(options);
+		await facetDeployable.render(options);
+
+		const {name} = options;
+
+		print(
+			'',
+			success`{Project has been generated successfully!}`,
+			'',
+			text`
+You can now run the following commands to build your project:
+
+    $ {cd ${name}| ↩|}
+    $ {npm install| ↩|} 
+    $ {npm run build| ↩|}
+
+That will create a {build} directory inside the project with all the contents
+needed to deploy your Remote App to your production servers.
+`
+		);
+	},
+};
+
+export default target;

--- a/projects/js-toolkit/packages/liferay-cli/src/new/target-theme-spritemap/templates/liferay.json.ejs
+++ b/projects/js-toolkit/packages/liferay-cli/src/new/target-theme-spritemap/templates/liferay.json.ejs
@@ -1,0 +1,8 @@
+{
+	"build": {
+		"type": "themeSpritemap",
+		"options": {
+			"extendClay": <%=extendClay %>
+		}
+	}
+}

--- a/projects/js-toolkit/packages/liferay-cli/src/new/target-theme-spritemap/templates/src/foo.svg.ejs
+++ b/projects/js-toolkit/packages/liferay-cli/src/new/target-theme-spritemap/templates/src/foo.svg.ejs
@@ -1,0 +1,5 @@
+<svg class="feather" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+	<path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path>
+	<line x1="16" x2="2" y1="8" y2="22"></line>
+	<line x1="17.5" x2="9" y1="15" y2="15"></line>
+</svg>


### PR DESCRIPTION
note, I added "(Experimental)" to the name, this way we don't have to make any grand promises :trollface: 

![image](https://user-images.githubusercontent.com/6843530/225595220-3efbfee9-8701-4503-9e1f-fd618fa7b66d.png)


I realized we still use "remote app" for naming stuff. Not sure if I should update that or just use "client extension" now and migrate those later.