### PR TITLE
feat(amd-loader): make loader compatible with CSP `script-src '[$NONCE$]'`

### DIFF
--- a/projects/amd-loader/src/loader/config.js
+++ b/projects/amd-loader/src/loader/config.js
@@ -28,6 +28,7 @@ export default class Config {
 		this._parse(cfg, 'basePath', '/');
 		this._parse(cfg, 'resolvePath', '/o/js_resolve_modules');
 		this._parse(cfg, 'combine', false);
+		this._parse(cfg, 'nonce', '');
 		this._parse(cfg, 'url', '');
 		this._parse(cfg, 'urlMaxLength', 2000);
 		this._parse(cfg, 'logLevel', 'error');

--- a/projects/amd-loader/src/loader/script-loader.js
+++ b/projects/amd-loader/src/loader/script-loader.js
@@ -68,6 +68,7 @@ export default class ScriptLoader {
 
 			script.src = modulesURL.url;
 			script.async = false;
+			script.setAttribute('nonce', config.nonce);
 
 			if (modulesURL.useESM) {
 				script.type = config.moduleType;

--- a/projects/amd-loader/test/loader/loader.js
+++ b/projects/amd-loader/test/loader/loader.js
@@ -44,7 +44,13 @@ describe('Loader', () => {
 
 		const document = {
 			createElement: () => {
-				const script = {};
+				const script = {
+					attributes: {},
+				};
+
+				script.setAttribute = (name, value) => {
+					script.attributes[name] = value;
+				};
 
 				setTimeout(() => {
 					try {

--- a/projects/amd-loader/test/loader/script-loader.js
+++ b/projects/amd-loader/test/loader/script-loader.js
@@ -12,7 +12,13 @@ describe('ScriptLoader', () => {
 	beforeEach(() => {
 		document = {
 			createElement: () => {
-				const script = {};
+				const script = {
+					attributes: {},
+				};
+
+				script.setAttribute = (name, value) => {
+					script.attributes[name] = value;
+				};
 
 				document.scripts.push(script);
 


### PR DESCRIPTION
We need to propagate the CSP nonce to be able to load AMD scripts.

See:

- https://liferay.atlassian.net/browse/LPS-178066
- https://liferay.atlassian.net/browse/LPS-178066?focusedCommentId=2184413
- https://liferay.atlassian.net/browse/LPS-178066?focusedCommentId=2184418