### PR TITLE
fix: babel loader and buildrc

### DIFF
--- a/maintenance/projects/js-toolkit/packages/generator-liferay-js/src/target-react-portlet/dependencies.json
+++ b/maintenance/projects/js-toolkit/packages/generator-liferay-js/src/target-react-portlet/dependencies.json
@@ -3,7 +3,8 @@
 		"@babel/cli": "^7.7.5",
 		"@babel/core": "^7.7.5",
 		"@babel/preset-env": "^7.7.6",
-		"@babel/preset-react": "^7.7.4"
+		"@babel/preset-react": "^7.7.4",
+		"babel-loader": "^8.0.0-beta.0"
 	},
 	"dependencies": {
 		"react": "16.8.6",

--- a/maintenance/projects/js-toolkit/packages/generator-liferay-js/src/utils/modifier/npmbuildrc.js
+++ b/maintenance/projects/js-toolkit/packages/generator-liferay-js/src/utils/modifier/npmbuildrc.js
@@ -81,7 +81,11 @@ export default class extends JsonModifier {
 
 			currentRules.push({
 				test,
-				use: loader,
+				"exclude": "/node_modules/",
+				"loader": loader,
+				"options": {
+					"configFile": "../.babelrc"
+				  }
 			});
 
 			prop.set(json, 'webpack.rules', currentRules);


### PR DESCRIPTION
In the latest Liferay React generator, I faced the following issues, that I was able to reproduce on different OS and setups.

- Windows 10 (Node 16)
-  MacOS (Node 16) 

The issues are: 
- Not recognising the presets, although they are installed (not recognising .babelrc)
- Dev server not starting because of the missing dependency of babel-loader. 

I added the first version, that I found it was compatible. Feel free to up/downgrade the version of babel-loader. 

