### PR TITLE
fix(alloy-ui): AUI-3221 This is not needed anymore and it's causing t…

### DIFF
--- a/third-party/projects/alloy-ui/src/aui-form-validator/js/aui-form-validator.js
+++ b/third-party/projects/alloy-ui/src/aui-form-validator/js/aui-form-validator.js
@@ -689,8 +689,6 @@ var FormValidator = A.Component.create({
                 field = boundingBox.one('.' + CSS_ERROR_FIELD);
 
             if (field) {
-                field = instance.findFieldContainer(field);
-
                 if (instance.get('selectText')) {
                     field.selectText();
                 }


### PR DESCRIPTION
…o try to focus on not focusable elements since parent container of a form field is in general a div element