### PR TITLE
feat(npm-scripts): detect root dir when package-lock.json present

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/utils/findRoot.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/findRoot.js
@@ -24,7 +24,10 @@ function findRoot() {
 	let directory = process.cwd();
 
 	while (directory) {
-		if (fs.existsSync(path.join(directory, 'yarn.lock'))) {
+		if (
+			fs.existsSync(path.join(directory, 'yarn.lock')) ||
+			fs.existsSync(path.join(directory, 'package-lock.json'))
+		) {
 			const basename = path.basename(directory);
 
 			if (basename === 'modules') {


### PR DESCRIPTION
This is needed so that liferay-portal's Playwright tests can use npm-scripts without the `--experimental-standalone` flag.