### PR TITLE
feat(js-api)!: improve FDS filter CX interfaces

### DIFF
--- a/projects/js-toolkit/packages/js-api/data-set/index.ts
+++ b/projects/js-toolkit/packages/js-api/data-set/index.ts
@@ -13,14 +13,6 @@ export interface FDSTableCellHTMLElementBuilder {
 	(args: FDSTableCellHTMLElementBuilderArgs): HTMLElement;
 }
 
-export interface FDSCellRendererArgs {
-	value: boolean | number | string | object | [];
-}
-
-export interface FDSCellRenderer {
-	(args: FDSCellRendererArgs): HTMLElement;
-}
-
 // Frontend data set filter
 
 export interface FDSFilterData<T> {

--- a/projects/js-toolkit/packages/js-api/data-set/index.ts
+++ b/projects/js-toolkit/packages/js-api/data-set/index.ts
@@ -45,7 +45,7 @@ export interface FDSFilterDescriptionBuilder<T> {
 }
 
 export interface FDSFilter<T> {
-	buildFilterDescription: FDSFilterDescriptionBuilder<T>,
-	buildHTMLElement: FDSFilterHTMLElementBuilder<T>,
-	buildODataQuery: FDSFilterODataQueryBuilder<T>,
+	buildFilterDescription: FDSFilterDescriptionBuilder<T>;
+	buildHTMLElement: FDSFilterHTMLElementBuilder<T>;
+	buildODataQuery: FDSFilterODataQueryBuilder<T>;
 }

--- a/projects/js-toolkit/packages/js-api/data-set/index.ts
+++ b/projects/js-toolkit/packages/js-api/data-set/index.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
+// Frontend data set cell renderer
+
 export interface FDSTableCellHTMLElementBuilderArgs {
 	value: boolean | number | string | object | [];
 }
@@ -19,26 +21,31 @@ export interface FDSCellRenderer {
 	(args: FDSCellRendererArgs): HTMLElement;
 }
 
-export interface FDSFilterData {
-	id: string;
-	odataFilterString: string;
-	selectedData: string;
+// Frontend data set filter
+
+export interface FDSFilterData<T> {
+	selectedData: T;
 }
 
-export interface FDSFilterArgs {
-	filter: FDSFilterData;
-	setFilter: (val: Partial<FDSFilterData>) => void;
+export interface FDSFilterHTMLElementBuilderArgs<T> {
+	filter: FDSFilterData<T>;
+	setFilter: (partialFilter: Partial<FDSFilterData<T>>) => void;
 }
 
-export interface FDSFilter {
-	(args: FDSFilterArgs): HTMLElement;
+export interface FDSFilterHTMLElementBuilder<T> {
+	(args: FDSFilterHTMLElementBuilderArgs<T>): HTMLElement;
 }
 
-export interface FDSFilterHTMLElementBuilderArgs {
-	filter: FDSFilterData;
-	setFilter: (val: Partial<FDSFilterData>) => void;
+export interface FDSFilterODataQueryBuilder<T> {
+	(selectedData: T): string;
 }
 
-export interface FDSFilterHTMLElementBuilder {
-	(args: FDSFilterHTMLElementBuilderArgs): HTMLElement;
+export interface FDSFilterDescriptionBuilder<T> {
+	(selectedData: T): string;
+}
+
+export interface FDSFilter<T> {
+	buildFilterDescription: FDSFilterDescriptionBuilder<T>,
+	buildHTMLElement: FDSFilterHTMLElementBuilder<T>,
+	buildODataQuery: FDSFilterODataQueryBuilder<T>,
 }

--- a/projects/js-toolkit/packages/js-api/data-set/index.ts
+++ b/projects/js-toolkit/packages/js-api/data-set/index.ts
@@ -37,7 +37,7 @@ export interface FDSFilterDescriptionBuilder<T> {
 }
 
 export interface FDSFilter<T> {
-	buildFilterDescription: FDSFilterDescriptionBuilder<T>;
-	buildHTMLElement: FDSFilterHTMLElementBuilder<T>;
-	buildODataQuery: FDSFilterODataQueryBuilder<T>;
+	descriptionBuilder: FDSFilterDescriptionBuilder<T>;
+	htmlElementBuilder: FDSFilterHTMLElementBuilder<T>;
+	oDataQueryBuilder: FDSFilterODataQueryBuilder<T>;
 }


### PR DESCRIPTION
See https://liferay.atlassian.net/browse/LPS-197299

This is a breaking change but we have not yet released any GA version of @liferay/js-api so there shouldn't be any problem.

Note that I've changed the names of the exported functions and types to meaningful (from the POV of the customer) ones. 

This is because I think we should not tie API names to portal internal stuff. In this case I've left the `HTMLBuilder` concept around because it makes sense, but I've renamed the names of the methods and they don't match the internal ones we use in portal any more.

The rationale for not aligning API and internal names is simple: internal names are subject to change and do change, in fact, as we evolve the product, whereas API names must remain stable forever unless we want to be continuously breaking customers code.