### PR TITLE
feat(js-api): add FDS CX interfaces with `HTMLBuilder` naming convention

### DIFF
--- a/projects/js-toolkit/packages/js-api/data-set/index.ts
+++ b/projects/js-toolkit/packages/js-api/data-set/index.ts
@@ -3,6 +3,14 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
+export interface FDSTableCellHTMLElementBuilderArgs {
+	value: boolean | number | string | object | [];
+}
+
+export interface FDSTableCellHTMLElementBuilder {
+	(args: FDSTableCellHTMLElementBuilderArgs): HTMLElement;
+}
+
 export interface FDSCellRendererArgs {
 	value: boolean | number | string | object | [];
 }
@@ -24,4 +32,13 @@ export interface FDSFilterArgs {
 
 export interface FDSFilter {
 	(args: FDSFilterArgs): HTMLElement;
+}
+
+export interface FDSFilterHTMLElementBuilderArgs {
+	filter: FDSFilterData;
+	setFilter: (val: Partial<FDSFilterData>) => void;
+}
+
+export interface FDSFilterHTMLElementBuilder {
+	(args: FDSFilterHTMLElementBuilderArgs): HTMLElement;
 }


### PR DESCRIPTION
### References

- [LPS-189354 Standardize renderer APIs](https://issues.liferay.com/browse/LPS-189354)

### What is the goal of this PR?

In the PR, we are introducing the `HTMLBuilder` naming convention to public API:
- `*Renderer` is not quite right, as this is a property of a "Renderer" in DXP.
- `*Component` would not be right, as the function is not [used](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/ClientExtension.tsx#L21) as a React component. It's used as a plain old function. 
- No suffix, like `FDSFilter`, might be confusing, as there are objects with the same name in DXP.
- We already introduced `htmlBuilder` as an argument of the [ClientExtension component](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/ClientExtension.tsx#L10).

We are only adding API, and not renaming, so that the existing contracts don't break. After we migrate usages in DXP, we can delete old API here.

@bryceosterhaus @izaera What do you think?
