### PR TITLE
fix(js-api): readd .js files to npm package

### DIFF
--- a/projects/js-toolkit/packages/js-api/.npmignore
+++ b/projects/js-toolkit/packages/js-api/.npmignore
@@ -3,6 +3,4 @@
 /tsconfig.tsbuildinfo
 /webpack.config.js
 
-/**/*.js
-
 /*.tgz


### PR DESCRIPTION
JS files are needed for webpack to work at the liferay portal side.

Additionally, it's possible that we add some runnable stuff to this package in the future, so we readd js files.