### PR TITLE
fix(npm-scripts): ignore url options in css as we don't support loading files other than js and css

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/utils/getExternalExportsWebpackConfigs.js
+++ b/projects/npm-tools/packages/npm-scripts/src/utils/getExternalExportsWebpackConfigs.js
@@ -127,6 +127,7 @@ module.exports = function getExternalExportsWebpackConfigs(
 						},
 						{
 							loader: require.resolve('css-loader'),
+							options: {url: false},
 						},
 					],
 				});


### PR DESCRIPTION
When adding an "exports" in a dxp module, we want to at times allow for setting css files. This is the case for `leaflet/dist/leaflet.css` which is used in DXP. However, this fails because it is trying to load an external .png file. By setting url to false, we disable webpack from processing url references.