### PR TITLE
fix(alloy-ui): scheduler accessibility fixes for OOTB calendar (LPD-87992)

### DIFF
--- a/third-party/projects/alloy-ui/src/aui-scheduler/js/aui-scheduler-base-event.js
+++ b/third-party/projects/alloy-ui/src/aui-scheduler/js/aui-scheduler-base-event.js
@@ -357,8 +357,8 @@ var SchedulerEvent = A.Component.create({
         'colorSaturationFactor', 'titleDateFormat', 'visible', 'disabled'],
 
     prototype: {
-        EVENT_NODE_TEMPLATE: '<div aria-expanded="false" aria-haspopup="dialog" class="' + CSS_SCHEDULER_EVENT + '" tabindex="0">' + '<div class="' +
-            CSS_SCHEDULER_EVENT_TITLE +
+        EVENT_NODE_TEMPLATE: '<div aria-expanded="false" aria-haspopup="dialog" class="' + CSS_SCHEDULER_EVENT +
+            '" role="button" tabindex="0">' + '<div class="' + CSS_SCHEDULER_EVENT_TITLE +
             '"></div>' + '<div class="' + CSS_SCHEDULER_EVENT_CONTENT + '"></div>' +
             '<div class="' + CSS_SCHEDULER_EVENT_NAME + '"></div>' +
             '<div class="' + CSS_SCHEDULER_EVENT_ICONS + '">' + '<span class="' + [

--- a/third-party/projects/alloy-ui/src/aui-scheduler/js/aui-scheduler-view-day.js
+++ b/third-party/projects/alloy-ui/src/aui-scheduler/js/aui-scheduler-view-day.js
@@ -548,6 +548,8 @@ var SchedulerDayView = A.Component.create({
                 instance.headerView.set('scheduler', instance.get('scheduler'));
 
                 instance.headerView.render();
+
+                instance.headerView.syncDaysHeaderUI();
             }
         },
 
@@ -888,6 +890,7 @@ var SchedulerDayView = A.Component.create({
          */
         syncDaysHeaderUI: function() {
             var instance = this;
+            var locale = instance.get('scheduler').get('locale');
             var viewDate = instance.get('scheduler').get('viewDate');
             var formatter = instance.get('headerDateFormatter');
             var todayDate = instance.get('scheduler').get('todayDate');
@@ -898,6 +901,13 @@ var SchedulerDayView = A.Component.create({
 
                     columnNode.toggleClass(
                         CSS_SCHEDULER_TODAY_HD, !DateMath.isDayOverlap(columnDate, todayDate));
+
+                    columnNode.setAttribute(
+                        'aria-label',
+                        A.DataType.Date.format(columnDate, {
+                            format: '%A, %B %d, %Y',
+                            locale: locale
+                        }));
 
                     columnNode.html(formatter.call(instance, columnDate));
                 }
@@ -1363,6 +1373,10 @@ var SchedulerDayView = A.Component.create({
 
             instance.syncColumnsUI();
             instance.syncDaysHeaderUI();
+
+            if (instance.headerView) {
+                instance.headerView.syncDaysHeaderUI();
+            }
         },
 
         /**


### PR DESCRIPTION
## Summary

Two accessibility fixes in `aui-scheduler` flagged by axe DevTools on the Liferay calendar (Jira: [LPD-87992](https://liferay.atlassian.net/browse/LPD-87992) / [LPP-63881](https://liferay.atlassian.net/browse/LPP-63881)).

### `aui-scheduler-base-event` — `role="button"` on event template

The `EVENT_NODE_TEMPLATE` renders `aria-expanded="false"` and `aria-haspopup="dialog"` on a bare `<div>`, where ARIA disallows both attributes. The element is already behaviourally a button (`tabindex="0"`, click + keyboard handlers, opens a dialog popover). Adding `role="button"` legalises both ARIA attributes without changing visuals.

### `aui-scheduler-view-day` — populate and label header cells

Two related issues:

1. The headerView (the all-day events strip, rendered as a nested `SchedulerTableView`) never had its `<th class="scheduler-view-table-header-day">` cells populated. `syncDaysHeaderUI` only runs from `_uiSetDate`, and the headerView's date is never set during initial render. Result: seven empty table headers in the week and day views.
2. The day view's own day-of-week `<a>` elements had no robust accessible name. Downstream stylesheets sometimes shrink the weekday `<span>` with `font-size: 0` to abbreviate it for narrow viewports, which strips the accessible name on platforms that drop zero-sized text from the accessibility tree.

Calls `instance.headerView.syncDaysHeaderUI()` after `render()` and inside `_uiSetDate` so the all-day strip's day-name `<th>` cells stay populated, and sets `aria-label` on each header anchor with the localized full date so the accessible name survives any visual abbreviation.