### PR TITLE
fix(alloy-ui): AUI-3222 Avoid calling selectionChange on invaild dates

### DIFF
--- a/third-party/projects/alloy-ui/src/aui-datepicker/js/aui-datepicker-native.js
+++ b/third-party/projects/alloy-ui/src/aui-datepicker/js/aui-datepicker-native.js
@@ -232,10 +232,12 @@ DatePickerNativeBase.prototype = {
             parsed = instance._parseDateFromString(activeInput.val());
         }
 
-        instance.fire(
-            'selectionChange', {
-                newSelection: parsed ? [parsed] : []
-            });
+        if (parsed) {
+            instance.fire(
+                'selectionChange', {
+                    newSelection: [parsed]
+                });
+        }
     },
 
     /**


### PR DESCRIPTION
https://liferay.atlassian.net/browse/AUI-3222
https://liferay.atlassian.net/browse/LPD-22812

This is to fix errors in the console when erasing the hour or minutes of input time. By preventing firing `selectionChange` when the date is invalid, we are able to keep the same behavior without having errors in the log.


If we try to fix this in [input_time/page.jsp](https://github.com/liferay/liferay-portal/blob/master/portal-web/docroot/html/taglib/ui/input_time/page.jsp#L129) the time will revert to `--:--:-` which will be tedious for users having to reenter the time again.
[Screencast from 04-10-2024 11:12:46 AM.webm](https://github.com/liferay/liferay-frontend-projects/assets/31672551/3082c4b2-f3f9-492f-84de-3031769cbc59)



