### PR TITLE
fix(npm-scripts): fix path so that it works in windows

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/utils/getExternalExportsWebpackConfigs.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/getExternalExportsWebpackConfigs.js
@@ -84,7 +84,10 @@ module.exports = function getExternalExportsWebpackConfigs(
 			if (importPath.endsWith('.css')) {
 				webpackConfig.module.rules.push({
 					include: /node_modules/,
-					test: new RegExp(`${importPath.replace('/', '\\/')}$`),
+					test: (filePath) =>
+						new RegExp(`${importPath.replace('/', '\\/')}$`).test(
+							filePath.split(path.sep).join(path.posix.sep)
+						),
 					use: [
 						{
 							loader: require.resolve('./webpackExportCssLoader'),


### PR DESCRIPTION
So I think webpack uses the path.sep when calling the "test" check. Need to stil actually verify this works in a windows machine.

[This seems to be a known issue as well with webpack](https://github.com/webpack/webpack/issues/2553)