### PR TITLE
fix(liferay-theme-task): Update regex to allow mulitple semicolons for @import

### DIFF
--- a/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/css-parse.js
+++ b/projects/js-themes-toolkit/packages/liferay-theme-tasks/lib/r2/liferay-r2/css-parse.js
@@ -584,7 +584,13 @@ module.exports = function (css, options) {
 
 	function _atrule(name) {
 		var pos = position();
-		var m = match(new RegExp('^@' + name + ' *([^;\\n]+);'));
+		var m = match(
+			new RegExp(
+				'^@' +
+					name +
+					' *(?:url\\(([^)]+)\\)|([^;\\n]*))(?: *([^;\\n]*))?;'
+			)
+		);
 		if (!m) {
 			return;
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-3102

When a theme contains the following, the regex stops at the first semicolon, causing issues in the _rtl.css files.
`@import url("https://fonts.googleapis.com/css2?family=Manrope:wght@300;500;600;700;800&display=swap");`

I was able to resolve this by adjusting the regex so it allows multiple semicolons.

Let me know if there are any questions or comments about this.
Thank you!