### PR TITLE
fix(senna): Modify URI generation to properly handle link to emails

### DIFF
--- a/maintenance/projects/senna/src/app/App.js
+++ b/maintenance/projects/senna/src/app/App.js
@@ -327,7 +327,9 @@ class App extends EventEmitter {
 	 * @return {boolean}
 	 */
 	canNavigate(url) {
-		const uri = utils.isWebUri(url);
+		const uri = url.startsWith('/')
+			? new URL(url, window.location.origin)
+			: new URL(url);
 
 		if (!uri) {
 			return false;


### PR DESCRIPTION
As of today email links such as mailto:john.doe@liferay.com are handled like regular links making a mess figuring out what the protocol, domain, etc. are. 

This PR is trying to fix that.