### PR TITLE
fix(alloy-ui): Use standard javascript for check to avoid compatibility issues

### DIFF
--- a/third-party/projects/alloy-ui/src/aui-datepicker/js/aui-datepicker.js
+++ b/third-party/projects/alloy-ui/src/aui-datepicker/js/aui-datepicker.js
@@ -273,7 +273,7 @@ A.mix(DatePickerBase.prototype, {
 
         instance.clearSelection(true);
 
-        instance._isInitializing = instance._isInitializing ?? true;
+        instance._isInitializing = instance._isInitializing == null ? true : instance._isInitializing;
 
         instance.selectDatesFromInputValue(instance.getParsedDatesFromInputValue());
     },


### PR DESCRIPTION
hey guys, this is a follow up from https://github.com/liferay/liferay-frontend-projects/pull/1255. 
Turns out the nullish coalescing operator (??) is not supported in the JavaScript version used by AlloyUI, this wasn't happening when I ran tests at runtime using the Chrome devtools override feature, but after it got merged, I kept getting this error: `Skip /o/frontend-js-aui-web/aui/aui-datepicker/aui-datepicker-min.js because its content type is not CSS or JavaScript`
So to be safe, I'm using a plain ternary here. thank you!
