### PR TITLE
fix(npm-scripts): don't use prettier plugins when formatting d.ts files

### DIFF
--- a/projects/npm-tools/packages/npm-scripts/src/typescript/runTSC.js
+++ b/projects/npm-tools/packages/npm-scripts/src/typescript/runTSC.js
@@ -137,6 +137,7 @@ async function postProcess({compilerOptions: {outDir: baseDir}}) {
 			const prettierOptions = {
 				...config,
 				filepath,
+				plugins: [], // intentionally drop any plugins
 			};
 
 			const formatted = await prettier.format(source, prettierOptions);


### PR DESCRIPTION
small patch to avoid some current headaches I am having