### PR TITLE
feat(npm-scripts): improve strategy for generating types, only generate types for modules that have changes to ts files or if their dependencies have changes

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/index.js
+++ b/projects/npm-tools/packages/npm-scripts/src/index.js
@@ -62,7 +62,7 @@ module.exports = async function () {
 		},
 
 		async types() {
-			await require('./scripts/types')();
+			await require('./scripts/types')(...ARGS_ARRAY.slice(1));
 		},
 
 		webpack() {

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/check/preflight/checkTypeScriptTypeArtifacts.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/check/preflight/checkTypeScriptTypeArtifacts.js
@@ -4,6 +4,7 @@
  */
 
 const getTypeScriptDependencyGraph = require('../../../typescript/getTypeScriptDependencyGraph');
+const getLiferayWorkingBranch = require('../../../utils/getLiferayWorkingBranch');
 const git = require('../../../utils/git');
 const types = require('../../types');
 
@@ -14,7 +15,7 @@ const types = require('../../types');
  * LIFERAY_NPM_SCRIPTS_WORKING_BRANCH_NAME is set).
  */
 async function checkTypeScriptTypeArtifacts() {
-	const upstream = process.env.LIFERAY_NPM_SCRIPTS_WORKING_BRANCH_NAME;
+	const upstream = getLiferayWorkingBranch();
 
 	const errors = [];
 

--- a/projects/npm-tools/packages/npm-scripts/src/scripts/types.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/types.js
@@ -9,10 +9,40 @@ const getTypeScriptBuildOrder = require('../typescript/getTypeScriptBuildOrder')
 const getTypeScriptDependencyGraph = require('../typescript/getTypeScriptDependencyGraph');
 const runTSC = require('../typescript/runTSC');
 const findRoot = require('../utils/findRoot');
+const getLiferayWorkingBranch = require('../utils/getLiferayWorkingBranch');
 const getMergedConfig = require('../utils/getMergedConfig');
+const git = require('../utils/git');
 const log = require('../utils/log');
 
-async function types() {
+function tsDiffFromWorkingBranch() {
+	const upstream = getLiferayWorkingBranch();
+
+	const mergeBase = git('merge-base', 'HEAD', upstream);
+
+	const diff = git('diff', mergeBase, '--name-only');
+
+	const changedFiles = diff
+		.split('\n')
+		.filter(
+			(filePath) =>
+				filePath.endsWith('.d.ts') ||
+				filePath.endsWith('.ts') ||
+				filePath.endsWith('.tsx')
+		)
+		.join('\n');
+
+	if (!changedFiles.length) {
+		log(
+			`There are no modified typescript files on the current branch compared to working branch (${upstream})`
+		);
+	}
+
+	return changedFiles;
+}
+
+async function types(...args) {
+	const force = args.includes('--force');
+
 	const cwd = process.cwd();
 	const root = findRoot();
 
@@ -34,9 +64,15 @@ async function types() {
 	const projects = getTypeScriptBuildOrder(graph);
 
 	let upToDateCount = 0;
+	let notChecked = 0;
+	let skipped = 0;
+
+	log(`Generating types for ${projects.length} projects:`);
+
+	const filesDiff = force ? [] : tsDiffFromWorkingBranch();
 
 	for (let i = 0; i < projects.length; i++) {
-		const {directory, name} = projects[i];
+		const {dependencies, directory, name} = projects[i];
 
 		try {
 			process.chdir(directory);
@@ -46,22 +82,40 @@ async function types() {
 			const {build: BUILD_CONFIG} = config;
 
 			if (BUILD_CONFIG.tsc !== false) {
-				log(
-					`Generating types (${i + 1} of ${projects.length}): ${name}`
+				const dependencyNames = Object.keys(dependencies);
+
+				const dependencyDirname = projects
+					.filter((project) => dependencyNames.includes(project.name))
+					.map((project) => path.basename(project.directory));
+
+				const moduleChanges = filesDiff.includes(
+					path.basename(directory)
 				);
 
-				if (await runTSC()) {
-					upToDateCount++;
+				const dependencyChanges = dependencyDirname.find(
+					(dependencyDirectoryName) =>
+						filesDiff.includes(dependencyDirectoryName)
+				);
+
+				if (force || moduleChanges || dependencyChanges) {
+					const description = moduleChanges
+						? `(changes detected)`
+						: dependencyChanges
+						? `(changes to a dependency)`
+						: '';
+
+					log(`> ${upToDateCount + 1}. '${name}' ${description}`);
+
+					if (await runTSC()) {
+						upToDateCount++;
+					}
+				}
+				else {
+					notChecked++;
 				}
 			}
 			else {
-				log(
-					`Skipping types for (${i + 1} of ${
-						projects.length
-					}): ${name}(config.build.tsc=false)`
-				);
-
-				upToDateCount++;
+				skipped++;
 			}
 		}
 		finally {
@@ -69,7 +123,21 @@ async function types() {
 		}
 	}
 
-	const staleCount = projects.length - upToDateCount;
+	const staleCount = projects.length - upToDateCount - skipped - notChecked;
+
+	if (filesDiff.length) {
+		if (skipped > 0) {
+			log(
+				`> Skipped types for ${skipped} modules. (config.build.tsc=false)`
+			);
+		}
+
+		if (notChecked > 0) {
+			log(
+				`> No changes were detected for ${notChecked} other modules or their dependencies.`
+			);
+		}
+	}
 
 	if (staleCount) {
 		const description =

--- a/projects/npm-tools/packages/npm-scripts/src/utils/getLiferayWorkingBranch.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/getLiferayWorkingBranch.js
@@ -1,0 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+module.exports = function getLiferayWorkingBranch() {
+	return process.env.LIFERAY_NPM_SCRIPTS_WORKING_BRANCH_NAME || 'master';
+};


### PR DESCRIPTION
Here the goal is to only generate types when ts files have been changed. This is particularly helpful when running `ant format-source-current-branch`

The strategy is to diff against the liferay working branch ([master](https://github.com/liferay/liferay-portal/blob/master/portal-impl/build.xml#L669)). If there are any typescript files changed then we re-build types for that module and it's dependents.

Here is the new output:

- No changes to any files
![Screenshot 2023-06-22 at 11 39 17 AM](https://github.com/liferay/liferay-frontend-projects/assets/6843530/97574127-5194-4f5b-8929-11c5f4863a14)

- new `--force` option when we want to re-build all types. Will primarily only be used by FI team
![Screenshot 2023-06-22 at 11 40 38 AM](https://github.com/liferay/liferay-frontend-projects/assets/6843530/6a59cc00-2687-446d-8423-8af6ae60815b)

- Changes to a single module's ts files. This rebuilds the changed module and any dependent modules
![Screenshot 2023-06-22 at 11 42 51 AM](https://github.com/liferay/liferay-frontend-projects/assets/6843530/9d19bc03-9c61-47a5-aa4e-91b9835ca9d8)

- `ant format-source-current-branch` when only java files have changed
![Screenshot 2023-06-22 at 11 44 45 AM](https://github.com/liferay/liferay-frontend-projects/assets/6843530/5ffd1f7a-5b80-4274-aa02-6776d831b6e9)

- `ant format-source-current-branch` when ts files have changed
![Screenshot 2023-06-22 at 11 47 13 AM](https://github.com/liferay/liferay-frontend-projects/assets/6843530/c13aef8a-c5ff-42f6-b099-fc8e77cd1b4f)


