### PR TITLE
feat(js-api): add types for Editor Config Contributor client extension

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,6 @@ jobs:
     triage:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/labeler@main
+            - uses: actions/labeler@v4
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/projects/js-toolkit/packages/js-api/editor/index.ts
+++ b/projects/js-toolkit/packages/js-api/editor/index.ts
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Editor Transformer
+ *
+ * For CKEditor 4, see config API:
+ * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html
+ */
+
+export interface EditorConfigTransformer<T> {
+	(args: T): T;
+}
+
+export interface EditorTransformer<T> {
+	editorConfigTransformer: EditorConfigTransformer<T>;
+}


### PR DESCRIPTION
### References

- [LPS-187309 Apply editor config contributor client extensions to CKEditor](https://issues.liferay.com/browse/LPS-187309)
- Related to https://github.com/liferay-frontend/liferay-portal/pull/3902

### What is the goal of this PR?

Adding public types for Editor Config Contributor client extension.

Notes:
- I intentionally named this in a generic way, `EditorConfigTransformer` and not  `EditorConfigContributor`. We plan to add a different CET in the future, that will not use the Java `EditorConfigContributor` framework in DXP. That CET will still be able to use this API, as both will do the same config transformation in the end.
- I don't think we want to manage anything more specific than `[key: string]: any;` for config structure. This is based on the third-party APIs and is likely to change with time. Being so generic will also enable us to be consistent with APIs for CKEditor 5 or other editors. I added in commited docs link to offical docs for the `config` object.
