### PR TITLE
feat(npm-scripts): provide a flag to disable sass

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
+++ b/projects/npm-tools/packages/npm-scripts/src/scripts/build.js
@@ -38,6 +38,7 @@ const CWD = process.cwd();
  * ".npmbridgerc" and "webpack.config.js" files, respectively, are
  * present.
  * `minify()` is run unless `NODE_ENV` is `development`.
+ * Sass is run unless disable flag is set.
  */
 module.exports = async function (...args) {
 	const bnd = parseBnd();
@@ -146,7 +147,7 @@ module.exports = async function (...args) {
 		);
 	}
 
-	if (inputPathExists) {
+	if (inputPathExists && BUILD_CONFIG.sass !== false) {
 		buildSass(path.join(CWD, BUILD_CONFIG.input), {
 			imports: BUILD_CONFIG.sassIncludePaths,
 			outputDir: BUILD_CONFIG.output,


### PR DESCRIPTION
I don't need this to be merged fast, but:

1. It makes sense since we already have disable flags for the rest of the toolling.
2. It will be handy when we start using the native sass compiler.