### PR TITLE
feat(npm-scripts): ignore dependency check for modules that have their own yarn.lock

### DIFF
--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -22,7 +22,7 @@ on:
 
 env:
     CI: true
-    yarn-cache-name: yarn-cache-10
+    yarn-cache-name: yarn-cache-11
     yarn-cache-path: .yarn
 
 jobs:

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/check/preflight/checkPackageJSONFiles.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/check/preflight/checkPackageJSONFiles.js
@@ -25,7 +25,22 @@ const BANNED_DEPENDENCY_PATTERNS = 'blacklisted-dependency-patterns';
  * Returns a (possibly empty) array of error messages.
  */
 function checkPackageJSONFiles() {
-	const packages = getPaths(['package.json'], [], IGNORE_FILE);
+	let packages = getPaths(['package.json'], [], IGNORE_FILE);
+
+	// Filters out packages that have their own yarn.lock
+
+	packages = packages.filter((packagePath) => {
+
+		// Ignore root level package.json
+
+		if (packagePath === 'package.json') {
+			return true;
+		}
+
+		return !fs.existsSync(
+			path.join(path.dirname(packagePath), 'yarn.lock')
+		);
+	});
 
 	const {rules} = getMergedConfig('npmscripts') || {};
 


### PR DESCRIPTION
Before this change we do a greedy check against ALL package.json files. We had thought that every package.json would need to follow the same dependency rules, but now with the introduction of client extensions, these package.json files will work within their own "workspace" and is isolated from liferay-portal. So now we check if the package.json has a sibling yarn.lock file, and if it does then we don't worry about that project.