### PR TITLE
fix(npm-scripts): glob pattern isn't greedy enough if there are other patterns that want to look deeper in the directory

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/typescript/runTSC.js
+++ b/projects/npm-tools/packages/npm-scripts/src/typescript/runTSC.js
@@ -104,7 +104,7 @@ async function postProcess({compilerOptions: {outDir: baseDir}}) {
 		return;
 	}
 
-	const paths = expandGlobs(['**/*.d.ts'], [], {baseDir});
+	const paths = expandGlobs(['**/types/**/*.d.ts'], [], {baseDir});
 
 	if (!paths.length) {
 		return;

--- a/projects/npm-tools/packages/npm-scripts/src/utils/expandGlobs.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/expandGlobs.js
@@ -197,9 +197,8 @@ function expandGlobs(matchGlobs, ignoreGlobs = [], options = {}) {
 				if (type === 'directory' && match()) {
 					results.push(file);
 				}
-				else {
-					traverse(file);
-				}
+
+				traverse(file);
 			}
 			else if (type === 'file' && match()) {
 				results.push(file);

--- a/projects/npm-tools/packages/npm-scripts/src/utils/getWorkspaces.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/getWorkspaces.js
@@ -10,8 +10,6 @@ const expandGlobs = require('./expandGlobs');
 const findRoot = require('./findRoot');
 const log = require('./log');
 
-const IGNORE_GLOBS = ['node_modules/**'];
-
 /**
  * Returns a list of workspaces.
  *
@@ -32,8 +30,8 @@ function getWorkspaces() {
 				fs.readFileSync('package.json', 'utf8')
 			);
 
-			const projects = expandGlobs(workspaces.packages, IGNORE_GLOBS, {
-				maxDepth: 3,
+			const projects = expandGlobs(workspaces.packages, [], {
+				maxDepth: 4,
 				type: 'directory',
 			});
 

--- a/projects/npm-tools/packages/npm-scripts/src/utils/getWorkspaces.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/getWorkspaces.js
@@ -30,10 +30,22 @@ function getWorkspaces() {
 				fs.readFileSync('package.json', 'utf8')
 			);
 
-			const projects = expandGlobs(workspaces.packages, [], {
-				maxDepth: 4,
-				type: 'directory',
-			});
+			const projects = expandGlobs(
+				workspaces.packages,
+				[
+					'**/node_modules/**',
+					'**/.releng/**',
+					'**/.npmscripts/**',
+					'**/build',
+					'**/classes',
+					'**/src',
+					'**/test',
+				],
+				{
+					maxDepth: 4,
+					type: 'directory',
+				}
+			);
 
 			return projects
 				.filter((project) => {

--- a/projects/npm-tools/packages/npm-scripts/test/utils/expandGlobs.js
+++ b/projects/npm-tools/packages/npm-scripts/test/utils/expandGlobs.js
@@ -26,6 +26,7 @@ const FIXTURES = `
 	apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/misc/swfobject.js
 	apps/frontend-theme-porygon/frontend-theme-porygon/build/css/_clay_custom.scss
 	apps/frontend-theme-porygon/frontend-theme-porygon/build/css/clay/components/_input-groups.scss
+	apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/main.js
 	apps/journal/journal-web/build/npm/npmRunBuild/outputs/META-INF/resources/js/DDMTemplatesManagementToolbarDefaultEventHandler.es.js
 	apps/journal/journal-web/classes/META-INF/resources/node_modules/journal-web$lodash.escape@4.0.1/index.js
 	apps/journal/journal-web/src/main/resources/META-INF/resources/js/DDMStructuresManagementToolbarDefaultEventHandler.es.js
@@ -150,11 +151,17 @@ describe('expandGlobs()', () => {
 
 		expect(matches).toEqual([
 			'apps/change-tracking',
+			'apps/change-tracking/change-tracking-change-lists-configuration-web',
+			'apps/change-tracking/change-tracking-change-lists-indicator-web',
 			'apps/document-library/document-library-preview-image',
 			'apps/fragment',
+			'apps/fragment/fragment-demo-data-creator-impl',
+			'apps/fragment/fragment-test',
 			'apps/frontend-theme-porygon',
+			'apps/frontend-theme-porygon/frontend-theme-porygon',
 			'apps/layout/layout-content-page-editor-web',
 			'apps/portal-portlet-bridge',
+			'apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl',
 			'sdk/gradle-plugins-theme-builder',
 		]);
 	});
@@ -239,5 +246,15 @@ describe('expandGlobs()', () => {
 		files = expand(['*'], [], {baseDir: randomTempDir});
 
 		expect(files).toEqual([tempFilePath]);
+	});
+
+	it('can match deeply nested directories when a previous glob matches', () => {
+		const matches = expand(['apps/*/*', 'apps/*/*/*'], [], {
+			type: 'directory',
+		});
+
+		expect(matches).toContain(
+			'apps/headless/headless-builder/headless-builder-web'
+		);
 	});
 });


### PR DESCRIPTION
This issue originally appeared here, 
https://liferay.slack.com/archives/C03CAD9EF/p1684869953566979?thread_ts=1684869909.630399&cid=C03CAD9EF


Essentially the issue we are running into is that our `expandGlobs` function is returning too soon and not looking deep enough 
into a directory. For example, in portal we have the globs of `['/apps/*/*', '/apps/*/*/*']`. This means we want to check for 
directories in both the 2nd and 3rd level deep from "apps". An example of this is that we would want to match both 
`apps/frontend-js/frontend-js-web` and additionally match `apps/headless/headless-builder/headless-builder-web`.

This doesn't actually work as we expected though because expandGlobs gets a postive hit for `apps/headless/headless-builder` and 
then doesn't look any deeper. The change I am making here ensures that we continue to look deeper in the file structure in case 
another matcher returns a hit.This issue originally appeared here,
https://liferay.slack.com/archives/C03CAD9EF/p1684869953566979?thread_ts=1684869909.630399&cid=C03CAD9EF


Essentially the issue we are running into is that our `expandGlobs` function is returning too soon and not looking deep enough
into a directory. For example, in portal we have the globs of `['/apps/*/*', '/apps/*/*/*']`. This means we want to check for
directories in both the 2nd and 3rd level deep from "apps". An example of this is that we would want to match both
`apps/frontend-js/frontend-js-web` and additionally match `apps/headless/headless-builder/headless-builder-web`.

This doesn't actually work as we expected though because expandGlobs gets a postive hit for `apps/headless/headless-builder` and
then doesn't look any deeper. The change I am making here ensures that we continue to look deeper in the file structure in case
another matcher returns a hit.