### PR TITLE
feat(@liferay/cli): add a way to specify what version of dxp that the target project is supported

### DIFF
--- a/projects/js-toolkit/packages/liferay-cli/src/new/index.ts
+++ b/projects/js-toolkit/packages/liferay-cli/src/new/index.ts
@@ -25,6 +25,7 @@ export interface Facet {
 }
 
 export interface Target extends Facet {
+	dxpSupport?: string;
 	name: string;
 }
 
@@ -88,7 +89,14 @@ export default async function newProject(
 		else {
 			options = await prompt(batch, options, [
 				{
-					choices: targets.map((target) => target.name),
+					choices: targets.map((target) => ({
+						name: `${target.name} ${
+							target.dxpSupport
+								? `(Support: ${target.dxpSupport})`
+								: ''
+						}`,
+						value: target.name,
+					})),
 					default: targets[0].name,
 					message: 'What type of project do you want to create?',
 					name: 'target',

--- a/projects/js-toolkit/packages/liferay-cli/src/new/target-theme-spritemap/index.ts
+++ b/projects/js-toolkit/packages/liferay-cli/src/new/target-theme-spritemap/index.ts
@@ -32,7 +32,8 @@ const TARGET_ID = 'target-theme-spritemap';
 const platforms = dependencies[TARGET_ID]['platforms'];
 
 const target: Target = {
-	name: 'Liferay Theme Spritemap Client Extension (Experimental)',
+	dxpSupport: 'experimental',
+	name: 'Liferay Theme Spritemap Client Extension',
 
 	async prompt(useDefaults: boolean, options: Options): Promise<Options> {
 		options = await facetProject.prompt(useDefaults, options);


### PR DESCRIPTION
Below is an example if we added `dxpSupport` key to multiple targets. Right now I am only adding experimental to the theme spritemap
<img width="485" alt="Screen Shot 2023-03-17 at 1 11 15 PM" src="https://user-images.githubusercontent.com/6843530/225863604-2d2048b4-c833-4876-ac88-84d4d95ca81c.png">
