### PR TITLE
fix: Exchange flipping and style evaluation order to avoid css flicker #1188

### DIFF
--- a/maintenance/projects/senna/src/app/App.js
+++ b/maintenance/projects/senna/src/app/App.js
@@ -483,8 +483,8 @@ class App extends EventEmitter {
 					this.extractParams(route, path)
 				);
 			})
-			.then(() => nextScreen.evaluateStyles(this.surfaces))
 			.then(() => nextScreen.flip(this.surfaces))
+			.then(() => nextScreen.evaluateStyles(this.surfaces))
 			.then(() => nextScreen.evaluateScripts(this.surfaces))
 			.then(() => this.maybeUpdateScrollPositionState_())
 			.then(() => this.syncScrollPositionSyncThenAsync_())

--- a/maintenance/projects/senna/test/app/App.js
+++ b/maintenance/projects/senna/test/app/App.js
@@ -1656,15 +1656,15 @@ describe('App', function () {
 			this.app.navigate('/path2').then(() => {
 				var lifecycleOrder = [
 					StubScreen.prototype.load,
-					StubScreen.prototype.evaluateStyles,
 					StubScreen.prototype.flip,
+					StubScreen.prototype.evaluateStyles,
 					StubScreen.prototype.evaluateScripts,
 					StubScreen.prototype.activate,
 					StubScreen.prototype.beforeDeactivate,
 					StubScreen2.prototype.load,
 					StubScreen.prototype.deactivate,
-					StubScreen2.prototype.evaluateStyles,
 					StubScreen2.prototype.flip,
+					StubScreen2.prototype.evaluateStyles,
 					StubScreen2.prototype.evaluateScripts,
 					StubScreen2.prototype.activate,
 					StubScreen.prototype.disposeInternal,


### PR DESCRIPTION
Hello,

**Issue:**
[ 🐛 Bug report](https://github.com/liferay/liferay-frontend-projects/issues/1188)

Description
[LPS-206518](https://liferay.atlassian.net/browse/LPS-206518)

**Desired behavior:**
Applied Style book's style remain unchanged during navigation

**Current behavior:**
Applied Style book's style changes during navigation as it is overridden by theme's style

**Other information** (environment, versions etc):
Reproducible on Liferay 7.3.x and lower

The same fix has been applied to senna within the DXP code base on 7.4 under [LPS-202135](https://liferay.atlassian.net/browse/LPS-202135)