### PR TITLE
feat(js-api): Add itemData to FDSTableCellHTMLElementBuilderArgs

### DIFF
--- a/projects/js-toolkit/packages/js-api/data-set/index.ts
+++ b/projects/js-toolkit/packages/js-api/data-set/index.ts
@@ -6,6 +6,7 @@
 // Frontend data set cell renderer
 
 export interface FDSTableCellHTMLElementBuilderArgs {
+	itemData?: object;
 	value: boolean | number | string | object | [];
 }
 


### PR DESCRIPTION
Follow up from: https://github.com/liferay/liferay-frontend-projects/pull/1247
Issue: https://liferay.atlassian.net/browse/LPD-50122

<h1>Allow accessing all row Content in the Cell Renderer Client Extension</h1>

The goal of this PR is to provide support for `itemData` arg in `js-api` , which is needed for Frontend data set cell renderer to access all row items.