### PR TITLE
fix(js-toolkit-core): if run from a workspace, traverse up tree to find client-extension.yaml

### DIFF
--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -22,7 +22,7 @@ on:
 
 env:
     CI: true
-    yarn-cache-name: yarn-cache-1
+    yarn-cache-name: yarn-cache-10
     yarn-cache-path: .yarn
 
 jobs:


### PR DESCRIPTION
This is to add support for multi-CX containers