### PR TITLE
fix(js-api): Update itemData type on FDSTableCellHTMLElementBuilderArgs

### DIFF
--- a/projects/js-toolkit/packages/js-api/data-set/index.ts
+++ b/projects/js-toolkit/packages/js-api/data-set/index.ts
@@ -6,7 +6,7 @@
 // Frontend data set cell renderer
 
 export interface FDSTableCellHTMLElementBuilderArgs {
-	itemData?: object;
+	itemData?: Record<string, unknown>;
 	value: boolean | number | string | object | [];
 }
 


### PR DESCRIPTION
Follow up from: https://github.com/liferay/liferay-frontend-projects/pull/1247
Issue: https://liferay.atlassian.net/browse/LPD-50122

Fixes type of itemData on FDSTableCellHTMLElementBuilderArgs to make it more convenient to use.