### PR TITLE
fix(alloy-ui): Avoid accessibility issues on calendar's add event modal

### DIFF
--- a/third-party/projects/alloy-ui/src/aui-datepicker/js/aui-datepicker.js
+++ b/third-party/projects/alloy-ui/src/aui-datepicker/js/aui-datepicker.js
@@ -273,6 +273,8 @@ A.mix(DatePickerBase.prototype, {
 
         instance.clearSelection(true);
 
+        instance._isInitializing = instance._isInitializing ?? true;
+
         instance.selectDatesFromInputValue(instance.getParsedDatesFromInputValue());
     },
 
@@ -333,6 +335,12 @@ A.mix(DatePickerBase.prototype, {
             selectionMode = calendar.get('selectionMode');
 
         instance._setCalendarToFirstSelectedDate();
+
+        if (instance._isInitializing) {
+            instance._isInitializing = false;
+            
+            return;
+        }        
 
         if (instance.get('autoHide') && (selectionMode !== 'multiple')) {
             instance.hide();


### PR DESCRIPTION
Hello, reviewer!
### **Context**
Currently, the add event calendar modal  is presenting the following behavior: after clicking the Add Event button, the modal opens, but the focus is being set on the first date input field instead of the modal title. 

### **Goal**
The purpose of these changes is to make it so that this modal present a consistent behavior with other modal's across the portal, which is: 

- Focusing on the modal title;
- It will read you are inside a modal;
- And that the header is “the header of said modal”;
- Then, with this context, the user begins to navigate the modal. After the first tab, they go to the first interactive element, “close the modal,” and then to the modal-body content.

see related threads: 
[dxp-accessibility](https://liferay.slack.com/archives/C04CPMRMXAL/p1752595166331279)  
[frontend-infra](https://liferay.slack.com/archives/CNBG06JS3/p1754343328319339) 

### **Understanding the changes**
As mentioned in the front end infra thread by Kevin, a run of the performance profiler in dev tools pointed out that this line in aui-datepicker.js's `useInputNode` function is what causes the focus to happen [https://github.com/liferay/liferay-frontend-projects/blob/8feda87f314b310c0f5cdd7c[…]party/projects/alloy-ui/src/aui-datepicker/js/aui-datepicker.js](https://github.com/liferay/liferay-frontend-projects/blob/8feda87f314b310c0f5cdd7c1704a49833cd48c7/third-party/projects/alloy-ui/src/aui-datepicker/js/aui-datepicker.js#L276)
`instance.selectDatesFromInputValue(instance.getParsedDatesFromInputValue());`

It triggers `this.fire("selectionChange", {newSelection: this._getSelectedDatesList()});` in yui's [calendar-base.js](https://alloyui.com/api/files/yui3_src_calendar_js_calendar-base.js.html)

Which ends ultimately in `_afterDatePickerSelectionChange` to be called in [aui-datepicker.js](https://github.com/liferay/liferay-frontend-projects/blob/8feda87f314b310c0f5cdd7c1704a49833cd48c7/third-party/projects/alloy-ui/src/aui-datepicker/js/aui-datepicker.js#L340) with
`instance.get('activeInput').focus();`

My goal with this fix is to skip setting focus on the input on the initial load but maintain it on subsequent calls, when a date selection happens.

I was able to run tests at runtime using the Chrome devtools override feature, following [this](https://liferay.atlassian.net/wiki/spaces/ENGFRONTENDINFRA/pages/3178823717/How+to+Use+Chrome+DevTools+Override+Content+to+Test+Changes+in+YUI3+on+Liferay). See results:
**Before:**

https://github.com/user-attachments/assets/300b2ff1-fb59-4927-97a6-ec73a05d9fdf

**After:**

https://github.com/user-attachments/assets/d86a5edb-108b-4283-a3ec-1a4347b138b7

