### PR TITLE
fix(alloy-ui): Use aria attributes in calendar event popup triggers

### DIFF
--- a/third-party/projects/alloy-ui/src/aui-scheduler/js/aui-scheduler-base-event.js
+++ b/third-party/projects/alloy-ui/src/aui-scheduler/js/aui-scheduler-base-event.js
@@ -357,7 +357,7 @@ var SchedulerEvent = A.Component.create({
         'colorSaturationFactor', 'titleDateFormat', 'visible', 'disabled'],
 
     prototype: {
-        EVENT_NODE_TEMPLATE: '<div class="' + CSS_SCHEDULER_EVENT + '" tabindex="0">' + '<div class="' +
+        EVENT_NODE_TEMPLATE: '<div aria-expanded="false" aria-haspopup="dioalog" class="' + CSS_SCHEDULER_EVENT + '" tabindex="0">' + '<div class="' +
             CSS_SCHEDULER_EVENT_TITLE +
             '"></div>' + '<div class="' + CSS_SCHEDULER_EVENT_CONTENT + '"></div>' +
             '<div class="' + CSS_SCHEDULER_EVENT_NAME + '"></div>' +

--- a/third-party/projects/alloy-ui/src/aui-scheduler/js/aui-scheduler-event-recorder.js
+++ b/third-party/projects/alloy-ui/src/aui-scheduler/js/aui-scheduler-event-recorder.js
@@ -329,6 +329,7 @@ var SchedulerEventRecorder = A.Component.create({
 
             if (selectedEvent) {
                 selectedEvent.focus();
+                selectedEvent.setAttribute('aria-expanded', false);
             }
         },
 
@@ -393,6 +394,10 @@ var SchedulerEventRecorder = A.Component.create({
                 node: node,
                 points: align.points
             });
+
+            instance._selectedEvent = node;
+
+            node.setAttribute('aria-expanded', true);
 
             popover.show();
 
@@ -722,6 +727,7 @@ var SchedulerEventRecorder = A.Component.create({
             instance.formNode.on('submit', A.bind(instance._onSubmitForm, instance));
 
             instance.popover.get('boundingBox').addClass(CSS_SCHEDULER_EVENT_RECORDER_POP_OVER);
+            instance.popover.get('boundingBox').setAttribute('tabindex', -1);
             instance.popover.get('contentBox').wrap(instance.formNode);
 
             schedulerBB.on('clickoutside', A.bind(instance._handleClickOutSide, instance));

--- a/third-party/projects/alloy-ui/src/aui-scheduler/js/aui-scheduler-view-agenda.js
+++ b/third-party/projects/alloy-ui/src/aui-scheduler/js/aui-scheduler-view-agenda.js
@@ -67,7 +67,7 @@ var Lang = A.Lang,
 
     TPL_EVENTS_CONTAINER = '<div class="' + CSS_EVENTS + '">{content}</div>',
 
-    TPL_EVENT = '<div class="' + [CSS_EVENT, CSS_CLEARFIX].join(' ') +
+    TPL_EVENT = '<div aria-expanded="false" aria-haspopup="dioalog" class="' + [CSS_EVENT, CSS_CLEARFIX].join(' ') +
         ' {firstClassName} {lastClassName} {eventClassName}" data-clientId="{clientId}">' +
         '<div class="' + CSS_EVENT_COLOR + '" style="background-color: {color};"></div>' +
         '<div class="' + CSS_EVENT_CONTENT + '">{content}</div>' +


### PR DESCRIPTION
Jira [ticket](https://liferay.atlassian.net/browse/LPD-43532), related to this [PTR](https://liferay.atlassian.net/browse/PTR-5837?focusedCommentId=2798756)

Hello reviewer, some line breaks were not performed. I had difficulty using gulp to automate things, such as code formatting. I made the version settings to those defined in alloy-ui/package.json:

```
"engines": {
    "npm": ">=2.0.0",
    "node": "<=0.12.0"
}
```

I ran the [setup](https://github.com/liferay/alloy-ui?tab=readme-ov-file#setup) commands, but I received errors when trying to run gulp help. Let me know if I need to do anything different to format these lines

I was able to run tests at runtime using the Chrome devtools override feature, following this [same approach](https://liferay.atlassian.net/wiki/spaces/ENGFRONTENDINFRA/pages/3178823717/How+to+Use+Chrome+DevTools+Override+Content+to+Test+Changes+in+YUI3+on+Liferay). The test result:

https://github.com/user-attachments/assets/be7ea6f9-a869-4287-9102-04a999a1a15b