### PR TITLE
feat(npm-scripts): support SVG exports

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/utils/webpackExportSvgLoader.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/webpackExportSvgLoader.js
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+module.exports = function (content, _map, _meta) {
+	return `
+const span = document.createElement('span');
+span.innerHTML = \`${content.replace(/`/g, '\\`')}\`;
+document.querySelector('head').appendChild(span);
+`;
+};


### PR DESCRIPTION
They work similar to CSS but inline the content directly instead of retrieving it from the server. This is because SVG files don't undergo any process in the server, as CSS files do, so there's no need to make two trips to the server when we can make just one.