### PR TITLE
fix(portal-base): ensure that there is whitespace surrounding the svg attribute

### DIFF
--- a/projects/js-toolkit/packages/portal-base/src/build/themeSpritemap.ts
+++ b/projects/js-toolkit/packages/portal-base/src/build/themeSpritemap.ts
@@ -116,7 +116,7 @@ async function buildProject(project: Project): Promise<void> {
 			.replace(/<svg/gm, '<symbol')
 			.replace(
 				/xmlns="http:\/\/www\.w3\.org\/2000\/svg"/gm,
-				`id="${fileName}"`
+				` id="${fileName}" `
 			)
 			.replace(/<\/svg/gm, '</symbol')
 			.replace(/\n/gm, '')


### PR DESCRIPTION
Without this change, there is possibility for breaking the svg markup depending on what is provided. We might want to look at an xml parser for doing this in the future, rather than just find/replace